### PR TITLE
Move account row to a macro

### DIFF
--- a/templates/account-row.html
+++ b/templates/account-row.html
@@ -1,0 +1,34 @@
+{% macro account_row(platform, account, auth_button) %}
+    <tr>
+        <td class="account-type">
+            <img src="/assets/{{ platform.name }}.png" />
+        </td>
+        <td class="account-details">
+            {% if account == None %}
+                {% if not user.ANON and user.participant == participant %}
+                    {% call auth_button(platform.name, 'connect') %}
+                        Connect a {{ platform.display_name }} account
+                    {% endcall %}
+                {% else %}
+                    No {{ platform.display_name }} account connected.
+                {% endif %}
+            {% else %}
+                <a rel="me" href="{{ account.html_url|e }}"
+                    ><img class="avatar" src="{{ get_avatar_url(account)|e }}"
+                    />{{ account.user_name|e }}
+                    {% if account.display_name and account.display_name != account.user_name %}
+                        ({{ account.display_name|e }})
+                    {% endif %}
+                </a>
+                {% if user.participant == participant %}
+                    <button class="account-delete"
+                            data-platform="{{ platform.name }}"
+                            data-user_id="{{ account.user_id }}">
+                        Disconnect
+                    </button>
+                {% endif %}
+                <div class="account-type">on {{ platform.display_name }}</div>
+            {% endif %}
+        </td>
+    </tr>
+{% endmacro %}

--- a/templates/connected-accounts.html
+++ b/templates/connected-accounts.html
@@ -1,41 +1,11 @@
 {% from 'templates/auth.html' import auth_button with context %}
+{% from 'templates/account-row.html' import account_row with context %}
 
 <h2>Connected Accounts</h2>
 <table id="accounts">
 {% for platform in website.platforms %}
     {% set account = accounts.get(platform.name, None) %}
-    <tr>
-        <td class="account-type">
-            <img src="/assets/{{ platform.name }}.png" />
-        </td>
-        <td class="account-details">
-            {% if account == None %}
-                {% if not user.ANON and user.participant == participant %}
-                    {% call auth_button(platform.name, 'connect') %}
-                        Connect a {{ platform.display_name }} account
-                    {% endcall %}
-                {% else %}
-                    No {{ platform.display_name }} account connected.
-                {% endif %}
-            {% else %}
-                <a rel="me" href="{{ account.html_url|e }}"
-                    ><img class="avatar" src="{{ get_avatar_url(account)|e }}"
-                    />{{ account.user_name|e }}
-                    {% if account.display_name and account.display_name != account.user_name %}
-                        ({{ account.display_name|e }})
-                    {% endif %}
-                </a>
-                {% if user.participant == participant %}
-                    <button class="account-delete"
-                            data-platform="{{ platform.name }}"
-                            data-user_id="{{ account.user_id }}">
-                        Disconnect
-                    </button>
-                {% endif %}
-                <div class="account-type">on {{ platform.display_name }}</div>
-            {% endif %}
-        </td>
-    </tr>
+    {{ account_row(platform, account, auth_button) }}
 {% endfor %}
     <tr>
         <td class="account-type">
@@ -115,9 +85,6 @@
                     <button type="cancel" class="bitcoin cancel hidden">Cancel</button>
                 </div>
             </form>
-
         </td>
     </tr>
 </table>
-
-


### PR DESCRIPTION
The "Connected Accounts" listing includes accounts elsewhere along with some kludged together systems (Bitcoin, Balanced). As part of #2053 we want to group the items under Connected Accounts, but the groups don't fall out along the lines of the accounts elsewhere/kludge split. Moving this bit of markup to a macro gives us the flexibility we need to knit true and kludges accounts elsewhere into the UI we want.
