### PR TITLE
Standardize placement of Teams/Communities

### DIFF
--- a/templates/community-listing.html
+++ b/templates/community-listing.html
@@ -10,4 +10,3 @@
     </li>
     {% endfor %}
 </ul>
-<a href="/for/">Join Communities</a>

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -65,7 +65,7 @@
     <!-- Memberships -->
     {% include "templates/team-listing.html" %}
     {% include "templates/community-listing.html" %}
-
+    <a href="/for/">Join Communities</a>
 
 </div>
 <div class="col2">

--- a/www/%username/index.html.spt
+++ b/www/%username/index.html.spt
@@ -69,31 +69,21 @@ else:
 {% else %}
     <div class="group">
         {% if participant.statement %}
-            <div class="{% if long_statement %}col1{% else %}col0{% endif %}">
+        <div class="{% if long_statement %}col1{% else %}col0{% endif %}">
             <h2>Statement</h2>
             <div class="statement">
                 {{ I_AM }}
                 {{ MAKING }} {{ wrap(participant.statement) }}
             </div>
-            </div>
-            <div class="{% if long_statement %}col2{% else %}col0{% endif %}">
-        {% else %}
-            <div class="col0">
-        {% endif %}
             {% include "templates/team-listing.html" %}
-
-            {% if communities %}
-            <h2>Communities</h2>
-            <ul class="community memberships">
-                {% for community in communities %}
-                <li>
-                    <a href="/for/{{ community.slug }}/">{{ community.name }}</a>
-                    {% set nothers = community.nmembers - 1 %}
-                    <div class="fine">with {{ nothers }} other{{ plural(nothers) }}</div>
-                </li>
-                {% endfor %}
-            </ul>
-            {% endif %}
+            {% include "templates/community-listing.html" %}
+        </div>
+        <div class="{% if long_statement %}col2{% else %}col0{% endif %}">
+        {% else %}
+        <div class="col0">
+            {% include "templates/team-listing.html" %}
+            {% include "templates/community-listing.html" %}
+        {% endif %}
 
             <h2>Funding Goal</h2>
             <div class="goal">
@@ -113,7 +103,6 @@ else:
             </div>
 
             {% include "templates/charts-for-user.html" %}
-
             {% include "templates/connected-accounts.html" %}
         </div>
     </div>


### PR DESCRIPTION
On profile pages, the placement of the teams/communities listings varied based on whether the user was logged in or not. This standardizes the location of those listings to the lower-left in the two-column display, which you get when editing your profile, or when viewing the profile of someone with a long statement. When viewing the profile of someone with a short statement or no statement there is a single column and the team/community listings are towards the top.

This fixes #956.
