### PR TITLE
Get the global stats periodically

### DIFF
--- a/configure-aspen.py
+++ b/configure-aspen.py
@@ -1,6 +1,5 @@
 from __future__ import division
 
-import locale
 import os
 import threading
 import time
@@ -29,9 +28,6 @@ gittip.wireup.nanswers()
 gittip.wireup.nmembers(website)
 gittip.wireup.envvars(website)
 tell_sentry = gittip.wireup.sentry(website)
-
-gnactive = ''
-gtransfer_volume = ''
 
 def up_minthreads(website):
     # https://github.com/gittip/www.gittip.com/issues/1098
@@ -120,20 +116,8 @@ def add_stuff(request):
     request.context['github'] = github
     request.context['twitter'] = twitter
     request.context['bountysource'] = bountysource
-    request.context['gnactive'] = gnactive
-    request.context['gtransfer_volume'] = gtransfer_volume
 
 website.hooks.inbound_early += [add_stuff]
-
-def gstats():
-    global gnactive
-    global gtransfer_volume
-    stats = gittip.db.one( "SELECT nactive, transfer_volume FROM paydays "
-                           "ORDER BY ts_end DESC LIMIT 1"
-                         , default=(0, 0.0)
-                          )
-    gnactive = locale.format("%d", round(stats[0], -2), grouping=True)
-    gtransfer_volume = locale.format("%d", round(stats[1], -2), grouping=True)
 
 # The homepage wants expensive queries. Let's periodically select into an
 # intermediate table.
@@ -143,7 +127,7 @@ def update_homepage_queries():
     from gittip import utils
     while 1:
         try:
-            gstats()
+            utils.update_global_stats(website)
             utils.update_homepage_queries_once(website.db)
         except:
             tell_sentry(None)

--- a/gittip/utils/__init__.py
+++ b/gittip/utils/__init__.py
@@ -1,3 +1,4 @@
+import locale
 import time
 
 import gittip
@@ -338,6 +339,15 @@ def get_participant(request, restrict=True):
                 raise Response(403)
 
     return participant
+
+
+def update_global_stats(website):
+    stats = gittip.db.one( "SELECT nactive, transfer_volume FROM paydays "
+                           "ORDER BY ts_end DESC LIMIT 1"
+                         , default=(0, 0.0)
+                          )
+    website.gnactive = locale.format("%d", round(stats[0], -2), grouping=True)
+    website.gtransfer_volume = locale.format("%d", round(stats[1], -2), grouping=True)
 
 
 def update_homepage_queries_once(db):

--- a/templates/base.html
+++ b/templates/base.html
@@ -51,7 +51,7 @@
                 </a>
             </h1>
             </td><td class="motto luxury">
-	    <a href='/about/charts.html'>{{ gnactive }} users exchanging ${{ gtransfer_volume }} per week</a>
+	    <a href='/about/charts.html'>{{ website.gnactive }} users exchanging ${{ website.gtransfer_volume }} per week</a>
         </td></tr></table>
         {% if user.ANON %}
           {% include sign-in-using.html %}


### PR DESCRIPTION
Global stats, user count and weekly dollar exchange, were being gathered on every single request, even requests for static assets. This commit changes the action to only look in the database during homepage cache updates and carry the data in memory so it is available to the application.
