### PR TITLE
Reimplement Sentry logging

### DIFF
--- a/configure-aspen.py
+++ b/configure-aspen.py
@@ -1,6 +1,7 @@
 from __future__ import division
 
 import os
+import sys
 import threading
 import time
 import traceback
@@ -57,11 +58,10 @@ def update_homepage_queries():
             utils.update_homepage_queries_once(website.db)
             website.db.self_check()
         except:
-            if tell_sentry:
-                tell_sentry(None)
-            else:
-                tb = traceback.format_exc().strip()
-                log_dammit(tb)
+            exception = sys.exc_info()[0]
+            tell_sentry(exception)
+            tb = traceback.format_exc().strip()
+            log_dammit(tb)
         time.sleep(UPDATE_HOMEPAGE_EVERY)
 
 if UPDATE_HOMEPAGE_EVERY > 0:
@@ -146,6 +146,8 @@ algorithm.functions = [ timer.start
                       , algorithm['get_response_for_socket']
                       , algorithm['get_resource_for_request']
                       , algorithm['get_response_for_resource']
+
+                      , tell_sentry
                       , algorithm['get_response_for_exception']
 
                       , authentication.outbound
@@ -155,8 +157,10 @@ algorithm.functions = [ timer.start
 
                       , algorithm['log_traceback_for_5xx']
                       , algorithm['delegate_error_to_simplate']
+                      , tell_sentry
                       , algorithm['log_traceback_for_exception']
                       , algorithm['log_result_of_request']
 
                       , timer.end
+                      , tell_sentry
                        ]

--- a/gittip/wireup.py
+++ b/gittip/wireup.py
@@ -49,20 +49,20 @@ def username_restrictions(website):
 def make_sentry_teller(website):
     if not website.sentry_dsn:
         aspen.log_dammit("Won't log to Sentry (SENTRY_DSN is empty).")
-        return None
+        def noop(exception, request=None):
+            pass
+        return noop
 
     sentry = raven.Client(website.sentry_dsn)
 
-    def tell_sentry(request):
-        cls, response = sys.exc_info()[:2]
-
+    def tell_sentry(exception, request=None):
 
         # Decide if we care.
         # ==================
 
-        if cls is aspen.Response:
+        if exception.__class__ is aspen.Response:
 
-            if response.code < 500:
+            if exception.code < 500:
 
                 # Only log server errors to Sentry. For responses < 500 we use
                 # stream-/line-based access logging. See discussion on:
@@ -130,8 +130,8 @@ def make_sentry_teller(website):
         ident = sentry.get_ident(result)
         aspen.log_dammit('Exception reference: ' + ident)
 
-
     return tell_sentry
+
 
 def nanswers():
     from gittip.models import participant
@@ -186,7 +186,7 @@ def envvars(website):
     website.bountysource_api_host = envvar('BOUNTYSOURCE_API_HOST')
     website.bountysource_api_secret = envvar('BOUNTYSOURCE_API_SECRET')
     website.bountysource_callback = envvar('BOUNTYSOURCE_CALLBACK')
-   
+
     website.openstreetmap_api = envvar('OPENSTREETMAP_API')
     website.openstreetmap_consumer_key = envvar('OPENSTREETMAP_CONSUMER_KEY')
     website.openstreetmap_consumer_secret = envvar('OPENSTREETMAP_CONSUMER_SECRET')


### PR DESCRIPTION
We lost this in the Aspen 0.28.x upgrade, because we failed to interpolate tell_sentry into the new algorithm list we constructed.
