### PR TITLE
Credit card expiration banner needs a link to setting

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -119,7 +119,7 @@
     {% if not user.ANON and user.participant.credit_card_expiring(request, response) %}
     <script>
         $(document).ready(function () {
-            Gittip.notification("Your credit card is about to expire!", "error")
+            Gittip.notification(["span", "Your credit card is about to expire! ", ['a', {'href': '/credit-card.html'}, 'Update card']], "error")
         });
     </script>
     {% endif %}


### PR DESCRIPTION
This banner came up for me today, which was awesome, but then I had to hunt around the site (with the banner showing up on every page, including the actual credit card update page) to figure out where to update it. It should include a link to the CC update page.
