### PR TITLE
Bugfix: Hide first and last bountysource-name if they are empty

### DIFF
--- a/templates/connected-accounts.html
+++ b/templates/connected-accounts.html
@@ -87,7 +87,7 @@
                 ><img class="avatar"
                       src="{{ bountysource_account.user_info.get('image_url', '/assets/%s/no-avatar.png' % website.version)|e }}"
             />{{ bountysource_account.user_info.get('display_name') }}
-            {% if bountysource_account.user_info.get('display_name') %}
+            {% if bountysource_account.user_info.get('first_name') and bountysource_account.user_info.get('last_name') %}
                 ({{ bountysource_account.user_info.get('first_name')|e }} {{ bountysource_account.user_info.get('last_name')|e }})
             {% endif %}
             </a>


### PR DESCRIPTION
As suggested in #1678, the first and last Bountysource name are now hided, if they are empty.
