### PR TITLE
Use VCR fixtures on branches in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install: make env node_modules
 before_script:
  - echo "DATABASE_URL=dbname=gittip" | tee -a tests/local.env local.env
  - psql -U postgres -c 'CREATE DATABASE "gittip";'
- - [ "`git rev-parse --abbrev-ref HEAD`" = "master" ] && rm -rf tests/fixtures
+ - if [ "`git rev-parse --abbrev-ref HEAD`" = "master" ]; then rm -rf tests/fixtures; fi
 script: make test
 notifications:
   email: false


### PR DESCRIPTION
This is a redo of #2102.

It's good to exercise live HTTP APIs, and Travis is the place to do that, but it slows down development to do that on every branch all the time. This commit changes our configuration to only clear out test fixtures on the master branch.
