### PR TITLE
Don't require activating virtualenv for payday

### DIFF
--- a/payday.sh
+++ b/payday.sh
@@ -80,7 +80,7 @@ else
     RUN="Run"
 fi
 
-PATH="./env/bin:$PATH"
+export PATH="./env/bin:$PATH"
 require honcho
 confirm "$RUN payday #$1?" || exit 0
 case "$2" in


### PR DESCRIPTION
Came up during payday 115 (#2634).
