### PR TITLE
Adjust size of Bitcoin address on small screens

### DIFF
--- a/scss/modules.scss
+++ b/scss/modules.scss
@@ -121,6 +121,7 @@ a.mini-user:hover {
     .account-details {
         padding: 10px;
         position: relative;
+        word-break: break-all;
     }
     .account-username {
         line-height: 16pt;

--- a/scss/responsiveness.scss
+++ b/scss/responsiveness.scss
@@ -149,8 +149,4 @@
             }
         }
     }
-
-    .address {
-        font-size: 11px
-    }
 }


### PR DESCRIPTION
**Ready for review again**

**Edit March 18**
Instead of decreasing the font-size we’ll just break the word when the text starts to overflow the table cell, per @seanlinsley’s suggestion.

![screen shot 2014-03-18 at 6 39 08 pm](https://f.cloud.github.com/assets/65468/2454617/545c5766-aeee-11e3-8e3a-293dd4c23fd6.png)

**Old post**

Fixes #2150. Prevents a horizontal scrollbar from appearing viewing profiles with Bitcoin addresses (mostly on iPhones). I decreased the size instead of trying to cut it off with an ellipsis because the implementation is a lot easier and some people may reference addresses by the last few digits.

![screen shot 2014-03-16 at 7 10 27 pm](https://f.cloud.github.com/assets/65468/2432331/2d7eee5e-ad60-11e3-8e3d-585592c28939.png)
