### PR TITLE
Vagrant base

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ If you'd like to contribute to Gittip, the best first reference is <https://gitt
 Quick Start
 ===========
 
+Vagrant
+-------
+
+If you have vagrant installed, you can run gittip merely by running
+`vagrant up` from the project directory. Please note that if you ever
+switch between running gittip on your own machine to vagrant or vice
+versa, you will need to run `make clean`.
+
+The Vagrantfile will download a custom made image from the internet. If you have a slow internet connection, you can download a local copy of this file, by running:
+
+`curl http://downloads.gittipllc.netdna-cdn.com/gittip.box`
+
+Once downloaded, vagrant will use this local file automatically when you run `vagrant up`
+
+
+Manual Quick Start
+------------------
+If you'd prefer to run on your machine directly, you can run these commands:
 ```
 $ git clone git@github.com:gittip/www.gittip.com.git
 $ cd www.gittip.com
@@ -171,10 +189,6 @@ You should then find this in your browser at
 
 Congratulations! Sign in using Twitter or GitHub and you're off and
 running. At some point, try [running the test suite](#testing-).
-
-Vagrant
--------
-If you have vagrant installed, you can run gittip merely by running `vagrant up` from the project directory. Please note that if you ever switch between running gittip on your own machine to vagrant or vice versa, you will need to run `make clean`.
 
 
 Help!

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  #For now we have a custom built vagrant image. It was built in the following manner:
+  #-Use 'precise64' as a base.
+  #-perform a 'vagrant up' using this vagrantfile: https://github.com/gittip/www.gittip.com/blob/83312e60c6b31c298ffca61036baa9849044c75e/Vagrantfile
+  #-drop database gittip
+  #-drop role gittip
+  config.vm.box = "gittip"
+  config.vm.box_url =  File.exist?("gittip.box") ? "file://gittip.box" : "http://downloads.gittipllc.netdna-cdn.com/gittip.box"
 
   # Sync the project directory and expose the app
   config.vm.synced_folder ".", "/home/vagrant/#{PROJECT_DIRECTORY}"
@@ -20,21 +25,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # TODO: Pin apt-get packages to the same versions Heroku uses
 
-  # Install dependencies
-  config.vm.provision :shell, :inline => <<-eos
-    echo 'deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main' > /etc/apt/sources.list.d/postgresql.list
-    wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-    echo 'deb http://ppa.launchpad.net/chris-lea/node.js/ubuntu precise main' > /etc/apt/sources.list.d/chrislea-nodejs.list
-    wget -qO- 'http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xB9316A7BC7917B12' | apt-key add -
-    apt-get update
-    apt-get -y install make git build-essential python-software-properties postgresql-9.3 postgresql-contrib-9.3 libpq-dev python-dev nodejs
-  eos
+  # Installed dependencies are already part of the base image now
 
   # Configure Postgres
   config.vm.provision :shell, :inline => <<-eos
     sudo -u postgres psql -U postgres -qf /home/vagrant/#{PROJECT_DIRECTORY}/create_db.sql
-    sudo -u postgres createuser --superuser root
-    sudo -u postgres createuser --superuser vagrant
+    # Root  and vagrant users are now part of the base image
   eos
 
   # Warn if Windows newlines are detected and try to fix the problem


### PR DESCRIPTION
A nearly complete 'custom base image' change to the vagrant workflow - this allows for much quicker new dev environment startup times, especially if you use a locally cached copy of the image - helpful over conference wifi.

**NOTE**: This PR is incomplete, someone still needs to upload `gittip_box.box` to a public location, and change `http://FIXME` in both the Vagrantfile and README.md to point to the new URL.
