### PR TITLE
Decrease duration of notifications and fade out notification on click.

### DIFF
--- a/js/gittip/notification.js
+++ b/js/gittip/notification.js
@@ -13,5 +13,8 @@ Gittip.notification = function(text, type) {
 
     $('#notification-area').prepend(dialog);
 
-    setTimeout(function() { $(dialog).fadeOut(); }, 15000);
+    $(dialog).on('click', function() {
+      $(this).fadeOut();
+    });
+    setTimeout(function() { $(dialog).fadeOut(); }, 5000);
 };


### PR DESCRIPTION
Quick fix for #2273 to improve usability until a long-term solution is agreed on and implemented.
