### PR TITLE
Enforce maximum chart width and layout at mobile sizes

### DIFF
--- a/scss/lib/_chart.scss
+++ b/scss/lib/_chart.scss
@@ -1,6 +1,7 @@
 .chart-wrapper {
 
     width: 480px;
+    max-width: 50%;
     float: left;
 
     &.newline {

--- a/scss/responsiveness.scss
+++ b/scss/responsiveness.scss
@@ -72,6 +72,13 @@
             }
         }
     }
+
+    .chart-wrapper {
+        width: 288px;
+        max-width: 100%;
+        float: none;
+        margin: 0 auto;
+    }
 }
 
 // Portrait phones


### PR DESCRIPTION
Fix chart size below 701px to the maximum width for portrait phones (288px).

Tablet:

![image 2013-12-02 at 8 31 13 pm](https://f.cloud.github.com/assets/185645/1661139/12f6b3ce-5bd4-11e3-89a9-7b75c1f1e2c8.png)

Phone:

![image 2013-12-02 at 8 33 05 pm](https://f.cloud.github.com/assets/185645/1661140/131efed8-5bd4-11e3-9575-f06f5569a6b3.png)

This isn't a perfect fix, however. The chart size is determined on page load, not on resize. Users visiting the site with a small screen will see appropriately sized charts, but resizing from a desktop size will still result in layout issues. This addresses the immediate needs of #1703, but not the underlying cause. I'd keep #1703 open for discussion/open a new issue for more charting discussion re: https://github.com/gittip/www.gittip.com/issues/1703#issuecomment-29682161
