### PR TITLE
Widen credit card fields in /credit-card.html

### DIFF
--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -447,10 +447,10 @@
         .city          INPUT { width: 137px; }
         .state         INPUT { width: 43px; }
         .zip           INPUT { width: 75px; }
-        .card_number   INPUT { width: 137px; }
+        .card_number   INPUT { width: 139px; }
         .cvv           INPUT { width: 43px; }
-        INPUT.expiration_month { width: 24px; }
-        INPUT.expiration_year  { width: 39px; margin-left: 1px ! important; }
+        INPUT.expiration_month { width: 25px; }
+        INPUT.expiration_year  { width: 42px; margin-left: 1px ! important; }
         .not-first LABEL,
         .not-first INPUT {
             margin-left: 10px;


### PR DESCRIPTION
In Firefox on Mac OS X, these fields were not wide enough to completely contain their text when filled in. This widens the form fields so they have just enough space to contain all of the text, in Firefox on Mac OS X on my machine.

The old version, currently on [gittip.com/credit-card.html](https://www.gittip.com/credit-card.html):

![old version, with too-narrow fields](https://f.cloud.github.com/assets/79168/1670674/431c71c0-5ca0-11e3-8951-341ad5084832.png)

This fixed version:

![fixed versions, with wide-enough fields](https://f.cloud.github.com/assets/79168/1670676/485dcf6c-5ca0-11e3-8724-2c00747bcc5b.png)

Note that the expiration fields are still too narrow to display the full “MM” and “YYYY” placeholders; they are still cut off. I tried widening the fields so you could see the whole placeholders, but then the form looked weird when those fields had values filled in.
