### PR TITLE
set up an email support system

### DIFF
--- a/www/about/index.html.spt
+++ b/www/about/index.html.spt
@@ -86,7 +86,8 @@ title = "About"
       Ambridge, PA 15003<br />
       USA<br />
       <br />
-      Twitter: <a href="https://twitter.com/Gittip">@Gittip</a> (preferred)<br />
+      Email: <a href="mailto:support@gittip.com">support@gittip.com</a><br />
+      Twitter: <a href="https://twitter.com/Gittip">@Gittip</a><br />
       Facebook: <a href="https://www.facebook.com/pages/Gittip/229465400522758">Gittip</a><br />
       Freenode: <a href="http://chat.gittip.com/">#gittip</a><br />
       GitHub: <a href="https://github.com/gittip/www.gittip.com/issues/new">gittip</a>
@@ -94,10 +95,7 @@ title = "About"
 
     <p style="width: 50%; float: left">
       <b>Chad Whitacre</b>, Founder<br />
-      Twitter: <a href="https://twitter.com/whit537">@whit537</a> 
-      (preferred)<br />
-      email: <a href="mailto:chad@zetaweb.com">chad@zetaweb.com</a><br />
-      cell: <a href="tel:+1-412-925-4220">+1-412-925-4220</a>
+      Twitter: <a href="https://twitter.com/whit537">@whit537</a>
     </p>
 
     <div class="clear"></div>


### PR DESCRIPTION
We need to provide email support for matters that users would like to keep private. @pjc has [reached out](https://twitter.com/celispj/status/361827541251661826) re: https://supportbee.com/. I've signed up for a trial account and it looks like it could be a fine product. We don't have quite the email support volume yet to justify it but hopefully we will soon! :-)
