### PR TITLE
Fix account closing flow

### DIFF
--- a/www/%username/account/close.spt
+++ b/www/%username/account/close.spt
@@ -17,8 +17,11 @@ if POST:
         pass    # User will get the "Try Again Later" message.
     else:
         disbursement_strategy = request.body.get('disbursement_strategy')
-        participant.close(disbursement_strategy)
-        request.redirect('/%s/' % participant.username)
+        if participant.balance and disbursement_strategy is None:
+            pass    # User will get the "Please choose a disbursement method" message.
+        else:
+            participant.close(disbursement_strategy)
+            request.redirect('/%s/' % participant.username)
 [---] text/html
 {% extends "templates/base.html" %}
 
@@ -150,4 +153,17 @@ if POST:
         </form>
         {% endif %}
     </div>
+{% endblock %}
+
+{% block scripts %}
+{% if not payday_is_running and POST %}
+    <script>
+        $(function () {
+            Gittip.notification(
+                'You still have money in this Gittip account, please ' +
+                'choose a disbursement method below or contact support.'
+            , 'error')
+        });
+    </script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
This is a fix for https://app.getsentry.com/gittip/gittip/group/23491408/

Users who have money in their Gittip balance are supposed to choose a disbursement option when closing their account. Unfortunately some people just scroll down to click on the button, and in that case we're currently raising a `BalanceIsNotZero` exception that results in a 500 response which ends up logged in Sentry. This PR implements showing an error message to the user instead.
