### PR TITLE
test environnements using tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules/
 docs/_build
 docs/gittip
 docs/gittip.rst
+/.tox

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+flake8
+nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+# Usage examples:
+# tox -epy27 -- --nocapture
+# tox -eflake8
+
+[tox]
+# Environnement to run by default
+envlist = py27, flake8
+
+[testenv]
+setenv VIRTUAL_ENV={envdir}
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+# The test configuration is done via environnement variables contained in the
+# default_tests.env. Since tox does not execute the commands in a shell, we
+# have to wrapp our command in a bash -c '' statement.  In there, we use the
+# `env` command to load all the environnement variables defined in
+# default_tests.env
+commands = /bin/bash -c '/usr/bin/env `/bin/cat default_tests.env` nosetests {posargs}'
+
+# Quality tool, runs both pep8 and pyflakes
+[testenv:flake8]
+commands = flake8
+
+[flake8]
+exclude = .tox,vendor


### PR DESCRIPTION
tox is a pretty nice utility to create isolated test environnements. It
will invoke virtualenv, setup the dependencies and run whatever you want
in there with an easy syntax.

The test suite require environnement variables defined in the
default_tests.env file.  To load it up, I am wrapping nose tests in a
bash shell and invoke /usr/bin/env to load the file containing
environnement variables.  A bit hacky but working.

By default, tox is instructed to run two environements:
- py27 which run the nosetest command with python 2.7
- flake8 a source code checker wrapping both pep8 and pyflakes

You can list the environnement with `tox -l`, and select one of them
using `tox -e<name>`. Options following a double dash '--', will fit in

Examples:

Simply run flake8 only:
  tox -eflake8

Nosetests without capturing output:
  tox -epy27 -- --nocapture
