### PR TITLE
Fix JSONP resources

### DIFF
--- a/www/%username/charts.json.spt
+++ b/www/%username/charts.json.spt
@@ -115,7 +115,7 @@ if callback is not None:
     if callback_pattern.match(callback) is None:
         raise Response(400, "bad callback")
     else:
-        response.body = "%s(%s)" % (callback, json.dumps(response.body))
+        response.body = "%s(%s)" % (callback, json.dumps(out))
         response.headers['Content-Type'] = 'application/javascript'
         raise response
 

--- a/www/on/%platform/%user_name/%endpoint.json.spt
+++ b/www/on/%platform/%user_name/%endpoint.json.spt
@@ -76,7 +76,7 @@ if callback is not None:
     if callback_pattern.match(callback) is None:
         raise Response(400, "bad callback")
     else:
-        response.body = "%s(%s)" % (callback, json.dumps(response.body))
+        response.body = "%s(%s)" % (callback, json.dumps(out))
         response.headers['Content-Type'] = 'application/javascript'
         raise response
 


### PR DESCRIPTION
Completes #2562. Closes #2560.

This PR doesn't add tests for each endpoint, because that would be bloating the test suite. The proper fix is to refactor the code so that CORS and JSONP work for all JSON endpoints.
