### PR TITLE
Enhance mobile view

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>Gittip - Personal Funding</title>
+        <meta content='width=device-width' name='viewport' />
         <style>
             @import url("/assets/{{ __version__ }}/gittip.css");
         </style>

--- a/www/assets/%version/gittip.css
+++ b/www/assets/%version/gittip.css
@@ -7,7 +7,7 @@ BODY {
     color: #614C3E;
 }
 #body {
-    width: 600px;
+    max-width: 600px;
     text-align: left;
     margin: 0 auto 64pt;
     z-index: 1;


### PR DESCRIPTION
This doesn't appear to break anything in browsers or mobile.  Both
before and after this commit, there are some uglies in skinny windows:
- The logo image is off-screen to the left.
- There are no page margins (the text flows right up against the
  window edges)
