### PR TITLE
Suggested quick workaround for issue #789

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -15,7 +15,7 @@ def _extract_avatar(participant_id):
         SELECT user_info
           FROM elsewhere
          WHERE participant_id=%s
-      ORDER BY platform
+      ORDER BY platform DESC
 
       """, (participant_id,))
     try:


### PR DESCRIPTION
Look for images in reverse order: Twitter, Github, Bitbucket.

This ducks around the real issue: where the front page does not find
images for bitbucket accounts.
