### PR TITLE
Replace broken avatars with default avatar

### DIFF
--- a/js/gittip/profile.js
+++ b/js/gittip/profile.js
@@ -234,7 +234,8 @@ Gittip.profile.init = function() {
     });
 
     $('img.avatar').one("error", function () {
-        $(this).attr("src", "avatar-default.png");
+        var defaultAvatar = $(this).data("default-avatar")
+        $(this).attr("src", defaultAvatar);
     });
 
 };

--- a/templates/account-row.html
+++ b/templates/account-row.html
@@ -6,7 +6,7 @@
         <td class="account-type">
             <div class="sanity-preserving-wrapper">
                 {% if account != None %}
-                    <img class="avatar" src="{{ avatar_url(account) }}"/>
+                    <img class="avatar" src="{{ avatar_url(account) }}" data-default-avatar="{{ website.asset_url }}/avatar-default.png"/>
                 {% endif %}
               <img class="platform" src="{{ website.asset_url }}/{{ platform.name }}.png" />
             </div>


### PR DESCRIPTION
This fixes #2208 where I suggested we handle the display of broken avatars by showing something else less broken.

Would be cool if there was a way to reference website.asset_url within JS so I don’t have to resort to the data-default-avatar hack I’ve done here.
