### PR TITLE
Fix propagation of avatar URLs

### DIFF
--- a/gittip/elsewhere/__init__.py
+++ b/gittip/elsewhere/__init__.py
@@ -305,22 +305,10 @@ class Platform(object):
              RETURNING participant
             """.format(cols, placeholders), vals+(self.name, i.user_id))
 
-        # Propagate avatar_url to participant
-        self.db.run("""
-            UPDATE participants p
-               SET avatar_url = (
-                       SELECT avatar_url
-                         FROM elsewhere
-                        WHERE participant = p.username
-                     ORDER BY platform = 'github' DESC,
-                              avatar_url LIKE '%%gravatar.com%%' DESC
-                        LIMIT 1
-                   )
-             WHERE p.username = %s
-        """, (username,))
-
-        # Now delegate to get_account_from_db
-        return self.get_account_from_db(i.user_name)
+        # Return account after propagating avatar_url to participant
+        account = self.get_account_from_db(i.user_name)
+        account.participant.update_avatar()
+        return account
 
 
 class PlatformOAuth1(Platform):


### PR DESCRIPTION
Our current code doesn't update the avatar of a Gittip account when it takes over another account. This results in the avatar not being updated after connecting an elsewhere account (because connecting is implemented as a take over). Moreover, the avatar wasn't being updated after disconnecting an elsewhere account either.

This PR fixes all that.

Thanks to @seanlinsley (https://github.com/gittip/www.gittip.com/pull/2314#issuecomment-41454031) and @YenaHong ([IRC](https://botbot.me/freenode/gittip/msg/13860356/)).
