### PR TITLE
Prevent click event from firing twice when updating anonymous giving pref

### DIFF
--- a/www/assets/%version/profile.js
+++ b/www/assets/%version/profile.js
@@ -223,7 +223,7 @@ $(document).ready(function()
     // Wire up aggregate giving knob.
     // ==============================
 
-    $('.anonymous').click(function()
+    $('.anonymous INPUT').click(function()
     {
         jQuery.ajax(
             { url: 'anonymous.json'
@@ -231,7 +231,7 @@ $(document).ready(function()
             , dataType: 'json'
             , success: function(data)
             {
-                $('INPUT.anonymous').attr('checked', data.anonymous);
+                $('.anonymous INPUT').attr('checked', data.anonymous);
             }
             , error: function() {
                     alert( "Failed to change your anonymity "


### PR DESCRIPTION
The selector was targeting the label instead of the input itself, which fires the event twice oddly. http://stackoverflow.com/a/13756844/1274612

I also updated the selector that is used to visually update the checkbox, it was targeting nothing.

Fixes #841
