### PR TITLE
Enforce uniqueness of API keys

### DIFF
--- a/branch.sql
+++ b/branch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE participants ADD CONSTRAINT participants_api_key UNIQUE (api_key);


### PR DESCRIPTION
This PR adds a `UNIQUE` constraint on `participants.api_key`, which is needed for consistency and performance.
