### PR TITLE
Change all blockchain.info URLs to https.

### DIFF
--- a/js/gittip/profile.js
+++ b/js/gittip/profile.js
@@ -304,7 +304,7 @@ Gittip.profile.init = function() {
                     html = "<span class=\"none\">None</span>"
                     html += "<button class=\"toggle-bitcoin\">+ Add</button>";
                 } else {
-                    html = "<a class=\"address\" rel=\"me\" href=\"http://blockchain.info/address/";
+                    html = "<a class=\"address\" rel=\"me\" href=\"https://blockchain.info/address/";
                     html += d.bitcoin_address + "\">" + d.bitcoin_address + "</a>";
                     html += "<button class=\"toggle-bitcoin\">Edit</button>";
                 }

--- a/templates/connected-accounts.html
+++ b/templates/connected-accounts.html
@@ -72,7 +72,7 @@
                 <div>
             {% endif %}
                 {% if participant.bitcoin_address %}
-                    <a class="address" rel="me" href="http://blockchain.info/address/{{ participant.bitcoin_address }}">
+                    <a class="address" rel="me" href="https://blockchain.info/address/{{ participant.bitcoin_address }}">
                       {{ participant.bitcoin_address }}
                     </a>
                     {% if not user.ANON and user.participant == participant %}

--- a/www/%username/public.json.spt
+++ b/www/%username/public.json.spt
@@ -100,7 +100,7 @@ for platform, account in accounts.items():
     elsewhere[platform] = {k: getattr(account, k, None) for k in fields}
 
 if participant.bitcoin_address is not None:
-    output['bitcoin'] = "http://blockchain.info/address/%s" % participant.bitcoin_address
+    output['bitcoin'] = "https://blockchain.info/address/%s" % participant.bitcoin_address
 
 response.body = output
 


### PR DESCRIPTION
I strongly believe that for every site that supports HTTPS instead of HTTP, only HTTPS should be used. This is even more true for sites that deal with sending money.

http://blockchain.info sets the `Strict-Transport-Security` header, indicating that any browser should try HTTPS instead of HTTP. However, linking to the HTTP version of the site leaves users vulnerable that have never visited blockchain.info over HTTPS before.
