### PR TITLE
1994 Birth Year Not Supported fix

### DIFF
--- a/www/bank-account.html
+++ b/www/bank-account.html
@@ -184,7 +184,7 @@ Thanks! :-)</p>
                 {% end %}
             </select>
             <select id="dob-year">
-            {% for i in range(1900, datetime.utcnow().year - 18) %}
+            {% for i in range(1900, datetime.utcnow().year - 17) %}
                 <option value="{{ i }}" {{ 'selected="selected"' if i == 1990 else '' }}>{{ i }}</option>
             {% end %}
             </select>


### PR DESCRIPTION
resolves issue 339 (1994 Birth Year Not Supported)
https://github.com/whit537/www.gittip.com/issues/339

Changed the for loop in bank-account.html to allow people who have become 18 in the current calendar year to register.
