### PR TITLE
Correctly display errors in configure-pg-env.sh.

### DIFF
--- a/configure-pg-env.sh
+++ b/configure-pg-env.sh
@@ -7,7 +7,7 @@
 # I committed this but @pjz wrote it: https://gist.github.com/pjz/5855367.
 
 if [ "$DATABASE_URL" = "" ]; then 
-    echo "Please set DATABASE_URL, perhaps by sourcing default_tests.env or something.";
+    echo "Please set DATABASE_URL, perhaps by sourcing default_tests.env or something." 1>&2;
 exit 1; fi
 
 # remove the protocol

--- a/recreate-schema.sh
+++ b/recreate-schema.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# Exit if any subcommands or pipeline returns a non-zero status.
 set -e
 
 # Make a database for Gittip.
@@ -10,7 +11,12 @@ set -e
 # Configure the Postgres environment.
 # ===================================
 
-export `./configure-pg-env.sh`
+# Store ./configure-pg-env.sh output in a variable, so if it fails, it'll exit
+# before running `export` (export with no args will print all exported variables).
+ENV=`./configure-pg-env.sh`
+
+# If we successfully got a result in $ENV, export it.
+export $ENV
 
 
 


### PR DESCRIPTION
- Print errors in configure-pg-env.sh to STDERR instead of STDOUT.
- Don't run `export` in recreate-schema.sh until after
  configure-pg-env.sh is successfully ran, to avoid the case where
  it would run `export` without any arguments. `set -e` ensures it
  won't run the `export $ENV` line if configure-pg-env.sh fails.

<!---
@huboard:{"order":135.625}
-->
