### PR TITLE
Fix logo on homepage in IE

### DIFF
--- a/www/assets/%version/logo.white.svg
+++ b/www/assets/%version/logo.white.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<svg width="502" height="160" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 502 160" xmlns="http://www.w3.org/2000/svg">
  <metadata id="metadata8">image/svg+xml</metadata>
  <defs>
   <clipPath id="clipPath16">
@@ -7,11 +7,6 @@
   </clipPath>
  </defs>
  <g>
-  <title>background</title>
-  <rect fill="none" id="canvas_background" height="162" width="504" y="-1" x="-1"/>
- </g>
- <g>
-  <title>Layer 1</title>
   <g id="g10" transform="matrix(5.1303170628778725,0,0,-5.1303170628778725,-15.926124824344924,189.39569960596938) ">
    <g id="g12">
     <g id="g14" clip-path="url(#clipPath16)">


### PR DESCRIPTION
Use viewBox instead of height/width in SVG:

http://stackoverflow.com/questions/9777143/svg-in-img-element-proportions-not-respected-in-ie9

Trims some extra fat while pruning additional height/width attrs.
