### PR TITLE
Call Python and virtualenv portably.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,11 @@
 python := "$(shell { command -v python2.7 || command -v python; } 2>/dev/null)"
 
-env: env/bin/swaddle
-	$(python) ./vendor/virtualenv-1.7.1.2.py \
-				--unzip-setuptools \
-				--prompt="[gittip] " \
-				--never-download \
-				--extra-search-dir=./vendor/ \
-				--distribute \
-				./env/
-	./env/bin/pip install -r requirements.txt
-	./env/bin/pip install ./vendor/nose-1.1.2.tar.gz
-	./env/bin/pip install -e ./
+# Set the relative path to installed binaries under the project virtualenv.
+# NOTE: Creating a virtualenv on Windows places binaries in the 'Scripts' directory.
+bin_dir := $(shell $(python) -c 'import sys; bin = "Scripts" if sys.platform == "win32" else "bin"; print(bin)')
+env_bin := env/$(bin_dir)
 
-env/bin/swaddle:
+env: $(env_bin)/swaddle
 	$(python) ./vendor/virtualenv-1.7.1.2.py \
 				--unzip-setuptools \
 				--prompt="[gittip] " \
@@ -20,9 +13,21 @@ env/bin/swaddle:
 				--extra-search-dir=./vendor/ \
 				--distribute \
 				./env/
-	./env/bin/pip install -r requirements.txt
-	./env/bin/pip install ./vendor/nose-1.1.2.tar.gz
-	./env/bin/pip install -e ./
+	./$(env_bin)/pip install -r requirements.txt
+	./$(env_bin)/pip install ./vendor/nose-1.1.2.tar.gz
+	./$(env_bin)/pip install -e ./
+
+$(env_bin)/swaddle:
+	$(python) ./vendor/virtualenv-1.7.1.2.py \
+				--unzip-setuptools \
+				--prompt="[gittip] " \
+				--never-download \
+				--extra-search-dir=./vendor/ \
+				--distribute \
+				./env/
+	./$(env_bin)/pip install -r requirements.txt
+	./$(env_bin)/pip install ./vendor/nose-1.1.2.tar.gz
+	./$(env_bin)/pip install -e ./
 
 clean:
 	rm -rf env *.egg *.egg-info tests/env
@@ -45,7 +50,7 @@ local.env:
 	echo "TWITTER_CALLBACK=http://127.0.0.1:8537/on/twitter/associate" >> local.env
 
 run: env local.env
-	./env/bin/swaddle local.env ./env/bin/aspen \
+	./$(env_bin)/swaddle local.env ./$(env_bin)/aspen \
 		--www_root=www/ \
 		--project_root=. \
 		--show_tracebacks=yes \
@@ -53,7 +58,7 @@ run: env local.env
 		--network_address=:8537
 
 test: env tests/env data
-	./env/bin/swaddle tests/env ./env/bin/nosetests ./tests/
+	./$(env_bin)/swaddle tests/env ./$(env_bin)/nosetests ./tests/
 
 tests: test
 
@@ -75,4 +80,4 @@ tests/env:
 
 data: env
 	./makedb.sh gittip-test gittip-test
-	./env/bin/swaddle tests/env ./env/bin/python ./gittip/testing.py
+	./$(env_bin)/swaddle tests/env ./$(env_bin)/python ./gittip/testing.py


### PR DESCRIPTION
My setup is a Windows 7 running official Python 2.7. I'm building under a msys/mingw shell, _not_ cmd.exe. Doing a `make run`, the first issue that I ran into was that CPython doesn't install a separate python2.7.exe executable. The first commit will fall back to the unversioned python executable if python2.7 isn't found.

The second issue was that CPython on Windows installs binaries and scripts to the Scripts/ directory, not bin/. So I replaced all hardcoded env/bin/ paths after detecting the platform-specific name of the bin directory.

There's a couple caveats with my approach:
- GNU make is now required. This is because I use the GNU make $(shell) function. Doing it under POSIX make is not as straightforward, but if someone really needs POSIX make to work, I'll fix it.
- On Windows, cmd.exe (or Powershell, or any non-POSIX shell) can't be used to build through the Makefile. I use POSIX `command` to detect which Python to use, and although there's a Windows equivalent, I didn't want to add more Makefile boilerplate at this time.
