### PR TITLE
Quick fix for sign out overemphasis?

### DIFF
--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -89,8 +89,8 @@ from aspen.utils import utcnow
         <h1>Welcome{{ " back" if user.participant.claimed_time < quick else "" }}, {{ user.participant.username }}</a>!</h1>
         <p>Your balance is ${{ user.participant.balance }}.</p>
 
-        <p>Go to <a href="/{{ user.participant.username }}/">your profile</a> (or
-        <a href="/sign-out.html">sign out</a>).</p>
+        <p>Go to <a href="/{{ user.participant.username }}/">your profile</a>, or
+        <a href="/sign-out.html">sign out</a>.</p>
 
         <div class="jump">
         <form id="jump">


### PR DESCRIPTION
@ericmeltzer points out that "sign out" is the strongest link for signed-in users now. Here's a tiny change that might help a little?

![screen shot 2014-07-21 at 5 13 43 pm](https://cloud.githubusercontent.com/assets/134455/3650377/ed5cf7c4-111b-11e4-97ea-e6425ee4f4eb.png)

Current:

![screen shot 2014-07-21 at 5 13 07 pm](https://cloud.githubusercontent.com/assets/134455/3650362/da507264-111b-11e4-8467-694beb783fbc.png)
