### PR TITLE
faq: stop mentioning bitcoin's impl detail

### DIFF
--- a/www/about/faq.html.spt
+++ b/www/about/faq.html.spt
@@ -53,8 +53,8 @@ title = "Frequently Asked Questions"
         <dd>Absolutely! We're working on a long-term solution for automated
         withdrawals outside the U.S. (details <a
             href="https://github.com/gittip/www.gittip.com/issues/126">here</a>),
-        and in the mean time we are happy to make manual PayPal payments when
-        you'd like to withdraw your funds from Gittip&mdash;<a
+        but in the meantime we are happy to make manual <a href="#bitcoin">Bitcoin</a>
+        or PayPal payments when you'd like to withdraw your funds from Gittip&mdash;<a
             href="/about/#contact-us">get in touch</a> as needed.</dd>
 
 
@@ -81,7 +81,7 @@ title = "Frequently Asked Questions"
 <div class="col2">
     <dl>
 
-        <dt>Can I use bitcoin?</dt>
+        <dt id="bitcoin">Can I use bitcoin?</dt>
 
         <dd>Sort of. We currently support manual payouts (Coinbase USD->BTC rates/fees apply).
         However, you cannot use bitcoin to pay in. The challenges with bitcoin 


### PR DESCRIPTION
"Using Coinbase" is an implementation detail that could lead
people to think they need a Coinbase account for getting the
payout, which is not true because a bitcoin address is the
only requirement (Coinbase is just the USD->BTC conversion
service), as pointed out in #310.
