### PR TITLE
Move final_gift to Participant method

### DIFF
--- a/bin/final-gift.py
+++ b/bin/final-gift.py
@@ -9,11 +9,9 @@ Usage:
 from __future__ import print_function
 
 import sys
-from decimal import ROUND_DOWN, Decimal as D
 
 from gittip import wireup
 from gittip.models.participant import Participant
-from gittip.exceptions import NegativeBalance
 
 db = wireup.db(wireup.env())
 
@@ -40,46 +38,4 @@ else:
     assert fields.api_key[0:8] == first_eight
 
 print("Distributing {} from {}.".format(tipper.balance, tipper.username))
-if tipper.balance == 0:
-    raise SystemExit
-
-claimed_tips, claimed_total, unclaimed_tips, unclaimed_total = tipper.get_giving_for_profile()
-transfers = []
-distributed = D('0.00')
-
-for tip in claimed_tips:
-    if tip.amount == 0:
-        continue
-    rate = tip.amount / claimed_total
-    pro_rated = (tipper.balance * rate).quantize(D('0.01'), ROUND_DOWN)
-    distributed += pro_rated
-    print( tipper.username.ljust(12)
-         , tip.tippee.ljust(18)
-         , str(tip.amount).rjust(6)
-         , str(rate).ljust(32)
-         , pro_rated
-          )
-    transfers.append([tip.tippee, pro_rated])
-
-diff = tipper.balance - distributed
-if diff != 0:
-    print("Adjusting for rounding error of {}. Giving it to {}.".format(diff, transfers[0][0]))
-    transfers[0][1] += diff  # Give it to the highest receiver.
-
-with db.get_cursor() as cursor:
-    for tippee, amount in transfers:
-        assert amount > 0
-        balance = cursor.one("""
-            UPDATE participants
-               SET balance = balance - %s
-             WHERE username = %s
-         RETURNING balance
-        """, (amount, tipper.username))
-        if balance < 0:
-            raise NegativeBalance
-        cursor.run( "UPDATE participants SET balance=balance + %s WHERE username=%s"
-                  , (amount, tippee)
-                   )
-        cursor.run( "INSERT INTO transfers (tipper, tippee, amount) VALUES (%s, %s, %s)"
-                  , (tipper.username, tippee, amount)
-                   )
+tipper.distribute_balance_as_final_gift()


### PR DESCRIPTION
This is another of the scripts that are part of the current account cancelation procedure, now moved to a (tested) method on the Participant object. The script is still in place but now delegates to the method.

Follow-on from #2469.
