### PR TITLE
Add title attribute to user statements on stats page

### DIFF
--- a/www/about/stats
+++ b/www/about/stats
@@ -251,7 +251,8 @@ names = ['ncc', 'pcc', 'statements', 'transfer_volume',
     <p>
     {% for statement in statements %}
     <b><a href="/{{ statement['id'] }}/">{{ escape(statement['id']) }}</a></b>
-    is {{ escape(part(statement['statement'])) }}</b><br />{% end %}
+    is <span title="{{ escape(statement['statement']) }}">{{ escape(part(statement['statement'])) }}</span><br />
+    {% end %}
     </p>
 </div>
 {% end %}


### PR DESCRIPTION
It's nice to be able to read the full statement simply by hovering over it rather than having to open their user page (perhaps this was by design, I'm not sure)

I also removed a stray </b> tag.
