### PR TITLE
Remove os.environ from error handling test page

### DIFF
--- a/www/about/error.html.spt
+++ b/www/about/error.html.spt
@@ -1,7 +1,9 @@
 import os
 from aspen import Response
+from environment import Environment, is_yesish
+env = Environment('GITTIP_', TEST_ERROR_HANDLING=is_yesish)
 [---]
-if os.environ.get('GITTIP_TEST_ERROR_HANDLING') is not None:
+if env.test_error_handling:
     raise Response(int(qs['code']))
 [---]
 <style>


### PR DESCRIPTION
Chain: #2226 #2227 #2228 #2229 #2230 #2231 #2232 #2233 
