### PR TITLE
Fix membership wrapping issue on profile pages

### DIFF
--- a/scss/modules.scss
+++ b/scss/modules.scss
@@ -180,6 +180,9 @@ ul.memberships {
             }
         }
     }
+    li:nth-child(3n+1) {
+        clear: both;
+    }
 }
 .communities {
     select {


### PR DESCRIPTION
While browsing Gittip, I noticed that membership lists sometime wrap in weird ways:

![screen shot 2014-01-06 at 1 08 20 pm](https://f.cloud.github.com/assets/688886/1853061/06802bd2-7706-11e3-8c2c-3c9071a50f50.png)

This PR clears the CSS float after every third element to prevent this.

Since it appears that our membership lists aren't deterministic (that is, ordered by date or name), I wasn't able to recreate that specific set of communities. However, this illustrates the solution: http://codepen.io/anon/pen/HCehj
