### PR TITLE
Start using simplate docstrings for IA docs

### DIFF
--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -1,3 +1,18 @@
+"""## Information Architecture
+
+This is where we document all the pages on our website, with their purpose and
+the most important thing on each page.
+
+
+### Homepage
+
+https://www.gittip.com/
+
+This is the homepage. The most important thing is to give a good first
+impression of Gittip and help people take the next step, whatever that might be
+for them.
+
+"""
 import os
 from aspen import Response
 from aspen.utils import to_age


### PR DESCRIPTION
This is also a test of our web hook to building.gittip.com. When this lands on master, we should see IA docs appear at building.gittip.com/ia.
