### PR TITLE
Move untip.py to a method on Participant

### DIFF
--- a/bin/untip.py
+++ b/bin/untip.py
@@ -11,34 +11,9 @@ from __future__ import print_function
 import sys
 
 from gittip import wireup
+from gittip.models.participant import Participant
 
 
 tippee = sys.argv[1] # will fail with KeyError if missing
-
 db = wireup.db(wireup.env())
-
-tips = db.all("""
-
-    SELECT amount
-         , ( SELECT participants.*::participants
-               FROM participants
-              WHERE username=tipper
-            ) AS tipper
-         , ( SELECT participants.*::participants
-               FROM participants
-              WHERE username=tippee
-            ) AS tippee
-      FROM current_tips
-     WHERE tippee = %s
-       AND amount > 0
-  ORDER BY amount DESC
-
-""", (tippee,))
-
-
-for tip in tips:
-    print( tip.tipper.username.ljust(12)
-         , tip.tippee.username.ljust(12)
-         , str(tip.amount).rjust(6)
-          )
-    tip.tipper.set_tip_to(tip.tippee.username, '0.00')
+Participant.from_username(tippee).clear_tips_receiving()

--- a/gittip/models/participant.py
+++ b/gittip/models/participant.py
@@ -246,6 +246,34 @@ class Participant(Model, MixinTeam):
             self.set_attributes(claimed_time=claimed_time)
 
 
+    # Canceling
+    # =========
+    # XXX Not done yet, building up in pieces.
+
+    def clear_tips_receiving(self):
+        """Zero out tips to a given user. This is a workaround for #1469.
+        """
+
+        tips = self.db.all("""
+
+            SELECT amount
+                 , ( SELECT participants.*::participants
+                       FROM participants
+                      WHERE username=tipper
+                    ) AS tipper
+                 , ( SELECT participants.*::participants
+                       FROM participants
+                      WHERE username=tippee
+                    ) AS tippee
+              FROM current_tips
+             WHERE tippee = %s
+               AND amount > 0
+          ORDER BY amount DESC
+
+        """, (self.username,))
+        for tip in tips:
+            tip.tipper.set_tip_to(tip.tippee.username, '0.00')
+
 
     # Random Junk
     # ===========

--- a/tests/py/test_cancel.py
+++ b/tests/py/test_cancel.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from decimal import Decimal as D
+
+from gittip.testing import Harness
+
+
+class Tests(Harness):
+
+    # ctr - clear_tips_receiving
+
+    def test_ctr_clears_tips_receiving(self):
+        alice = self.make_participant('alice')
+        self.make_participant('bob').set_tip_to('alice', D('1.00'))
+        ntips = lambda: self.db.one("SELECT count(*) FROM current_tips "
+                                    "WHERE tippee='alice' AND amount > 0")
+        assert ntips() == 1
+        alice.clear_tips_receiving()
+        assert ntips() == 0
+
+    def test_ctr_doesnt_duplicate_zero_tips(self):
+        alice = self.make_participant('alice')
+        bob = self.make_participant('bob')
+        bob.set_tip_to('alice', D('1.00'))
+        bob.set_tip_to('alice', D('0.00'))
+        ntips = lambda: self.db.one("SELECT count(*) FROM tips WHERE tippee='alice'")
+        assert ntips() == 2
+        alice.clear_tips_receiving()
+        assert ntips() == 2
+
+    def test_ctr_doesnt_zero_when_theres_no_tip(self):
+        alice = self.make_participant('alice')
+        ntips = lambda: self.db.one("SELECT count(*) FROM tips WHERE tippee='alice'")
+        assert ntips() == 0
+        alice.clear_tips_receiving()
+        assert ntips() == 0
+
+    def test_ctr_clears_multiple_tips_receiving(self):
+        alice = self.make_participant('alice')
+        self.make_participant('bob').set_tip_to('alice', D('1.00'))
+        self.make_participant('carl').set_tip_to('alice', D('2.00'))
+        self.make_participant('darcy').set_tip_to('alice', D('3.00'))
+        self.make_participant('evelyn').set_tip_to('alice', D('4.00'))
+        self.make_participant('francis').set_tip_to('alice', D('5.00'))
+        ntips = lambda: self.db.one("SELECT count(*) FROM current_tips "
+                                    "WHERE tippee='alice' AND amount > 0")
+        assert ntips() == 5
+        alice.clear_tips_receiving()
+        assert ntips() == 0


### PR DESCRIPTION
This is a step on the way to making account cancelation self-serve. This commit keeps the untip.py script used in the current cancelation process but delegates to a (tested) method on Participant.
