### PR TITLE
Allow subclasses of Response to be not reported.

### DIFF
--- a/gittip/wireup.py
+++ b/gittip/wireup.py
@@ -60,7 +60,7 @@ def make_sentry_teller(website):
         # Decide if we care.
         # ==================
 
-        if exception.__class__ is aspen.Response:
+        if isinstance(exception, aspen.Response):
 
             if exception.code < 500:
 


### PR DESCRIPTION
CRLFInjection is a subclass of Response and it was being reported to
sentry as unhandled exception.

Attempt to fix #1701.
