### PR TITLE
Cache static assets

### DIFF
--- a/configure-aspen.py
+++ b/configure-aspen.py
@@ -5,6 +5,7 @@ import gittip.wireup
 import gittip.authentication
 import gittip.orm
 import gittip.csrf
+import gittip.cache_static
 import gittip.models.participant
 
 
@@ -42,9 +43,13 @@ website.hooks.inbound_early += [ gittip.canonize
                                , gittip.authentication.inbound
                                , gittip.csrf.inbound
                                 ]
+
+website.hooks.inbound_core += [gittip.cache_static.inbound]
+
 website.hooks.outbound += [ gittip.authentication.outbound
                           , gittip.csrf.outbound
                           , gittip.orm.rollback
+                          , gittip.cache_static.outbound
                            ]
 
 

--- a/gittip/cache_static.py
+++ b/gittip/cache_static.py
@@ -1,0 +1,56 @@
+"""
+Handles caching of static resources.
+"""
+from os import path
+from calendar import timegm
+from email.utils import parsedate
+from wsgiref.handlers import format_date_time
+
+from aspen import Response
+
+
+def inbound(request):
+    """
+    Checks the last modified time of a file against
+    an If-Modified-Since header and responds with
+    a 304 if appropriate.
+    """
+    uri = request.line.uri
+    version = request.context['__version__']
+
+    if not uri.startswith('/assets'):
+        return request
+    elif not version.endswith('dev') and version in uri:
+        # These will be cached indefinitely in the outbound hook
+        return request
+
+    ims = request.headers.get('If-Modified-Since')
+    last_modified = int(path.getctime(request.fs))
+
+    if ims:
+        ims = timegm(parsedate(ims))
+        if ims >= last_modified:
+            raise Response(304, headers={
+                'Last-Modified': format_date_time(last_modified),
+                'Cache-Control': 'no-cache'
+            })
+
+
+def outbound(response):
+    request = response.request
+    uri = request.line.uri
+    if not uri.startswith('/assets'):
+        return response
+
+    version = request.context['__version__']
+    if not version.endswith('dev') and version in uri:
+        # This specific asset is versioned, so
+        # it's fine to cache this forever
+        response.headers['Expires'] = 'Sun, 17 Jan 2038 19:14:07 GMT'
+        response.headers['Cache-Control'] = 'public'
+
+    else:
+        # Asset is not versioned or dev version is running.
+        last_modified = int(path.getctime(request.fs))
+        response.headers['Last-Modified'] = format_date_time(last_modified)
+        response.headers['Cache-Control'] = 'no-cache'


### PR DESCRIPTION
Phew... this was annoying.
I had a bit of trouble with it not working consistently across different browsers, but it _should_ be fine now.

This will cache any assets in `www/assets/%version` indefinitely and force revalidation for others. It will also force revalidation for all assets in a dev environment, we wouldn't want to force people to hard reload all the time!

Somebody that knows what they're doing when it comes to HTTP caching (maybe @clone1018?) please take a look, too!
