### PR TITLE
Fix #1175, make default credit card country "United States".

### DIFF
--- a/gittip/utils/__init__.py
+++ b/gittip/utils/__init__.py
@@ -9,6 +9,7 @@ from postgres.cursors import SimpleCursorBase
 
 
 COUNTRIES = (
+    ('US', u'United States'),
     ('AF', u'Afghanistan'),
     ('AX', u'\xc5land Islands'),
     ('AL', u'Albania'),


### PR DESCRIPTION
Put "United States" at the head of the list, which will make it a default for credit cards. 

This should address #1175.
