### PR TITLE
Make Makefile a little more fine-grained

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-env:
+env: env/bin/swaddle
 	python2.7 ./vendor/virtualenv-1.7.1.2.py \
 				--unzip-setuptools \
 				--prompt="[gittip] " \
@@ -10,6 +10,17 @@ env:
 	./env/bin/pip install ./vendor/nose-1.1.2.tar.gz
 	./env/bin/pip install -e ./
 
+env/bin/swaddle:
+	python2.7 ./vendor/virtualenv-1.7.1.2.py \
+				--unzip-setuptools \
+				--prompt="[gittip] " \
+				--never-download \
+				--extra-search-dir=./vendor/ \
+				--distribute \
+				./env/
+	./env/bin/pip install -r requirements.txt
+	./env/bin/pip install ./vendor/nose-1.1.2.tar.gz
+	./env/bin/pip install -e ./
 
 clean:
 	rm -rf env *.egg *.egg-info tests/env


### PR DESCRIPTION
If Postgres headers are missing when the "env" rule is executed, it
fails without building env/bin/swaddle.  When the rule is executed
again after the headers are installed, the Makefile thinks "env" is up
to date, although swaddle wasn't built.  To correct this, add an
explicit rule for env/bin/swaddle and make the env rule depend on it.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
