### PR TITLE
Fix Balanced JS error messages

### DIFF
--- a/js/gittip/payments.js
+++ b/js/gittip/payments.js
@@ -48,10 +48,8 @@ Gittip.payments.onError = function(response) {
     $('button#save').text('Save');
     var msg = response.status_code + ": " +
         $.map(response.errors, function(obj) { return obj.description }).join(', ');
-
-    $.post('/credit-card.json', {action: 'store-error', msg: msg});
-
     Gittip.forms.showFeedback(null, [msg]);
+    return msg;
 };
 
 Gittip.payments.onSuccess = function(data) {
@@ -168,7 +166,8 @@ Gittip.payments.ba.submit = function (e) {
 
 Gittip.payments.ba.handleResponse = function (response) {
     if (response.status_code !== 201) {
-        Gittip.payments.onError(response);
+        var msg = Gittip.payments.onError(response);
+        $.post('/bank-account.json', {action: 'store-error', msg: msg});
         return;
     }
 
@@ -296,7 +295,8 @@ Gittip.payments.cc.submit = function(e) {
 
 Gittip.payments.cc.handleResponse = function(response) {
     if (response.status_code !== 201) {
-        Gittip.payments.onError(response);
+        var msg = Gittip.payments.onError(response);
+        $.post('/credit-card.json', {action: 'store-error', msg: msg});
         return;
     }
 


### PR DESCRIPTION
While testing #2482 I noticed that the default CC form was raising an exception when I didn't manually provide the country. That's a problem, since it means that anyone who's tried adding a CC (and presumably a bank account) since #2448 (?) has had the form silently fail since they likely didn't choose their country.

It turns out that Balanced API version 1.1 has changed the structure of the error messages. Where before we expected `response.error.description`, now we're told to expect responses like this: ([docs](https://docs.balancedpayments.com/1.1/guides/balanced-js/))

![screen shot 2014-06-09 at 9 30 00 pm](https://cloud.githubusercontent.com/assets/688886/3225065/39bbcc76-f047-11e3-93da-ad57a6609c2f.png)

To clarify, the JS error where the code actually failed was: `TypeError: response.status is undefined`

I'm not happy with this solution though, because it gives a rather obtuse error message:

![screen shot 2014-06-09 at 9 17 21 pm](https://cloud.githubusercontent.com/assets/688886/3225080/7c53a45a-f047-11e3-9eb4-cda770ab3dda.png)

While we can of course default the country to the United States, is there a plan to provide more concise error messages @mjallday / @msherry?
