### PR TITLE
Fix regression in payday with #2226 chain

### DIFF
--- a/gittip/cli.py
+++ b/gittip/cli.py
@@ -17,8 +17,8 @@ def payday():
     db = wireup.db(env)
     db.run("SET statement_timeout = 0")
 
-    wireup.billing()
-    wireup.nanswers()
+    wireup.billing(env)
+    wireup.nanswers(env)
 
 
     # Lazily import the billing module.


### PR DESCRIPTION
The wireup.{billing,nanswers} functions also need an env arg now. Discovered in #2236.
