### PR TITLE
Add Bantik's contributor code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+# Contributor Code of Conduct
+## Version 0.4
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+If any participant in this project has issues or takes exception with a contribution, they are obligated to provide constructive feedback and never resort to personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+We promise to extend courtesy and respect to everyone involved in this project regardless of gender, gender identity, sexual orientation, ability or disability, ethnicity, religion, or level of experience.


### PR DESCRIPTION
@Bantik's contributor convenant: https://github.com/Bantik/contributor_covenant

Heard about it while reading the #atunit meeting minutes:
https://www.atunit.org/wiki/MeetingMinutes

It doesn't seem to be opinionated enough that it could be controversial. Adding it seems simple enough, and the real proof of it's effectiveness will be proved by our referencing back to it :)

(Worth noting that this applies to contributors, not users, so https://github.com/gittip/www.gittip.com/issues/1425 still stands.)
