### PR TITLE
Rework /for/ to not talk about viability

### DIFF
--- a/www/for/index.html.spt
+++ b/www/for/index.html.spt
@@ -1,24 +1,12 @@
 from gittip.models import community
 from gittip.utils import plural
 
-THRESHOLD = website.NMEMBERS_THRESHOLD
-
 [-----------------------------]
 
 communities = community.get_list_for(website.db, None)
 ncommunities = len(communities)
-
-viable = []
-forming = []
-
-for community in communities:
-    if community.nmembers >= THRESHOLD:
-        seq = viable
-    else:
-        seq = forming
-    seq.append(community)
-
 title = "Browse Communities"
+
 [-----------------------------]
 {% extends "templates/base.html" %}
 {% block head %}
@@ -29,11 +17,8 @@ title = "Browse Communities"
 
 {% block heading %}
 <h2 class="top"><span>Communities</span></h2>
-
-<p>Self-organized communities of {{ THRESHOLD }} or more<br />
-members get their own page on Gittip.</p>
-
 {% endblock %}
+
 {% block box %}
 <div class="on-community">
     <h2 class="pad-sign">There are</h2>
@@ -78,10 +63,9 @@ members get their own page on Gittip.</p>
 </script>
 <div class="col0">
 
-    <h2>Viable Communities (N = {{ len(viable) }})</h2>
-    <p class="help">At least {{ THRESHOLD }} members</p>
+    <h2>Large Communities</h2>
     <ul class="community memberships">
-        {% for community in viable %}
+        {% for community in communities[:18] %}
         <li>
             <a href="/for/{{ community.slug }}/">{{ community.name }}</a>
             {% set n = community.nmembers %}
@@ -90,12 +74,11 @@ members get their own page on Gittip.</p>
         {% endfor %}
     </ul>
 
-    <h2>Communities in Formation (N = {{ len(forming) }})</h2>
-    <p class="help">Less than {{ THRESHOLD }} members</p>
+    <h2>All Communities</h2>
     <form class="communities">
         <select data-placeholder="Find or add a community ..." tabindex="1">
             <option></option>
-            {% for community in forming %}
+            {% for community in communities %}
             <option value="{{ community.slug }}">{{ community.name }} -
             {% set n = community.nmembers %}
             {{ n }} member{{ plural(n) }}


### PR DESCRIPTION
Instead we just refer to "Large Communities" and "All Communities." Large is simply defined as the 18 largest (fits the 3-column listing well). Note that NMEMBERS_THRESHOLD survives, because I'm still thinking we'll vary what we show for > and < THRESHOLD (only the "New Members" listing below THRESHOLD; all three listings as usual for above).

This PR depends on #1908.
