### PR TITLE
Work around a Cheroot bug

### DIFF
--- a/configure-aspen.py
+++ b/configure-aspen.py
@@ -126,6 +126,25 @@ def add_stuff_to_context(request):
     request.context['openstreetmap'] = openstreetmap
 
 
+def scab_body_onto_response(response):
+
+    # This is a workaround for a Cheroot bug, where the connection is closed
+    # too early if there is no body:
+    #
+    # https://bitbucket.org/cherrypy/cheroot/issue/1/fail-if-passed-zero-bytes
+    #
+    # This Cheroot bug is manifesting because of a change in Aspen's behavior
+    # with the algorithm.py refactor in 0.27+: Aspen no longer sets a body for
+    # 302s as it used to. This means that all redirects are breaking
+    # intermittently (sometimes the client seems not to care that the
+    # connection is closed too early, so I guess there's some timing
+    # involved?), which is affecting a number of parts of Gittip, notably
+    # around logging in (#1859).
+
+    if not response.body:
+        response.body = '*sigh*'
+
+
 algorithm = website.algorithm
 algorithm.functions = [ timer.start
                       , algorithm['parse_environ_into_request']
@@ -161,6 +180,7 @@ algorithm.functions = [ timer.start
                       , algorithm['log_traceback_for_exception']
                       , algorithm['log_result_of_request']
 
+                      , scab_body_onto_response
                       , timer.end
                       , tell_sentry
                        ]


### PR DESCRIPTION
Newly manifesting due to a change in Aspen behavior (302 bodies are now empty, as they should be, and Cheroot more often than not closes the socket too early when there is no body).
