### PR TITLE
Add id tags to FAQ for deeplinking

### DIFF
--- a/www/about/faq.html.spt
+++ b/www/about/faq.html.spt
@@ -5,13 +5,13 @@ title = "Frequently Asked Questions"
 <div class="col1">
     <dl>
 
-        <dt>What is Gittip?</dt>
+        <dt id="what-gittip">What is Gittip?</dt>
 
         <dd>Gittip is a way to give money every week to people and teams you
         believe in.</dd>
 
 
-        <dt>Who is Gittip?</dt>
+        <dt id="who-gittip">Who is Gittip?</dt>
 
         <dd>Gittip, LLC is an <a
           href="http://blog.gittip.com/post/26350459746/the-first-open-company">open
@@ -22,7 +22,7 @@ title = "Frequently Asked Questions"
         Gittip team <a href="/Gittip/members/">here</a>.</dd>
 
 
-        <dt>How is Gittip funded?</dt>
+        <dt id="how-funded">How is Gittip funded?</dt>
 
         <dd>Gittip is funded on Gittip. As an <a
             href="http://blog.gittip.com/post/26350459746/the-first-open-company">open
@@ -31,7 +31,7 @@ title = "Frequently Asked Questions"
         we ourselves are charged for.</dd>
 
 
-        <dt>Can I make a one-time gift?</dt>
+        <dt id="one-time-gift">Can I make a one-time gift?</dt>
 
         <dd>No. Gittip is designed for long-term, sustainable funding, and only
         supports recurring gifts at this time. We will probably offer one-time
@@ -41,12 +41,12 @@ title = "Frequently Asked Questions"
         the first week.</dd>
 
 
-        <dt>I'm not in the U.S., can I still use Gittip?</dt>
+        <dt id="not-in-us">I'm not in the U.S., can I still use Gittip?</dt>
 
         <dd>Yes, but moving funds takes more time and the fees are higher.</dd>
 
 
-        <dt>How do I add funds to Gittip?</dt>
+        <dt="how-add-funds">How do I add funds to Gittip?</dt>
 
         <dd>There are two ways to add funds to Gittip:
 
@@ -67,7 +67,7 @@ title = "Frequently Asked Questions"
         </dd>
 
 
-        <dt>How do I withdraw funds from Gittip?</dt>
+        <dt id="how-withdraw-funds">How do I withdraw funds from Gittip?</dt>
 
         <dd>There are three ways to withdraw funds from Gittip:
 
@@ -96,7 +96,7 @@ title = "Frequently Asked Questions"
 <div class="col2">
     <dl>
 
-        <dt>Is there a minimum or maximum amount I can give or receive?</dt>
+        <dt id="maximum-amount">Is there a minimum or maximum amount I can give or receive?</dt>
 
         <dd>There are no restrictions on the total amount you can give
         or receive.</dd>
@@ -110,12 +110,12 @@ title = "Frequently Asked Questions"
         large patrons.</dd>
 
 
-        <dt>Can I use Gittip to support organizations?</dt>
+        <dt id="support-organizations">Can I use Gittip to support organizations?</dt>
 
         <dd>Yes. Some accounts on Gittip represent organizations.</dd>
 
 
-        <dt>What's the point of communities?</dt>
+        <dt id="whats-point-of-communities">What's the point of communities?</dt>
 
         <dd><a href="/for/">Communities</a> let you identify with groups
         of people that share your interests, such as <a href="/for/python/">
@@ -123,7 +123,7 @@ title = "Frequently Asked Questions"
         regions</a>.
 
 
-        <dt>How do I know my gifts are being received by the right person?</dt>
+        <dt id="how-know-right-person">How do I know my gifts are being received by the right person?</dt>
 
         <dd>You can follow links to Gittip from a trusted source like a person
         or organization's website. Also, Twitter verifies accounts in instances
@@ -131,18 +131,18 @@ title = "Frequently Asked Questions"
         carefully if it's linked.</dd>
 
 
-        <dt>Do I have to pay taxes on the income I receive from Gittip?</dt>
+        <dt id="taxable">Do I have to pay taxes on the income I receive from Gittip?</dt>
 
         <dd>We can't offer blanket legal advice on that, sorry. You'll have to
         talk to a lawyer.</dd>
 
 
-        <dt>Are gifts I give through Gittip tax-deductible?</dt>
+        <dt id="tax-deductible">Are gifts I give through Gittip tax-deductible?</dt>
 
         <dd>No.</dd>
 
 
-        <dt>I don't want to receive gifts, I just want to give them. What should
+        <dt id="dont-want-gifts">I don't want to receive gifts, I just want to give them. What should
         I do?</dt>
 
         <dd>Please select &ldquo;I'm here as a patron, and politely decline to


### PR DESCRIPTION
Would be great to link to specific items, as this is likely to be shared:

https://www.gittip.com/about/faq.html#who-is-gittip
