### PR TITLE
Clarify FAQ item on PayPal withdrawal fee

### DIFF
--- a/www/about/faq.html.spt
+++ b/www/about/faq.html.spt
@@ -79,7 +79,7 @@ title = "Frequently Asked Questions"
 
             <li><a
                 href="mailto:support@gittip.com?subject=configuring%20PayPal">Email
-            us</a> to set up a weekly PayPal payout (2% fee, capped at
+            us</a> to set up a weekly PayPal payout (unlimited payout; 2% fee capped at
             $20).</li>
 
             <li><a


### PR DESCRIPTION
https://www.gittip.com/about/faq.html

Currently reads:

> How do I withdraw funds from Gittip?
> There are three ways to withdraw funds from Gittip:
>  [...]
> 2. Email us to set up a weekly PayPal payout (2% fee, capped at $20).

Context of the copy: https://github.com/gittip/www.gittip.com/issues/1658

@whit537 can you comment on what exactly you meant with the copy? Is it to say PayPal payout can't be higher than $1000, and if so, can we just say this?

This has twice come to light as causing confusion, as people think that PayPal payouts are capped at $20, rather than the fees:

https://botbot.me/freenode/gittip/msg/10811014/
http://blogs.perl.org/users/peter_rabbitson/2014/02/i-bought-a-weekly-round-for-my-friends.html#comment-1318459

Would also be nice to deeplink into FAQ items, so reticketed in #2019
