### PR TITLE
Add slugignore file

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,6 @@
+# Files removed before slug
+# compilation on Heroku
+# See: https://devcenter.heroku.com/articles/slug-compiler#slug-size
+img-src/
+tests/
+jstests/


### PR DESCRIPTION
Heroku allows for a slugignore file to help keep the compiled slug as small as possible:
https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore

Supposedly this speeds up deploy and dyno scaling.
