### PR TITLE
Charts: use percentage instead of calc()

### DIFF
--- a/js/gittip/charts.js
+++ b/js/gittip/charts.js
@@ -35,7 +35,7 @@ Gittip.charts.make = function(series) {
 
     var H = $('.chart').height();
     var nweeks = series.length;
-    var w = 'calc(100% / '+ nweeks +')';
+    var w = (1 / nweeks * 100).toFixed(10) + '%';
 
     $('.n-weeks').text(nweeks);
 

--- a/scss/lib/_chart.scss
+++ b/scss/lib/_chart.scss
@@ -31,16 +31,6 @@
         display: none;
         color: #630;
     }
-    .week SPAN.x-tick.on {
-        display: block;
-        border-color: #B2A196;
-        color: #B2A196;
-    }
-    .week.flagged SPAN.x-tick.on,
-    .week.hover SPAN.x-tick.on {
-        border-color: #630;
-        color: #630;
-    }
     .week SPAN.y-label {    // This is the flag.
         display: none;
         position: absolute;


### PR DESCRIPTION
in order to support IE 8 & iOS 6 Safari w/out a vendor prefix

also removes old CSS that @whit537 forgot about ([IRC](https://botbot.me/freenode/gittip/msg/8715357/)) :octopus: 

This follows up on #1745, fixes #1763, and fixes #1765

<!---
@huboard:{"order":137.625}
-->
