### PR TITLE
Require HTTP POST for signing out

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -63,7 +63,7 @@
         {% else %}
         <div class="you-are">
             <a href="/{{ user.username }}/">{{ user.username }}</a> &ndash;
-            <a href="/sign-out.html">sign out</a>
+            <a id="sign-out" href="/sign-out.html">sign out</a>
             <div class="quick-stats">
               Giving: <a href="/{{ user.username }}/giving/">${{ user.get_dollars_giving() }}/wk</a><br />
               Receiving: <b>${{ user.get_dollars_receiving() }}/wk</b>

--- a/www/assets/%version/gittip.js
+++ b/www/assets/%version/gittip.js
@@ -9,6 +9,7 @@ Gittip = {};
 Gittip.init = function()
 {
     Gittip.forms.initCSRF();
+    Gittip.signOut();
 };
 
 
@@ -68,4 +69,23 @@ Gittip.jsonml = function(jsonml)
     });
 
     return node;
+};
+
+
+Gittip.signOut = function()
+{
+    $('a#sign-out').click(function(e) {
+        e.preventDefault();
+
+        jQuery.ajax({
+            url: '/sign-out.html',
+            type: 'POST',
+            success: function() {
+                window.location.href = window.location.href;
+            },
+            error: function() {
+                alert('Failed to sign out');
+            }
+        });        
+    });
 };

--- a/www/sign-out.html
+++ b/www/sign-out.html
@@ -4,8 +4,31 @@ from gittip.orm import db
 
 # ========================================================================== ^L
 
-user = user.sign_out()
-back_to = request.headers.get('referer', '/')
-request.redirect(back_to)
+if user.id is None:
+    request.redirect('/')
+
+if POST:
+    user = user.sign_out()
+
+    if 'back_to' in request.body:
+        back_to = request.body['back_to']
+    else:
+        back_to = request.headers.get('referer', '/')
+
+    request.redirect(back_to)
 
 # ========================================================================== ^L
+{% extends templates/base.html %}
+{% block heading %}
+    <h2 class="top"><span>Sign out</span></h2>
+{% end %}
+
+{% block box %}
+    <div class="as-content">
+        <h1>Are you sure you wish to sign out?</h1>
+        <form id="sign-out" method="POST">
+            <input name="back_to" type="hidden" value="/" />
+            <button type="submit">Yes!</button>
+        </form>
+    </div>
+{% end %}


### PR DESCRIPTION
Currently `<img src="https://www.gittip.com/sign-out.html" />` would sign out all users that view the image.

This should leave the sign out flow the same as always for users with JS running, others will be directed to /sign-out.html and have to submit an HTML form. Considering most functions of the site won't work without js anyway, I think this is OK.
