### PR TITLE
Provide better message for bad tests/env

### DIFF
--- a/gittip/wireup.py
+++ b/gittip/wireup.py
@@ -156,6 +156,10 @@ def nmembers(website):
     community.NMEMBERS_THRESHOLD = int(os.environ['NMEMBERS_THRESHOLD'])
     website.NMEMBERS_THRESHOLD = community.NMEMBERS_THRESHOLD
 
+
+class BadEnvironment(SystemExit):
+    pass
+
 def envvars(website):
 
     missing_keys = []
@@ -226,7 +230,8 @@ def envvars(website):
         aspen.log_dammit("See ./default_local.env for hints.")
 
         aspen.log_dammit("=" * 42)
-        raise SystemExit
+        keys = ', '.join([key for key in malformed_values])
+        raise BadEnvironment("Malformed envvar{}: {}.".format(plural, keys))
 
     if missing_keys:
         missing_keys.sort()
@@ -250,4 +255,5 @@ def envvars(website):
         aspen.log_dammit("See ./default_local.env for hints.")
 
         aspen.log_dammit("=" * 42)
-        raise SystemExit
+        keys = ', '.join([key for key in missing_keys])
+        raise BadEnvironment("Missing envvar{}: {}.".format(plural, keys))


### PR DESCRIPTION
We provide a nice error message when you `make run` with a bad
local.env, but `make test` with a bad tests/env was giving just
SystemExit. This commit subclasses SystemExit to provide a more
specific error message.
