### PR TITLE
Allow widget to work when dynamically inserted into middle of DOM

### DIFF
--- a/www/assets/widgets/0002.js
+++ b/www/assets/widgets/0002.js
@@ -1,19 +1,12 @@
-(function($, _) {
-	var s = $('script');
-	var script;
-	for (var i = s.length - 1; i >= 0; i--) {
-		if (s[i].getAttribute('data-gittip-username')) {
-			script = s[i];
-			break;
-		}
-	}
-	var baseURI  = script.getAttribute('data-gittip-base')
+(function(_) {
+	var script   = document.querySelector('script[data-gittip-username]'),
+	    baseURI  = script.getAttribute('data-gittip-base')
 	            || script.src.replace(/^((https?:)?\/\/[^\/]+).*$/, '$1'),
 	    username = script.getAttribute('data-gittip-username'),
 	    widget, receiving, number;
 
 	// include css
-	$('head')[0].appendChild(
+	document.querySelector('head').appendChild(
 		_.ml(['link', {
 			rel: 'stylesheet',
 			href: script.src.replace('.js', '.css').replace(/\?.+/, '')
@@ -39,7 +32,7 @@
 		receiving.innerHTML = data.receiving;
 		number.innerHTML = data.number === 'singular' ? 'I' : 'We';
 	});
-})(function(q) { return document.querySelectorAll(q); }, {
+})({
 	ml: function(jsonml) {
 		var i, p, v, node;
 


### PR DESCRIPTION
Previously if you dynamically added the JS to the middle of an existing DOM structure, the code to grab the `script` tag would grab the last tag, which is not necessarily `0002.js`.

This change forces it to look for the script tag with the appropriate data attribute.
