### PR TITLE
Require api key confirm for redistributing final gift

### DIFF
--- a/bin/deactivate-final-rename.py
+++ b/bin/deactivate-final-rename.py
@@ -9,7 +9,7 @@ this script will report the problem and abort without making any update.
 
 Usage:
 
-    [gittip] $ heroku config -s -a gittip | foreman run -e /dev/stdin ./env/bin/python ./scripts/deactivate-final-rename.py "username" [first-eight-of-api-key]
+    [gittip] $ heroku config -s -a gittip | foreman run -e /dev/stdin ./env/bin/python ./bin/deactivate-final-rename.py "username" [first-eight-of-api-key]
 
 """
 from __future__ import print_function

--- a/bin/final-gift.py
+++ b/bin/final-gift.py
@@ -3,7 +3,7 @@
 
 Usage:
 
-    [gittip] $ heroku config -s -a gittip | foreman run -e /dev/stdin ./env/bin/python ./scripts/final-gift.py "username"
+    [gittip] $ heroku config -s -a gittip | foreman run -e /dev/stdin ./env/bin/python ./bin/final-gift.py "username" [first-eight-of-api-key]
 
 """
 from __future__ import print_function
@@ -18,7 +18,25 @@ db = wireup.db()
 
 username = sys.argv[1] # will fail with KeyError if missing
 tipper = Participant.from_username(username)
+if len(sys.argv) < 3:
+    first_eight = "unknown!"
+else:
+    first_eight = sys.argv[2]
 
+# Ensure user is legit
+FIELDS = """
+        SELECT username, username_lower, api_key, claimed_time
+          FROM participants
+         WHERE username = %s
+"""
+
+fields = db.one(FIELDS, (username,))
+print(fields)
+
+if fields.api_key == None:
+    assert first_eight == "None"
+else:
+    assert fields.api_key[0:8] == first_eight
 
 print("Distributing {} from {}.".format(tipper.balance, tipper.username))
 if tipper.balance == 0:


### PR DESCRIPTION
Redistributed gift based on support email, and then realized that I hadn't gotten the API key to do the actual account deactivation. Probably a good idea to enforce this, so that we don't somehow redistribute gifts without being sure of the identity of the person who contacted us :)
