### PR TITLE
Added rel-payment link to profiles

### DIFF
--- a/www/%username/index.html
+++ b/www/%username/index.html
@@ -43,6 +43,7 @@ else:
 # ========================================================================== ^L
 {% extends templates/profile.html %}
 {% block head %}
+    <link rel="payment" type="text/html" title="Give weekly gift on Gittip" href="https://www.gittip.com/{{ username }}/" />
     <meta name="twitter:card" content="summary" />
     <meta name="og:url" content="https://www.gittip.com/{{ username }}/" />
     <meta name="og:type" content="website" />


### PR DESCRIPTION
Fixes #483 - exposes metadata that shows that Gittip enables people to donate/pay for something: http://relpayment.com/
