### PR TITLE
Add ellipsis text-overflow for long usernames

### DIFF
--- a/scss/modules.scss
+++ b/scss/modules.scss
@@ -39,6 +39,8 @@
             font: normal 11px $Helvetica;
             margin: 3px 0;
             white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
     }
 


### PR DESCRIPTION
There are a few usernames on the homepage right now where the usernames are cut off. This pull requests provides a workaround by showing them with an ellipsis if necessary.

It might be an option to add a title-tag to the link to be able to read the username without clicking through, e.g. 

```
<a href="/KlarnaEngineers/" class="mini-user" title="KlarnaEngineers">
```
