### PR TITLE
Correct customer URL to Balanced

### DIFF
--- a/templates/connected-accounts.html
+++ b/templates/connected-accounts.html
@@ -76,7 +76,7 @@
             <div class="account-type">
                 Balanced Payments
                 {% if user.ADMIN and participant.balanced_customer_href %}
-                (<a href="https://dashboard.balancedpayments.com/#/{{ participant.balanced_customer_href[4:] }}"
+                (<a href="https://dashboard.balancedpayments.com/#/marketplaces/MP12Xw5lL6iaILtqImIoroDL{{ participant.balanced_customer_href }}"
                     >view on dashboard</a>)
                 {% endif %}
             </div>


### PR DESCRIPTION
The Gittip provided URL to Balanced makes no sense. This is an attempt to fix it. I haven't ever tried testing with Balanced, so I do not know how to test this change. But, I know that the existing code does not work. This really cannot be any worse.
