### PR TITLE
Update README with Apple LLVM/Xcode 5.1 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ and `python-dev` (includes Python header files for `psycopg2`).
 If you are receiving issues from `psycopg2`, please [ensure that its needs are
 met](http://initd.org/psycopg/docs/faq.html#problems-compiling-and-deploying-psycopg2).
 
+If you are getting an error about `unknown argument: '-mno-fused-madd'` when running `make`, then add `Wno-error=unused-command-line-argument-hard-error-in-future` to your `ARCHFLAGS` environment variable and try again (see [this Stack Overflow answer for more information](http://stackoverflow.com/a/22355874/347246):
+
+    $ ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
+
 Building
 --------
 


### PR DESCRIPTION
Was having problems getting the project. With @whit537’s help it was narrowed-down to changes in the GCC included with Xcode 5.1 that caused, what used to be a warning, an error that occurs during the build process and causes it to fail.

Updated the README with info on getting through the error, by downgrading the error to a warning. I’m not really down with some Unix lingo so feel free to make wording changes.
