### PR TITLE
Fix link to Balanced Payments

### DIFF
--- a/www/about/privacy/index.html
+++ b/www/about/privacy/index.html
@@ -101,7 +101,7 @@ work on our behalf:</p>
 
 <ul>
 
-    <li><a href="https://www.balancedpayemnts.com/">Balanced Payments</a>
+    <li><a href="https://www.balancedpayments.com/">Balanced Payments</a>
     provides payment processing.</li>
 
     <li><a href="http://www.google.com/">Google Analytics</a> provides website


### PR DESCRIPTION
Fix the link to Balanced Payments, on the privacy page. Small typo.
