### PR TITLE
Smoother tests

### DIFF
--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -114,57 +114,57 @@ class TestAbsorptions(Harness):
 class TestTakeOver(Harness):
 
     def test_cross_tip_doesnt_become_self_tip(self):
-        alice = self.make_elsewhere('twitter', 1, 'alice')
-        bob   = self.make_elsewhere('twitter', 2, 'bob')
-        alice_participant = alice.opt_in('alice')[0].participant
-        bob_participant = bob.opt_in('bob')[0].participant
-        alice_participant.set_tip_to('bob', '1.00')
-        bob_participant.take_over(alice, have_confirmation=True)
+        alice_twitter = self.make_elsewhere('twitter', 1, 'alice')
+        bob_twitter   = self.make_elsewhere('twitter', 2, 'bob')
+        alice = alice_twitter.opt_in('alice')[0].participant
+        bob = bob_twitter.opt_in('bob')[0].participant
+        alice.set_tip_to('bob', '1.00')
+        bob.take_over(alice_twitter, have_confirmation=True)
         self.db.self_check()
 
     def test_zero_cross_tip_doesnt_become_self_tip(self):
-        alice = self.make_elsewhere('twitter', 1, 'alice')
-        bob   = self.make_elsewhere('twitter', 2, 'bob')
-        alice_participant = alice.opt_in('alice')[0].participant
-        bob_participant = bob.opt_in('bob')[0].participant
-        alice_participant.set_tip_to('bob', '1.00')
-        alice_participant.set_tip_to('bob', '0.00')
-        bob_participant.take_over(alice, have_confirmation=True)
+        alice_twitter = self.make_elsewhere('twitter', 1, 'alice')
+        bob_twitter   = self.make_elsewhere('twitter', 2, 'bob')
+        alice = alice_twitter.opt_in('alice')[0].participant
+        bob = bob_twitter.opt_in('bob')[0].participant
+        alice.set_tip_to('bob', '1.00')
+        alice.set_tip_to('bob', '0.00')
+        bob.take_over(alice_twitter, have_confirmation=True)
         self.db.self_check()
 
     def test_do_not_take_over_zero_tips_giving(self):
-        alice = self.make_elsewhere('twitter', 1, 'alice')
+        alice_twitter = self.make_elsewhere('twitter', 1, 'alice')
         self.make_elsewhere('twitter', 2, 'bob').opt_in('bob')
-        carl  = self.make_elsewhere('twitter', 3, 'carl')
-        alice_participant = alice.opt_in('alice')[0].participant
-        carl_participant = carl.opt_in('carl')[0].participant
-        carl_participant.set_tip_to('bob', '1.00')
-        carl_participant.set_tip_to('bob', '0.00')
-        alice_participant.take_over(carl, have_confirmation=True)
+        carl_twitter  = self.make_elsewhere('twitter', 3, 'carl')
+        alice = alice_twitter.opt_in('alice')[0].participant
+        carl = carl_twitter.opt_in('carl')[0].participant
+        carl.set_tip_to('bob', '1.00')
+        carl.set_tip_to('bob', '0.00')
+        alice.take_over(carl_twitter, have_confirmation=True)
         ntips = self.db.one("select count(*) from tips")
         assert 2 == ntips
         self.db.self_check()
 
     def test_do_not_take_over_zero_tips_receiving(self):
-        alice = self.make_elsewhere('twitter', 1, 'alice')
-        bob   = self.make_elsewhere('twitter', 2, 'bob')
-        carl  = self.make_elsewhere('twitter', 3, 'carl')
-        alice_participant = alice.opt_in('alice')[0].participant
-        bob_participant   = bob.opt_in('bob')[0].participant
-        carl.opt_in('carl')
-        bob_participant.set_tip_to('carl', '1.00')
-        bob_participant.set_tip_to('carl', '0.00')
-        alice_participant.take_over(carl, have_confirmation=True)
+        alice_twitter = self.make_elsewhere('twitter', 1, 'alice')
+        bob_twitter   = self.make_elsewhere('twitter', 2, 'bob')
+        carl_twitter  = self.make_elsewhere('twitter', 3, 'carl')
+        alice = alice_twitter.opt_in('alice')[0].participant
+        bob = bob_twitter.opt_in('bob')[0].participant
+        carl_twitter.opt_in('carl')
+        bob.set_tip_to('carl', '1.00')
+        bob.set_tip_to('carl', '0.00')
+        alice.take_over(carl_twitter, have_confirmation=True)
         ntips = self.db.one("select count(*) from tips")
         assert 2 == ntips
         self.db.self_check()
 
     def test_idempotent(self):
-        alice = self.make_elsewhere('twitter', 1, 'alice')
-        bob   = self.make_elsewhere('github', 2, 'bob')
-        alice_participant = alice.opt_in('alice')[0].participant
-        alice_participant.take_over(bob, have_confirmation=True)
-        alice_participant.take_over(bob, have_confirmation=True)
+        alice_twitter = self.make_elsewhere('twitter', 1, 'alice')
+        bob_github    = self.make_elsewhere('github', 2, 'bob')
+        alice = alice_twitter.opt_in('alice')[0].participant
+        alice.take_over(bob_github, have_confirmation=True)
+        alice.take_over(bob_github, have_confirmation=True)
         self.db.self_check()
 
 


### PR DESCRIPTION
Change from `alice_participant` and `alice` to `alice` and `alice_twitter`. Makes it easier to reason about participants vs. accounts elsewhere if we use this nomenclature.

Follow-on from #2465.
