### PR TITLE
Adding titles to community pages

### DIFF
--- a/www/for/%slug/index.html
+++ b/www/for/%slug/index.html
@@ -88,6 +88,8 @@ if community is None:
 
     community = StubCommunity()
 
+# Set the page title based on the communities name.
+title = community.name + ' Community'
 
 if community.nmembers >= website.NMEMBERS_THRESHOLD:
 


### PR DESCRIPTION
This pull request improves our titles for community pages, so we'll better show up on Google and in your browser. This also assume the input we're getting is already escaped, since we do just display it on that page.
