### PR TITLE
Convert UNSECURE_RANDOM_STRING to a byte string.

### DIFF
--- a/gittip/crypto.py
+++ b/gittip/crypto.py
@@ -26,7 +26,7 @@ except NotImplementedError:
 SECRET_KEY = ""
 import string
 pool = string.digits + string.letters + string.punctuation
-UNSECURE_RANDOM_STRING = "".join([random.choice(pool) for i in range(64)])
+UNSECURE_RANDOM_STRING = b"".join([random.choice(pool) for i in range(64)])
 
 
 # I get wet.


### PR DESCRIPTION
This fixes the case where the native encoding contains characters
outside of the ASCII range (0 <= c <= 127). For example, the default encoding for Windows notion of 'en_US' is CP1252, which includes several letters outside of the ASCII range.
