### PR TITLE
fix to #1832 android sign-in button wrong height (because of width: auto)

### DIFF
--- a/scss/lib/_dropdown.scss
+++ b/scss/lib/_dropdown.scss
@@ -23,6 +23,7 @@
 }
 a.dropdown-toggle{
   width: 75px;
+  text-align: center;
 }
 .caret {
   display: inline-block;


### PR DESCRIPTION
fix to #1832 on android. Please test it on more browser but this should work fine. everywhere.
