### PR TITLE
Updates after #1806

### DIFF
--- a/scss/widgets/my_tip.scss
+++ b/scss/widgets/my_tip.scss
@@ -40,11 +40,13 @@ form.my-tip {
 
     .cancel-tip {
         opacity: 0.5;
+        cursor: default;
     }
 
     &.changed {
         .cancel-tip {
             opacity: 1;
+            cursor: pointer;
         }
     }
 }

--- a/templates/my-tip-bulk.html
+++ b/templates/my-tip-bulk.html
@@ -1,13 +1,12 @@
-<div class="my-tip{{ " anon" if user.ANON else "" }}">
+<form class="my-tip{{ " anon" if user.ANON else "" }}">
     $ <input type="number"
            class="my-tip"
            min="0"
            max="100"
            step="0.01"
            value="{{ my_tip }}"
-           data-tippee="{{ tippee }}"
-           data-old-amount="{{ my_tip }}"> / wk
+           data-tippee="{{ tippee }}"> / week
 
     <button class="confirm-tip" disabled>Confirm</button>
     <a href="#" class="cancel-tip">Cancel</a>
-</div>
+</form>

--- a/templates/my-tip.html
+++ b/templates/my-tip.html
@@ -1,7 +1,7 @@
 <form class="my-tip{{ " anon" if user.ANON else "" }}">
 	<div class="tip-controls">
 		<div class="tip-amount">
-			$ <input type="number" class="my-tip" min="0" max="100" step="0.01" value="{{ my_tip }}" data-tippee="{{ tippee }}" data-old-amount="{{ my_tip }}"> / week
+			$ <input type="number" class="my-tip" min="0" max="100" step="0.01" value="{{ my_tip }}" data-tippee="{{ tippee }}"> / week
 		</div>
 
 		<ul class="tip-suggestions">


### PR DESCRIPTION
After #1806, the `endAction` event callback introduced in #1795 was made irrelevant. I introduced the callback to only submit the form after the tip value was validated, but since we're now using a `<form>`, HTML5 browsers already validate before submission.

Since we're now using `form.submit()`, I updated the cancel link to use the native `form.reset()` behavior.

Again, since we're now using a `<form>` I figure we can use the already-provided `input.defaultValue` instead of our hand-made solution to track the previous value.

While making these changes I noticed that the cancel link has the standard `<a>` mouse pointer even when it's disabled, so I updated the CSS to fix this.

This commit also fixes a bug introduced in #1806 by not updating `my-tip-bulk` to use `<form>`.
