### PR TITLE
Fix BountySource regression from #1734

### DIFF
--- a/www/on/bountysource/associate.spt
+++ b/www/on/bountysource/associate.spt
@@ -44,7 +44,7 @@ else:
     user_info = bountysource.filter_user_info(qs)
 
     # create a linked account
-    account = bountysource.BountysourceAccount(user_info['id'], user_info)
+    account = bountysource.BountysourceAccount(website.db, user_info['id'], user_info)
 
     # associate with the Gittip participant
     try:


### PR DESCRIPTION
@logankoester discovered in [IRC](https://botbot.me/freenode/gittip/msg/8696595/) that associating with your BountySource account is broken. It turns out to be a pretty simple regression from #1734. One day it'd be nice to have tests for these things :V

<!---
@huboard:{"order":137.625}
-->
