### PR TITLE
Change save goal button logic, fixes #753

### DIFF
--- a/www/assets/%version/profile.js
+++ b/www/assets/%version/profile.js
@@ -194,7 +194,7 @@ $(document).ready(function()
                      }
             , success: success
             , error: function() {
-                    $('#save-goal').text('Save');
+                    $('.goal BUTTON.save').text('Save');
                     alert( "Failed to change your funding goal. "
                          + "Please try again."
                           );


### PR DESCRIPTION
This commit solves #753, an issue with the logic of trying to save a wonky custom goal amount. The button gets stuck at 'Saving...' as opposed to switching back to 'Save' after an error with the wonky custom goal amount.
