### PR TITLE
Fix bug when tip amount is empty

### DIFF
--- a/www/assets/%version/gittip/tips.js
+++ b/www/assets/%version/gittip/tips.js
@@ -7,7 +7,7 @@ Gittip.tips.init = function()
         var $this     = $(this),
             $parent   = $this.parents('[class^="my-tip"]'),
             $confirm  = $parent.find('.confirm-tip'),
-            amount    = parseFloat($this.val(), 10),
+            amount    = parseFloat($this.val(), 10) || 0,
             oldAmount = parseFloat($this.data('old-amount'), 10);
 
         // force two decimal points on value


### PR DESCRIPTION
Before this commit, if a user emptied the tip field then clicked off, they'd be greeted with `NaN`
