### PR TITLE
Redirect with CORS header

### DIFF
--- a/www/on/%platform/%user_name/public.json.spt
+++ b/www/on/%platform/%user_name/public.json.spt
@@ -34,7 +34,10 @@ if account is None:
 if account.participant.is_claimed:
     next_url = '/%s/public.json' % account.participant.username
     next_url += stringify_qs(qs)
-    request.redirect(next_url)
+    headers = {}
+    headers["Access-Control-Allow-Origin"] = "*"
+    headers["Location"] = next_url
+    raise Response(302, body='*barrel roll*', headers=headers)
 
 
 participant = account.participant


### PR DESCRIPTION
Right now we're getting errors due to `/on/%elsewhere/%user_name/public.json` not passing a CORS header when redirecting
