### PR TITLE
Clicking Sign in no-longer closes menu if it’s open

### DIFF
--- a/js/gittip.js
+++ b/js/gittip.js
@@ -80,8 +80,13 @@ Gittip.signIn = function() {
     });
 
     $('.dropdown-toggle').click(function(e) {
-        e.preventDefault();
-        return false;
+        if ($('.sign-in > .dropdown').hasClass('open')) {
+            e.preventDefault();
+            return false;
+        }
+        else {
+            $(this).addClass('open');
+        }
     });
 
     // disable the tip-changed prompt when trying to sign in


### PR DESCRIPTION
Closes #1289 nothing fancy. This just prevents the _Sign in_ button from closing the dropdown menu if that menu is already open.
