### PR TITLE
Update handling of elsewhere avatars

### DIFF
--- a/gittip/elsewhere/__init__.py
+++ b/gittip/elsewhere/__init__.py
@@ -271,7 +271,8 @@ class Platform(object):
         if i.avatar_url:
             scheme, netloc, path, query, fragment = urlsplit(i.avatar_url)
             fragment = ''
-            if netloc.endswith('gravatar.com'):
+            if netloc.endswith('githubusercontent.com') or \
+               netloc.endswith('gravatar.com'):
                 query = 's=128'
             i.avatar_url = urlunsplit((scheme, netloc, path, query, fragment))
 


### PR DESCRIPTION
Needed because GitHub doesn't use Gravatar anymore. This should fix the problem that @YenaHong reported [in IRC](https://botbot.me/freenode/gittip/msg/13665444/).
