### PR TITLE
Increase Bitbucket response size to reduce IO

### DIFF
--- a/gittip/elsewhere/bitbucket.py
+++ b/gittip/elsewhere/bitbucket.py
@@ -52,7 +52,7 @@ def get_user_info(username):
     if rec is not None:
         user_info = rec['user_info']
     else:
-        url = "%s/users/%s"
+        url = "%s/users/%s?pagelen=100"
         user_info = requests.get(url % (BASE_API_URL, username))
         status = user_info.status_code
         content = user_info.content


### PR DESCRIPTION
Bitbucket page sizes can be set by the caller.

The default is 50 items per page, but we can increase this to 100
(max), which will halve the number of API calls needed on large
teams.

Note that we can't set it to an even higher value, because
Bitbucket will reject `pagelen` values that exceed its max (100) and
return a 400 Bad Request.
