### PR TITLE
Use proper URL for fonts

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
     <link rel="apple-touch-icon-precomposed" href="{{ website.asset_url }}/touch/icon-76x76.png" sizes="76x76">
     <link rel="apple-touch-icon-precomposed" href="{{ website.asset_url }}/touch/icon-120x120.png" sizes="120x120">
     <link rel="apple-touch-icon-precomposed" href="{{ website.asset_url }}/touch/icon-152x152.png" sizes="152x152">
-    <link rel="stylesheet" type="text/css" href="https://downloads-gittipllc.netdna-ssl.com/fonts/186388/577BA6429696B27AD.css">
+    <link rel="stylesheet" type="text/css" href="//cloud.typography.com/6540672/682244/css/fonts.css" />
     {% block head %}{% endblock %}
 </head>
 <body>


### PR DESCRIPTION
We should be using the project link that H&Co. gives us rather than dereferencing to our CDN. I believe that this way whenever we update the project we won't need to also update this link anymore.
