### PR TITLE
Do a `make clean` on a fresh vagrant provision.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ You should then find this in your browser at
 Congratulations! Sign in using Twitter or GitHub and you're off and
 running. At some point, try [running the test suite](#testing-).
 
+Vagrant
+-------
+If you have vagrant installed, you can run gittip merely by running `vagrant up` from the project directory. Please note that if you ever switch between running gittip on your own machine to vagrant or vice versa, you will need to run `make clean`.
+
 
 Help!
 -----

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,7 +67,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   eos
 
   # Set up the environment, the database, and run Gittip
-  config.vm.provision :shell, :inline => "cd #{PROJECT_DIRECTORY} && make env schema data"
+  config.vm.provision :shell, :inline => "cd #{PROJECT_DIRECTORY} && make clean env schema data"
 
   # add run script
   config.vm.provision :shell, :inline => <<-eos


### PR DESCRIPTION
While not necessary for fresh installs, this is done to prevent errors
that can arise if you are switching from running on your own machine to
vagrant. Make a note of this in the readme.
