### PR TITLE
Update balanced account links for new dashboard

### DIFF
--- a/templates/connected-accounts.html
+++ b/templates/connected-accounts.html
@@ -123,7 +123,7 @@
 
             {% end %}
             <div class="account-type">{% if user.ADMIN and participant.balanced_account_uri %}
-                <a href="https://www.balancedpayments.com/{{ participant.balanced_account_uri[3:] }}"
+                <a href="https://dashboard.balancedpayments.com/#/{{ participant.balanced_account_uri[4:] }}"
                     >on Balanced Payments</a>{% else %}on Balanced Payments{% end %}</div>
         </td>
     </tr>


### PR DESCRIPTION
Balanced has a new dashboard now, and we should use it (it has a
different URL).
