### PR TITLE
Changing the term 'reconnect' by 'transfer' 

### DIFF
--- a/gittip/models/participant.py
+++ b/gittip/models/participant.py
@@ -721,7 +721,7 @@ class Participant(Model, MixinTeam):
         ever decide to join Gittip).
 
         In certain circumstances, we want to present the user with a
-        confirmation before proceeding to reconnect the account elsewhere to
+        confirmation before proceeding to transfer the account elsewhere to
         the new Gittip account; NeedConfirmation is the signal to request
         confirmation. If it was the last account elsewhere connected to the old
         Gittip account, then we absorb the old Gittip account into the new one,

--- a/www/on/confirm.html.spt
+++ b/www/on/confirm.html.spt
@@ -54,7 +54,7 @@ title = "Please Confirm"
 
     <div><img class="platform-icon" src="{{ platform.icon }}"
     /> <span class="highlight">{{ user_name }}</span> is connected<br />to
-    <b>{{ other.username }}</b> on Gittip.<br />Reconnect it?</div>
+    <b>{{ other.username }}</b> on Gittip.<br />Transfer it?</div>
 
     <h2>Now</h2>
 
@@ -116,7 +116,7 @@ title = "Please Confirm"
     </table>
 
 
-    <h2>After Reconnect</h2>
+    <h2>After Transfer</h2>
 
     <table class="scenario">
         <tr>
@@ -218,15 +218,15 @@ title = "Please Confirm"
 
 
     <div class="nav level-2">
-        <h2>Reconnect?</h2>
+        <h2>Transfer it?</h2>
 
         <form action="/on/take-over.html" method="POST">
             <input type="hidden" name="platform" value="{{ account.platform }}" />
             <input type="hidden" name="user_id" value="{{ account.user_id }}" />
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
             <input type="hidden" name="connect_token" value="{{ connect_token }}" />
-            <button name="should_reconnect" value="yes" class="selected larger">Yes</button>
-            <button name="should_reconnect" value="no" >No</button>
+            <button name="should_transfer" value="yes" class="selected larger">Yes</button>
+            <button name="should_transfer" value="no" >No</button>
         </form>
     </div>
 

--- a/www/on/take-over.html.spt
+++ b/www/on/take-over.html.spt
@@ -6,7 +6,7 @@ if user.ANON:
 if not POST:
     raise Response(405)
 
-if body['should_reconnect'] != 'yes':
+if body['should_transfer'] != 'yes':
     request.redirect('/about/me.html')
 
 platform = body['platform']


### PR DESCRIPTION
when a third party account is already connected to an other user, the confirmation form is a little confusing. I think transfer is more clear for what it's doing.

This was insiered by this issue Fix #980
