### PR TITLE
Add support for JavaScript unit and end-to-end testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ nosetests.xml
 .sass-cache/
 gittip.css
 .vagrant
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ test: env tests/env data
 
 tests: test
 
+jstest:
+	./node_modules/.bin/testacular start testacular.unit-conf.js
+
 tests/env:
 	echo "Creating a tests/env file ..."
 	echo

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "gittip",
+  "version": "0.0.0",
+  "dependencies": {},
+  "devDependencies": {
+    "testacular": ">=0.6.0"
+  }
+  "engines": {
+    "node": ">=0.8.0"
+  }
+}

--- a/testacular.unit-conf.js
+++ b/testacular.unit-conf.js
@@ -1,0 +1,70 @@
+// Testacular configuration
+// Generated on Mon Mar 18 2013 13:15:41 GMT-0700 (PDT)
+
+
+// base path, that will be used to resolve files and exclude
+basePath = '';
+
+
+// list of files / patterns to load in the browser
+files = [
+  JASMINE,
+  JASMINE_ADAPTER,
+
+  'www/assets/jquery-1.8.3.min.js',
+  'www/assets/%version/gittip.js',
+
+  'jstests/unit/*.js'
+];
+
+
+// list of files to exclude
+exclude = [
+
+];
+
+
+// test results reporter to use
+// possible values: 'dots', 'progress', 'junit'
+reporters = ['progress'];
+
+
+// web server port
+port = 9876;
+
+
+// cli runner port
+runnerPort = 9100;
+
+
+// enable / disable colors in the output (reporters and logs)
+colors = true;
+
+
+// level of logging
+// possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+logLevel = LOG_INFO;
+
+
+// enable / disable watching file and executing tests whenever any file changes
+autoWatch = false;
+
+
+// Start these browsers, currently available:
+// - Chrome
+// - ChromeCanary
+// - Firefox
+// - Opera
+// - Safari (only Mac)
+// - PhantomJS
+// - IE (only Windows)
+browsers = ['PhantomJS'];
+
+
+// If browser does not capture in given timeout [ms], kill it
+captureTimeout = 60000;
+
+
+// Continuous Integration mode
+// if true, it capture browsers, run tests and exit
+singleRun = true;


### PR DESCRIPTION
There is a lot of JS code that makes changes to the data and to the DOM that isn't being tested right now.

For the test configuration and runner I would suggest the excellent [Testacular](http://testacular.github.com/0.6.0/index.html). This allows for configuring and running unit and end-2-end tests in a headless WebKit browser ([PhantomJS](http://phantomjs.org)), and [Jasmine](http://pivotal.github.com/jasmine) as the test framework (this is the default in [Testacular](http://testacular.github.com/0.6.0/index.html).)

Edit: Using Testacular and PhantomJS will introduce a dependency on NodeJS and for PhantomJS to be installed system-wide. It's easy enough to configure the test suite to skip JS tests with a warning when deps are not installed, to avoid _requiring_ people to have these installed. TravisCI has PhantomJS installed by default, and I believe also NodeJS, so no issues there.
