### PR TITLE
1320 regression in resolve_unclaimed

### DIFF
--- a/gittip/models/participant.py
+++ b/gittip/models/participant.py
@@ -183,11 +183,13 @@ class Participant(Model, MixinElsewhere, MixinTeam):
                             )
         if rec is None:
             out = None
-        elif rec['platform'] == 'github':
-            out = '/on/github/%s/' % rec['user_info']['login']
+        elif rec.platform == 'bitbucket':
+            out = '/on/bitbucket/%s/' % rec.user_info['username']
+        elif rec.platform == 'github':
+            out = '/on/github/%s/' % rec.user_info['login']
         else:
-            assert rec['platform'] == 'twitter'
-            out = '/on/twitter/%s/' % rec['user_info']['screen_name']
+            assert rec.platform == 'twitter'
+            out = '/on/twitter/%s/' % rec.user_info['screen_name']
         return out
 
     def set_as_claimed(self):

--- a/tests/test_participant.py
+++ b/tests/test_participant.py
@@ -8,6 +8,8 @@ import psycopg2
 import pytz
 from aspen.utils import utcnow
 from gittip import NotSane
+from gittip.elsewhere.bitbucket import BitbucketAccount
+from gittip.elsewhere.github import GitHubAccount
 from gittip.elsewhere.twitter import TwitterAccount
 from gittip.models._mixin_elsewhere import NeedConfirmation
 from gittip.models.participant import Participant
@@ -18,7 +20,6 @@ from gittip.models.participant import ( UsernameTooLong
                                       , NoSelfTipping
                                       , BadAmount
                                        )
-from gittip.elsewhere.github import GitHubAccount
 from gittip.testing import Harness
 from nose.tools import assert_equals, assert_raises
 
@@ -496,15 +497,26 @@ class Tests(Harness):
         assert actual == -1, actual
 
 
-
     # resolve_unclaimed - ru
 
     def test_ru_returns_None_for_orphaned_participant(self):
         resolved = self.make_participant('alice').resolve_unclaimed()
         assert resolved is None, resolved
 
+    def test_ru_returns_bitbucket_url_for_stub_from_bitbucket(self):
+        unclaimed = BitbucketAccount('1234', {'username': 'alice'})
+        stub = Participant.from_username(unclaimed.participant)
+        actual = stub.resolve_unclaimed()
+        assert actual == "/on/bitbucket/alice/", actual
+
     def test_ru_returns_github_url_for_stub_from_github(self):
         unclaimed = GitHubAccount('1234', {'login': 'alice'})
         stub = Participant.from_username(unclaimed.participant)
         actual = stub.resolve_unclaimed()
         assert actual == "/on/github/alice/", actual
+
+    def test_ru_returns_twitter_url_for_stub_from_twitter(self):
+        unclaimed = TwitterAccount('1234', {'screen_name': 'alice'})
+        stub = Participant.from_username(unclaimed.participant)
+        actual = stub.resolve_unclaimed()
+        assert actual == "/on/twitter/alice/", actual


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "aspen/website.py", line 76, in handle_safely
    response = self.handle(request)
  File "aspen/website.py", line 109, in handle
    response = request.resource.respond(request)
  File "aspen/resources/dynamic_resource.py", line 47, in respond
    exec self.pages[1] in context
  File "/app/www/%username/index.html.spt", line 21, in <module>
    participant = get_participant(request, restrict=False)
  File "gittip/utils/__init__.py", line 330, in get_participant
    to = participant.resolve_unclaimed()
  File "gittip/models/participant.py", line 186, in resolve_unclaimed
    elif rec['platform'] == 'github':
TypeError: tuple indices must be integers, not unicode
```

https://app.getsentry.com/gittip/gittip/group/7545956/
