### PR TITLE
Add a link to our Google+ page

### DIFF
--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -98,6 +98,7 @@ receivers = utter_hack(website.db, website.db.all("""
 [---]
 {% extends "templates/base.html" %}
 {% block head %}
+    <link rel="publisher" href="https://plus.google.com/110591317655791133884">
     <meta name="description" content="Inspiring Generosity. Gittip is a weekly gift exchange. Support and thank your favorite people and projects and communities with small cash gifts." />
 {% endblock %}
 


### PR DESCRIPTION
From their instructions:

> By adding a short line of code to https://www.gittip.com/, you can make your Google+ page eligible to show up on the right hand side of the Google search page for relevant queries and make your Google+ page more discoverable.

[These instructions](https://support.google.com/plus/answer/1713826?hl=en) indicate that we can include a text-less A tag in the HEAD rather than an actual link in the page (which would require a little more thought).
