### PR TITLE
Stop clobbering tests/env in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(env_bin)/swaddle:
 	./$(env_bin)/pip install -e ./
 
 clean:
-	rm -rf env *.egg *.egg-info tests/env
+	rm -rf env *.egg *.egg-info
 	find . -name \*.pyc -delete
 
 local.env:


### PR DESCRIPTION
That'd be more like make distclean, which we don't have.

This is ready for review.
