### PR TITLE
Don't send Content-Type for 304; fixes #1308

### DIFF
--- a/gittip/cache_static.py
+++ b/gittip/cache_static.py
@@ -111,6 +111,10 @@ def outbound(response):
     response.headers.cookie.clear()
 
     if response.code == 304:
+
+        # https://github.com/gittip/www.gittip.com/issues/1308
+        del response.headers['Content-Type']
+
         return response
 
     if website.cache_static:


### PR DESCRIPTION
This is ready for review.

Here's how I tested this:

```
$ curl -I http://localhost:8537/assets/reset.css -H"If-Modified-Since: Fri, 1 Jan 2100 00:00:00 GMT"
HTTP/1.1 304 Not Modified
Vary: Cookie
Last-Modified: Mon, 22 Jul 2013 02:00:07 GMT
Cache-Control: no-cache
X-Frame-Options: SAMEORIGIN
X-Gittip-Version: 10.0.5-dev
Date: Fri, 09 Aug 2013 20:03:27 GMT
Server: Aspen! Cheroot!

$
```

Notice there is no `Content-Type` header now.
