### PR TITLE
Add link to colophon on building.gittip.com

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -76,6 +76,7 @@
                 <li><a href="/about/terms/">Terms</a></li>
                 <li><a href="/about/privacy/">Privacy</a></li>
                 <li><a href='/about/fraud/'>Fraud</a></li>
+                <li><a href='http://building.gittip.com/appendices/colophon'>Colophon</a></li>
                 <li><a href='/security.txt'>Security</a></li>
             </ul>
         </div>


### PR DESCRIPTION
Not merged yet, but would be nice to have it somewhere on the main site once this goes through:

https://github.com/gittip/building.gittip.com/pull/36
