### PR TITLE
#2545 - don't wrap content in .you-are

### DIFF
--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -34,6 +34,8 @@
     }
     .you-are {
         padding-top: 4px;
+        white-space: nowrap;
+
         .quick-stats {
             font: normal 11px/13px $Ideal;
             a {


### PR DESCRIPTION
Fixes #2545 by setting a `white-space: nowrap` declaration on the offending element.

![image](https://cloud.githubusercontent.com/assets/65468/3486480/604eaf30-043c-11e4-9a45-3bc4aabcf151.png)

Tested in Chrome, Firefox and Opera in OS X at various screen sizes.
