### PR TITLE
Add missing comma back into /about/stats names list.

### DIFF
--- a/www/about/stats
+++ b/www/about/stats
@@ -194,7 +194,7 @@ tip_distribution_json = {str(k): v for k,v in tip_distribution.items()}
 names = ['ncc', 'pcc', 'statements', 'transfer_volume',
          'last_thursday', 'this_thursday', 'punc', 'other_people',
          'average_tip', 'average_tippees', 'total_backed_tips',
-         'tip_distribution_json', 'tip_n', 'nach', 'escrow'
+         'tip_distribution_json', 'tip_n', 'nach', 'escrow',
          'ngivers', 'nreceivers', 'noverlap', 'nactive']
 
 ^L application/json


### PR DESCRIPTION
This was causing stats.json to look for an 'escrowngivers' key in globals(), completely breaking it
