### PR TITLE
Fixed the iframe scrollbar getting displayed

### DIFF
--- a/www/%participant_id/widget.html
+++ b/www/%participant_id/widget.html
@@ -14,11 +14,12 @@ else:
     <head>
         <style>@import url("/assets/{{ __version__ }}/gittip.css");</style>
         <style>
-            BODY {
+            body {
                 margin: 0;
                 padding: 0;
+                overflow: hidden;
             }
-            BUTTON {
+            button {
                 position: absolute;
                 top: 0;
                 left: 0;


### PR DESCRIPTION
Before:

![screenshot before](http://i.minus.com/jbhMBwAkEEmMaD.png)

After:

![after](http://i.minus.com/jbv8o3c629Gn32.png)

Apparently, [its only a webkit issue](http://stackoverflow.com/questions/1691873/safari-chrome-webkit-cannot-hide-iframe-vertical-scrollbar). We could also use the scrolling=no attribute for the sample iframe code.
