### PR TITLE
Don't raise a 500 response if user denies github auth request (#619)

### DIFF
--- a/gittip/elsewhere/github.py
+++ b/gittip/elsewhere/github.py
@@ -60,9 +60,6 @@ def oauth_dance(website, qs):
 
     log("Doing an OAuth dance with Github.")
 
-    if 'error' in qs:
-        raise Response(500, str(qs['error']))
-
     data = { 'code': qs['code'].encode('US-ASCII')
            , 'client_id': website.github_client_id
            , 'client_secret': website.github_client_secret

--- a/www/on/github/associate.spt
+++ b/www/on/github/associate.spt
@@ -14,6 +14,9 @@ from gittip.participant import NeedConfirmation
 
 [-----------------------------]
 
+if 'error' in qs:
+    request.redirect('/')
+
 # Load GitHub user info.
 user_info = github.oauth_dance(website, qs)
 


### PR DESCRIPTION
This brings it more in line with what the other elsewheres do
