### PR TITLE
Linkify end-of-string url bug fix

### DIFF
--- a/gittip/utils/__init__.py
+++ b/gittip/utils/__init__.py
@@ -273,7 +273,7 @@ def wrap(u):
 def linkify(u):
     escaped = unicode(escape(u))
 
-    urls = re.compile(r"((?:https?://|www\.)[\w\d.-]*\w(?=\W)(?:/(?:\S*\(\S*[^\s.,;:'\"]|\S*[^\s.,;:'\"()])*)?)", re.MULTILINE|re.UNICODE)
+    urls = re.compile(r"((?:https?://|www\.)[\w\d.-]*\w(?:/(?:\S*\(\S*[^\s.,;:'\"]|\S*[^\s.,;:'\"()])*)?)", re.MULTILINE|re.UNICODE)
     value = urls.sub(r'<a href="\1" target="_blank">\1</a>', escaped)
 
     return value


### PR DESCRIPTION
In linkify, the lookahead assertion for a non-alphanumeric character, (?=\W), was causing URLs at the end of a string, like ^http://example.com$, to match http://example rather than http://example.com while ^http://example.com/$ and ^http://example.com\n$ worked fine. Discovered in user statement.
