### PR TITLE
fix a masspay rounding error

### DIFF
--- a/bin/masspay.py
+++ b/bin/masspay.py
@@ -64,8 +64,8 @@ class Payee(object):
         fee = self.gross - round_(self.gross / D('1.02'))   # 2% fee
         fee = min(fee, D('20.00'))                          # capped at $20
         self.fee += fee                                     #  XXX or $1 for U.S. :/
-        self.net -= fee
-        if self.net % 1 in (D('0.25'), D('0.75')):
+        self.net -= fee                                     #  XXX See #1675.
+        if self.net % 1 == D('0.25'):
 
             # Prevent an escrow leak. It's complicated, but it goes something
             # like this:
@@ -91,7 +91,8 @@ class Payee(object):
             #  10. Our solution is to leave a penny behind in Gittip for
             #       affected payees.
             #
-            # See also: https://github.com/gittip/www.gittip.com/issues/1673.
+            # See also: https://github.com/gittip/www.gittip.com/issues/1673
+            #           https://github.com/gittip/www.gittip.com/issues/2029
 
             self.gross -= D('0.01')
             self.net -= D('0.01')


### PR DESCRIPTION
Fixes rounding bug that cropped up during Gittip 89 (#2029).
