### PR TITLE
Responsive CSS on charts page.

### DIFF
--- a/www/about/charts.html.spt
+++ b/www/about/charts.html.spt
@@ -82,6 +82,11 @@ title = "Charts"
         line-height: 10pt;
         padding-bottom: 12pt;
     }
+    @media screen and (min-width: 1030px) {
+        .chart-wrapper:nth-child(odd) .note {
+            padding-left: 15pt;
+        }
+    }
 </style>
 
 <div class="chart-wrapper">


### PR DESCRIPTION
Originally, the number note bubbles were taking over the text in the next chart. 
# Before

![before](https://f.cloud.github.com/assets/1558388/1558442/97b55016-4f90-11e3-8299-4304641f55d8.png)
# After

![after](https://f.cloud.github.com/assets/1558388/1558443/a18adc1e-4f90-11e3-9b42-2a2c9dcb46db.png)
