### PR TITLE
use TwitterAccount's get_url instead of custom html_url

### DIFF
--- a/templates/connected-accounts.html
+++ b/templates/connected-accounts.html
@@ -12,7 +12,7 @@
                     No Twitter account connected.
                 {% endif %}
             {% else %}
-            <a rel="me" href="{{ twitter_account.user_info.get('html_url', '')|e }}"
+            <a rel="me" href="{{ twitter_account.get_url() }}"
                 ><img class="avatar"
                 src="{{ twitter_account.user_info.get('profile_image_url_https', '/assets/%s/no-avatar.png' % website.version )|e }}"
                 />{{ twitter_account.user_info.get('screen_name')|e }}

--- a/www/on/twitter/%screen_name/index.html.spt
+++ b/www/on/twitter/%screen_name/index.html.spt
@@ -24,7 +24,6 @@ username = user_info['screen_name']
 name = user_info.get('name')
 if not name:
     name = username
-url = user_info['html_url'] = "https://twitter.com/%s" % username
 
 account = twitter.TwitterAccount(website.db, user_info['id'], user_info)
 participant = Participant.from_username(account.participant)
@@ -57,7 +56,7 @@ title = username
             <img src="{{ participant.get_img_src(128) }}" />
         </td>
         <td class="ready">
-            <h2><a href="{{ url }}">{{ username|e }}</a> has</h2>
+            <h2><a href="{{ account.get_url() }}">{{ username|e }}</a> has</h2>
             <div class="number">{{ nbackers }}</div>
             <div class="unit">{{ 'person' if nbackers == 1 else 'people' }} ready to give</div>
         </td>
@@ -76,7 +75,7 @@ title = username
 
     <h2>{{ username|e }} has opted out of Gittip.</h2>
 
-    <p>If you are <a href="{{ user_info.get('html_url', '') }}">{{ username|e }}</a>
+    <p>If you are <a href="{{ account.get_url() }}">{{ username|e }}</a>
     on Twitter, you can unlock your account to allow people to pledge tips to
     you on Gittip.</p>
 

--- a/www/on/twitter/associate.spt
+++ b/www/on/twitter/associate.spt
@@ -69,7 +69,6 @@ if screen_name is None:
     log(u"We got a user_info from Twitter with no screen_name [%s, %s]"
         % (action, then))
     raise Response(400)
-user_info['html_url'] = "https://twitter.com/" + screen_name
 
 # Do something.
 log(u"%s wants to %s" % (screen_name, action))


### PR DESCRIPTION
This resolves #1997 by using what we have instead of relying on a derivative value from the database (that happened to be blown away by #1989)
