### PR TITLE
Remove form feed from COPYING file

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,9 +1,10 @@
-Gittip is in the public domain. Page two of this file is the summary of "CC0
-1.0 Universal - Public Domain Dedication" from the Creative Commons. Page three
-is the full legal code for the same.
+Gittip is in the public domain, via the "CC0 1.0 Universal - Public Domain
+Dedication" from the Creative Commons.
 
 
-http://creativecommons.org/publicdomain/zero/1.0/
+## Summary of "CC0 1.0 Universal - Public Domain Dedication"
+
+http://creativecommons.org/publicdomain/zero/1.0/
 
 No Copyright
  
@@ -31,7 +32,9 @@ Other Information
         author or the affirmer.
 
 
-http://creativecommons.org/publicdomain/zero/1.0/legalcode
+## CC0 1.0 Universal - Public Domain Dedication
+
+http://creativecommons.org/publicdomain/zero/1.0/legalcode
 
 
 Statement of Purpose


### PR DESCRIPTION
These are a holdover from old Aspen, where we were using form feeds in simplates. Those are gone now, these don't belong here (they cause confusion such as #2302).
