### PR TITLE
Remove display of rank in top/new users lists

### DIFF
--- a/scss/modules.scss
+++ b/scss/modules.scss
@@ -21,19 +21,6 @@
             display: block;
             min-height: 70px;
             position: relative;
-
-            span.rank {
-                background: $brown;
-                bottom: 4px;
-                color: white;
-                display: block;
-                font: normal 12px $Mensch;
-                left: 4px;
-                padding: 3px 5px 3px 6px;
-                position: absolute;
-                text-align: center;
-                @include border-radius(2px);
-            }
         }
         span.age,
         span.money {

--- a/www/for/%slug/index.html.spt
+++ b/www/for/%slug/index.html.spt
@@ -278,7 +278,6 @@ $(document).ready(function() {
                         <span class="avatar"
                             style="background-image:
                                 url('{{ participant.get_img_src() }}')">
-                            <span class="rank">{{ i }}</span>
                         </span>
                         <span class="age">{{ _to_age(participant) }}</span>
                         <span class="name">{{ participant.username }}</span>
@@ -297,7 +296,6 @@ $(document).ready(function() {
                 <span class="mini-user">
                     <span class="inner">
                         <span class="avatar">
-                            <span class="rank">{{ i }}</span>
                         </span>
                         <span class="money">${{ giver.amount }}</span>
                         <span class="name">???</span>
@@ -309,7 +307,6 @@ $(document).ready(function() {
                     <span class="inner">
                         <span class="avatar"
                             style="background-image: url('{{ giver.get_img_src() }}')">
-                            <span class="rank">{{ i }}</span>
                         </span>
                         <span class="money">${{ giver.amount }}</span>
                         <span class="name">{{ giver.username }}</span>
@@ -329,7 +326,6 @@ $(document).ready(function() {
                     <span class="inner">
                         <span class="avatar"
                             style="background-image: url('{{ receiver.get_img_src() }}')">
-                            <span class="rank">{{ i }}</span>
                         </span>
                         <span class="money">${{ receiver.amount }}</span>
                         <span class="name">{{ receiver.username }}</span>

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -115,7 +115,6 @@ receivers = _wrap(db.all("""
                         <span class="avatar"
                             style="background-image:
                                 url('{{ participant.get_img_src() }}')">
-                            <span class="rank">{{ i }}</span>
                         </span>
                         <span class="age">{{ _to_age(participant) }}</span>
                         <span class="name">{{ participant.username }}</span>
@@ -134,7 +133,6 @@ receivers = _wrap(db.all("""
                 <span class="mini-user">
                     <span class="inner">
                         <span class="avatar">
-                            <span class="rank">{{ i }}</span>
                         </span>
                         <span class="money">${{ giver.amount }}</span>
                         <span class="name">???</span>
@@ -146,7 +144,6 @@ receivers = _wrap(db.all("""
                     <span class="inner">
                         <span class="avatar"
                             style="background-image: url('{{ giver.get_img_src() }}')">
-                            <span class="rank">{{ i }}</span>
                         </span>
                         <span class="money">${{ giver.amount }}</span>
                         <span class="name">{{ giver.username }}</span>
@@ -166,7 +163,6 @@ receivers = _wrap(db.all("""
                     <span class="inner">
                         <span class="avatar"
                             style="background-image: url('{{ receiver.get_img_src() }}')">
-                            <span class="rank">{{ i }}</span>
                         </span>
                         <span class="money">${{ receiver.amount }}</span>
                         <span class="name">{{ receiver.username }}</span>


### PR DESCRIPTION
Hi!

I'd like to propose removing the display of rank numbers from Gittip's home and community pages.
Removing them would look cleaner and de-emphasize notions of a popularity contest. Still, ranking would be clear from the timestamps and given amounts below the profile pics. 

Removing them can be previewed with

```
$('.rank').hide()
```

in the console.
