### PR TITLE
Fixed missing button when statement change

### DIFF
--- a/js/gittip/profile.js
+++ b/js/gittip/profile.js
@@ -43,6 +43,15 @@ Gittip.profile.init = function() {
             $('.statement textarea').focus();
         });
     }
+
+    function update_members_button(is_plural) {
+        if (is_plural) {
+            $("#members-button").removeClass("hidden")
+        } else {
+            $("#members-button").addClass("hidden")
+        }
+    }
+
     if ($('.statement textarea').val() === '') {
         start_editing_statement();
     }
@@ -55,6 +64,7 @@ Gittip.profile.init = function() {
     $('form.statement').submit(function(e) {
         e.preventDefault();
 
+        var is_plural = jQuery("#statement-select").val() === "plural";
         $('.statement button.save').text('Saving ...');
 
         function success(d) {
@@ -62,6 +72,7 @@ Gittip.profile.init = function() {
             var number = $('.statement select').val();
             Gittip.profile.toNumber(number);
             finish_editing_statement();
+            update_members_button(is_plural);
         }
         function error(e) {
             $('.statement button.save').text('Save');

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -9,7 +9,7 @@
         </h2>
 
         <div class="edit">
-            <select tabindex="201" name="number">
+            <select tabindex="201" name="number" id="statement-select">
                 <option value="singular"
                     {{ "selected" if participant.number == 'singular' else ''}}>
                     I am

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -20,9 +20,13 @@
     {% for slug, name in pages %}
     <a href="/{{ participant.username }}{{ slug }}"><button{% if slug.strip('/') == current_page %} class="selected"{% endif %}>{{ name }}</button></a>
     {% endfor %}
-    {% if participant.show_as_team(user) %}
-    <a href="/{{ participant.username }}/members/"><button{% if 'members' == current_page %} class="selected"{% endif %}>Members</button></a>
+
+    <a href="/{{ participant.username }}/members/" id="members-button"
+    {% if not participant.show_as_team(user) %}
+        class="hidden"
     {% endif %}
+    ><button{% if 'members' == current_page %} class="selected"{% endif %}>Members</button></a>
+
     {% if user.ADMIN %}
     <a href="/{{ participant.username }}/events/"><button{% if 'events' == current_page %} class="selected"{% endif %}>Events</button></a>
     {% endif %}


### PR DESCRIPTION
I am not sure if this bug has been found, but when a user changes "I am" to "We are" on the statement page and click Save, the "Members" button is missing and appears only on page reload:

![missing_button](https://cloud.githubusercontent.com/assets/592286/3077913/a1bc91ba-e44a-11e3-977b-18eec5c263e6.png)

The opposite problem appears when you change "We are" to "I am", while changes are saved the "Members" button is still there:

![wrong_button](https://cloud.githubusercontent.com/assets/592286/3077923/ec78f5d6-e44a-11e3-8762-5e206384b2a2.png)
Both problems were fixed in this PR.
