### PR TITLE
Update README to reflect clearer information about the gratitude gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ for your project!
    Academy's setup](http://ejohn.org/blog/gittip-at-khan-academy/))
 
 
- - [Ruby: gratitude](http://rubygems.org/gems/gratitude)
+ - [Ruby: gratitude](https://github.com/JohnKellyFerguson/gratitude): A ruby gem that wraps the Gittip API (currently in development and not feature complete).
  
  - [WordPress: WP-Gittip](https://github.com/daankortenbach/WP-Gittip)
 


### PR DESCRIPTION
I just started working on gratitude, a gem to wrap the Gittip API. It's the first gem I've ever made and is not yet feature complete. 

Thus far, I've only really wrapped the public user information aspect of the API. I'll be working on adding the rest of the API soon.

I saw a re-tweet the other day on Twitter from @whit537 announcing the v0.0.1 release. I wasn't expecting that and found it pretty funny as v0.0.1 had no real functionality. It was just the basic gem project structure. Anyone who installed the gem ended up with a gem that didn't really do anything. :smile: I figured people should know that the gem is not yet finished so as to avoid any confusion or frustration.
