### PR TITLE
Remove "Congrats!" text for first N communities

### DIFF
--- a/www/for/%slug/index.html.spt
+++ b/www/for/%slug/index.html.spt
@@ -27,35 +27,6 @@ def _to_age(participant):
         age = age.replace(word, str(i))
     return age.replace(' ', ' <span class="unit">') + "</span>"
 
-THRESHOLD = website.NMEMBERS_THRESHOLD
-
-def get_first_ten():
-    """Return a dictionary mapping community slugs to ordinal numbers.
-    """
-    holy_heck = website.db.all("SELECT * FROM communities ORDER BY mtime ASC")
-    _first_ten = []
-    communities = defaultdict(lambda: (defaultdict(set), defaultdict(int)))
-    for detail in holy_heck:
-        _slug = detail.slug
-        _members, _nmembers = communities[_slug]
-        if detail.is_member:
-            if detail.participant not in _members[_slug]:
-                _members[_slug].add(detail.participant)
-                _nmembers[_slug] += 1
-            else:
-                _members[_slug].remove(detail.participant)
-                _nmembers[_slug] -= 1
-
-        if _nmembers[_slug] == THRESHOLD:
-            _first_ten.append(_slug)
-            if len(_first_ten) == 10:
-                break
-
-    first_ten = {}
-    for i, slug in enumerate(_first_ten, start=1):
-        first_ten[slug] = ORDINALS[i]
-
-    return first_ten
 [---]
 
 _slug = path['slug']
@@ -87,14 +58,6 @@ if community is None:
 title = community.name + ' Community'
 
 if community.nmembers >= website.NMEMBERS_THRESHOLD:
-
-    # Compute a dict of the first ten communities.
-    # ============================================
-    # We want to reward the first ten communities on Gittip with a message
-    # saying they were the first.
-
-    first_ten = get_first_ten()
-
 
     # Run queries for listings.
     # =========================
@@ -250,13 +213,6 @@ $(document).ready(function() {
 
 </div>
 {% else %}
-
-{% if community.slug in first_ten %}
-<div style="text-align: center;">
-    <h1 class="congrats">Congratulations!</h1>
-    <p>You're the {{ first_ten[community.slug] }} community on Gittip! :D</p>
-</div>
-{% endif %}
 
 
 <div id="leaderboard">


### PR DESCRIPTION
Now that we've dropped the threshold for "viable" communities from 150 to 50 (#1316), that throws a wrench in the "Congratulations!" text we had for the first communities to reach the 150 mark on Gittip. After talking with @dahlia in [IRC](https://botbot.me/freenode/gittip/msg/9818883/), we're dropping the "Congratulations!" text entirely.
