### PR TITLE
Point people straight to email for payins/outs

### DIFF
--- a/www/about/faq.html.spt
+++ b/www/about/faq.html.spt
@@ -57,8 +57,10 @@ title = "Frequently Asked Questions"
             minimum; 2.9% + 30&cent; fee, with additional fees from non-U.S.
             banks).</li>
 
-            <li><a href="/about/#contact">Contact us</a> to request a one-time
-            bitcoin payin (1% + 15&cent; fee).</li>
+            <li><a
+                href="mailto:support@gittip.com?subject=bitcoin%20payin">Email
+            us</a> to request a one-time bitcoin payin (1% + 15&cent;
+        fee).</li>
 
         </ol>
 
@@ -75,11 +77,15 @@ title = "Frequently Asked Questions"
                 bank account</a>. Funds will be deposited every Friday (no fee;
             U.S.-only).</li>
 
-            <li> <a href="/about/#contact-us">Contact us</a> to set up
-            a weekly PayPal payout (2% fee, capped at $20).</li>
+            <li><a
+                href="mailto:support@gittip.com?subject=configuring%20PayPal">Email
+            us</a> to set up a weekly PayPal payout (2% fee, capped at
+            $20).</li>
 
-            <li> <a href="/about/#contact-us">Contact us</a> to request
-            a one-time bitcoin payout (1% + 15&cent; fee).</li>
+            <li><a
+                href="mailto:support@gittip.com?subject=bitcoin%20payout">Email
+            us</a> to request a one-time bitcoin payout (1% + 15&cent;
+            fee).</li>
 
         </ol>
 


### PR DESCRIPTION
We heard from @jslegers at https://github.com/gittip/www.gittip.com/issues/126#issuecomment-31969020 about the confusing flow for configuring PayPal or requesting bitcoin payins/outs. This PR addresses the issue by pointing directly to email as the preferred support method for these requests, rather than linking to the general "Contact us" info.

@jslegers Is this at all more helpful?
