### PR TITLE
Only display alternate names of connected accounts if they are not equal

### DIFF
--- a/templates/connected-accounts.html
+++ b/templates/connected-accounts.html
@@ -17,7 +17,7 @@
                 ><img class="avatar"
                 src="{{ escape(twitter_account.user_info.get('profile_image_url_https', '/assets/%s/no-avatar.png' % website.version )) }}"
                 />{{ escape(twitter_account.user_info.get('screen_name')) }}
-                {% if twitter_account.user_info.get('name') %}
+                {% if twitter_account.user_info.get('name') and twitter_account.user_info.get('name') != twitter_account.user_info.get('screen_name') %}
                 ({{ escape(twitter_account.user_info.get('name')) }})
                 {% end %}
             </a>
@@ -40,7 +40,7 @@
             <a rel="me" href="{{ escape(github_account.user_info.get('html_url', '')) }}"
                 ><img class="avatar" src="{{ escape(github_account.user_info.get('avatar_url', '/assets/%s/no-avatar.png' % website.version)) }}"
                 />{{ escape(github_account.user_info.get('login')) }}
-                {% if github_account.user_info.get('name') %}
+                {% if github_account.user_info.get('name') and github_account.user_info.get('name') != github_account.user_info.get('login') %}
                 ({{ escape(github_account.user_info.get('name')) }})
                 {% end %}
             </a>
@@ -64,7 +64,7 @@
                 ><img class="avatar"
                 src="{{ escape(bitbucket_account.user_info.get('avatar', '/assets/%s/no-avatar.png' % website.version)) }}"
                 />{{ escape(bitbucket_account.user_info.get('username')) }}
-                {% if bitbucket_account.user_info.get('display_name') %}
+                {% if bitbucket_account.user_info.get('display_name') and bitbucket_account.user_info.get('display_name') != bitbucket_account.user_info.get('username') %}
                 ({{ escape(bitbucket_account.user_info.get('display_name')) }})
                 {% end %}
             </a>


### PR DESCRIPTION
I'm a little bit confused about the double displayed names on gittip, where the nickname is equal to the real name (twitter for example).
I think if the nickname is equal to the real name, the bracketed name should not be shown.

So "Santina4r3 (Santina4r3)" becomes "Santina4r3" and "whit537 (Chad Whitacre)" stays "whit537 (Chad Whitacre)".
