### PR TITLE
Simple formatting for site footer, "||" -> "|".

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -75,14 +75,14 @@
     </div></div>
 
     <div class="main-padding"><div id="footer">
-        <a href='http://blog.gittip.com/'>Blog</a> ||
+        <a href='http://blog.gittip.com/'>Blog</a> |
         <a href="/about/">About</a> |
-        <a href='/about/faq.html'>FAQ</a> ||
+        <a href='/about/faq.html'>FAQ</a> |
         <a href='/about/stats.html'>Stats</a> |
-        <a href='/about/charts.html'>Charts</a> ||
+        <a href='/about/charts.html'>Charts</a> |
         <a href="/about/terms/">Terms</a> |
         <a href="/about/privacy/">Privacy</a> |
-        <a href='/about/fraud/'>Fraud</a> ||
+        <a href='/about/fraud/'>Fraud</a> |
         <a href='/security.txt'>Security</a>
     </div></div>
 


### PR DESCRIPTION
I think replacing the double vertical bar in the site's footer with single vertical bar is better design.

IMO it looks more pleasant to the eyes, it feels more modern and clean, and it's _simpler_.

![image](https://f.cloud.github.com/assets/1924134/140129/f6519614-7211-11e2-817d-58315bf7aafe.png)

At first I thought it's a bug on the site, and there was some missing text between each `||` pair. I couldn't understand why there was an inconsistency (sometimes single vertical bar, and sometimes double). After a lot of thinking (and verifying the source), I realized it's supposed to group similar sections together. But I really don't think `||` does the job, nor is it needed.
