### PR TITLE
Record event when changing is_suspicious

### DIFF
--- a/tests/py/test_is_suspicious.py
+++ b/tests/py/test_is_suspicious.py
@@ -7,30 +7,45 @@ from gittip.models.participant import Participant
 class TestIsSuspicious(Harness):
     def setUp(self):
         Harness.setUp(self)
-        self.make_participant('bar', is_admin=True)
+        self.bar = self.make_participant('bar', is_admin=True)
 
     def toggle_is_suspicious(self):
         self.client.GET('/foo/toggle-is-suspicious.json', auth_as='bar')
 
     def test_that_is_suspicious_defaults_to_None(self):
-        foo = self.make_participant('foo')
+        foo = self.make_participant('foo', claimed_time='now')
         actual = foo.is_suspicious
         assert actual == None
 
     def test_toggling_NULL_gives_true(self):
-        self.make_participant('foo')
+        self.make_participant('foo', claimed_time='now')
         self.toggle_is_suspicious()
         actual = Participant.from_username('foo').is_suspicious
         assert actual == True
 
     def test_toggling_true_gives_false(self):
-        self.make_participant('foo', is_suspicious=True)
+        self.make_participant('foo', is_suspicious=True, claimed_time='now')
         self.toggle_is_suspicious()
         actual = Participant.from_username('foo').is_suspicious
         assert actual == False
 
     def test_toggling_false_gives_true(self):
-        self.make_participant('foo', is_suspicious=False)
+        self.make_participant('foo', is_suspicious=False, claimed_time='now')
         self.toggle_is_suspicious()
         actual = Participant.from_username('foo').is_suspicious
         assert actual == True
+
+    def test_toggling_adds_event(self):
+        foo = self.make_participant('foo', is_suspicious=False, claimed_time='now')
+        self.toggle_is_suspicious()
+
+        actual = self.db.one("""\
+                SELECT type, payload
+                FROM events
+                WHERE CAST(payload->>'id' AS INTEGER) = %s
+                  AND (payload->'values'->'is_suspicious')::text != 'null'
+                ORDER BY ts DESC""",
+                (foo.id,))
+        assert actual == ('participant', dict(id=foo.id,
+            recorder=dict(id=self.bar.id, username=self.bar.username), action='set',
+            values=dict(is_suspicious=True)))

--- a/www/%username/toggle-is-suspicious.json.spt
+++ b/www/%username/toggle-is-suspicious.json.spt
@@ -29,7 +29,10 @@ with website.db.get_cursor() as c:
 
         """, (to == 'true', path['username'],))
 
-    add_event(c, 'participant', dict(id=get_participant(request).id, recorder=dict(id=user.participant.id, username=user.participant.username),
-	action='set', values=dict(is_suspicious=is_suspicious)))
+    add_event(c, 'participant', dict(
+        id=get_participant(request).id,
+        recorder=dict(id=user.participant.id, username=user.participant.username),
+        action='set', values=dict(is_suspicious=is_suspicious)
+    ))
 
 response.body = {"is_suspicious": is_suspicious}


### PR DESCRIPTION
This PR moves the logic for updating the `is_suspicious` column out of the `toggle-is-suspicious.json` simplate, and into the `Participant` model. The event is then logged using `add_event`.

See issue https://github.com/gittip/www.gittip.com/issues/2261
