### PR TITLE
Footer stats link is wrong

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -44,7 +44,7 @@
         <p id='footer-nav'>
             <a href="/about/">About</a> |
             <a href='/about/faq.html'>FAQ</a> |
-            <a href='/about/stats/'>Stats</a> |
+            <a href='/about/stats.html'>Stats</a> |
             <a href='/about/charts.html'>Charts</a> |
             <a href='http://blog.gittip.com/'>Blog</a> |
             <a href='/about/fraud/'>Fraud</a>


### PR DESCRIPTION
Both `/about/stats` and `/about/stats.html` works, I'm not sure which is the correct link to be used.
