### PR TITLE
Improve exceptions organization

### DIFF
--- a/gittip/elsewhere/__init__.py
+++ b/gittip/elsewhere/__init__.py
@@ -6,9 +6,9 @@ from aspen.utils import typecheck
 from psycopg2 import IntegrityError
 
 import gittip
+from gittip.exceptions import ProblemChangingUsername
 from gittip.security.user import User
 from gittip.models.participant import Participant, reserve_a_random_username
-from gittip.models.participant import ProblemChangingUsername
 
 
 ACTIONS = [u'opt-in', u'connect', u'lock', u'unlock']

--- a/gittip/exceptions.py
+++ b/gittip/exceptions.py
@@ -1,0 +1,33 @@
+"""
+This module contains exceptions shared across application code.
+"""
+
+from __future__ import print_function, unicode_literals
+
+
+# originally from gittip.models.participant
+
+class ProblemChangingUsername(Exception):
+    def __str__(self):
+        return self.msg.format(self.args[0])
+
+class UsernameIsEmpty(ProblemChangingUsername):
+    msg = "You need to provide a username!"
+
+class UsernameTooLong(ProblemChangingUsername):
+    msg = "The username '{}' is too long."
+
+# Not passing the potentially unicode characters back because of:
+# https://github.com/gittip/aspen-python/issues/177
+class UsernameContainsInvalidCharacters(ProblemChangingUsername):
+    msg = "That username contains invalid characters."
+
+class UsernameIsRestricted(ProblemChangingUsername):
+    msg = "The username '{}' is restricted."
+
+class UsernameAlreadyTaken(ProblemChangingUsername):
+    msg = "The username '{}' is already taken."
+
+class TooGreedy(Exception): pass
+class NoSelfTipping(Exception): pass
+class BadAmount(Exception): pass

--- a/gittip/models/participant.py
+++ b/gittip/models/participant.py
@@ -21,6 +21,16 @@ from aspen import Response
 from aspen.utils import typecheck
 from psycopg2 import IntegrityError
 from postgres.orm import Model
+from gittip.exceptions import (
+    UsernameIsEmpty,
+    UsernameTooLong,
+    UsernameContainsInvalidCharacters,
+    UsernameIsRestricted,
+    UsernameAlreadyTaken,
+    NoSelfTipping,
+    BadAmount,
+)
+
 from gittip.models._mixin_elsewhere import MixinElsewhere
 from gittip.models._mixin_team import MixinTeam
 from gittip.utils import canonicalize
@@ -677,35 +687,6 @@ class Participant(Model, MixinElsewhere, MixinTeam):
             now = datetime.datetime.now(self.claimed_time.tzinfo)
             out = (now - self.claimed_time).total_seconds()
         return out
-
-
-# Exceptions
-# ==========
-
-class ProblemChangingUsername(Exception):
-    def __str__(self):
-        return self.msg.format(self.args[0])
-
-class UsernameIsEmpty(ProblemChangingUsername):
-    msg = "You need to provide a username!"
-
-class UsernameTooLong(ProblemChangingUsername):
-    msg = "The username '{}' is too long."
-
-# Not passing the potentially unicode characters back because of:
-# https://github.com/gittip/aspen-python/issues/177
-class UsernameContainsInvalidCharacters(ProblemChangingUsername):
-    msg = "That username contains invalid characters."
-
-class UsernameIsRestricted(ProblemChangingUsername):
-    msg = "The username '{}' is restricted."
-
-class UsernameAlreadyTaken(ProblemChangingUsername):
-    msg = "The username '{}' is already taken."
-
-class TooGreedy(Exception): pass
-class NoSelfTipping(Exception): pass
-class BadAmount(Exception): pass
 
 
 # Username Helpers

--- a/tests/test_participant.py
+++ b/tests/test_participant.py
@@ -11,16 +11,17 @@ from gittip import NotSane
 from gittip.elsewhere.bitbucket import BitbucketAccount
 from gittip.elsewhere.github import GitHubAccount
 from gittip.elsewhere.twitter import TwitterAccount
+from gittip.exceptions import (
+    UsernameIsEmpty,
+    UsernameTooLong,
+    UsernameAlreadyTaken,
+    UsernameContainsInvalidCharacters,
+    UsernameIsRestricted,
+    NoSelfTipping,
+    BadAmount,
+)
 from gittip.models._mixin_elsewhere import NeedConfirmation
 from gittip.models.participant import Participant
-from gittip.models.participant import ( UsernameIsEmpty
-                                      , UsernameTooLong
-                                      , UsernameAlreadyTaken
-                                      , UsernameContainsInvalidCharacters
-                                      , UsernameIsRestricted
-                                      , NoSelfTipping
-                                      , BadAmount
-                                       )
 from gittip.testing import Harness
 
 

--- a/www/%username/tip.json.spt
+++ b/www/%username/tip.json.spt
@@ -3,7 +3,8 @@
 from decimal import InvalidOperation
 
 from aspen import Response
-from gittip.models.participant import Participant, BadAmount
+from gittip.exceptions import BadAmount
+from gittip.models.participant import Participant
 
 [-----------------------------------------------------------------------------]
 

--- a/www/%username/username.json.spt
+++ b/www/%username/username.json.spt
@@ -1,6 +1,6 @@
 from aspen import Response, log_dammit
+from gittip.exceptions import ProblemChangingUsername
 from gittip.models.participant import Participant
-from gittip.models.participant import ProblemChangingUsername
 
 
 [-----------------------------------------------------------------------------]


### PR DESCRIPTION
I created a root `gittip.exceptions` module for exceptions to live at, and moved in those from the participant model.

Two benefits:
1. better organization
2. one step towards resolving circular import issues (eg `gittip/elsewhere/__init__.py` -> participant)

cc @thomasboyt
