### PR TITLE
fixing minor issues on about/teams

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -3,7 +3,7 @@
     {% set current_page = path.raw.split('/')[2] %}
     {% set nav_base = "/about" %}
     <div class="nav">
-        {% set pages = [('/', 'About'), ('/faq.html', 'FAQ'), ('/teams/index.html', 'Teams')] %}
+        {% set pages = [('/', 'About'), ('/faq.html', 'FAQ'), ('/teams/', 'Teams')] %}
         {% include nav.html %}
     </div>
     <div class="nav level-1">

--- a/www/about/teams/index.html.spt
+++ b/www/about/teams/index.html.spt
@@ -99,7 +99,7 @@ you can increase to $1). If you set your new take higher than double the
 previous take, it will be clipped to double. Here’s the throttled growth curve:
 </p>
 
-<img src="/assets/teams/take-growth-curve.png" />
+<img src="/assets/teams/take-growth-curve.png" class="col0" />
 
 <p>Note that your take does not increase automatically, and no-one else can
 change it for you. This means you will have to increase your take manually each


### PR DESCRIPTION
This fixes the highlighting of the teams button while on team page as well as constrain one of the images to the width of the column to make it look all aligned.

Also, fixes #1427.
