### PR TITLE
Remove mention of make local.env due to it being removed in PR #1974

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ time.
 The included `Makefile` contains several targets. Configuration options
 are stored in default_local.env file while overrides are in local.env.
 
-To create a local environment configuration file:
-
-    $ make local.env
-
 To create virtualenv enviroment with all python dependencies installed
 in a sandbox:
 


### PR DESCRIPTION
The README.md needs updated to match the changes made to the makefile and the setup process that were changed with PR #1975. This mention of make local.env is the only discrepancy I caught on a quick read through.
