### PR TITLE
Add an empty page to simplates who only have 2 pages

### DIFF
--- a/www/about/charts.html.spt
+++ b/www/about/charts.html.spt
@@ -1,5 +1,6 @@
 title = "Charts"
 [---]
+[---]
 {% extends "templates/about.html" %}
 
 {% block scripts %}

--- a/www/about/dnt.html.spt
+++ b/www/about/dnt.html.spt
@@ -1,5 +1,6 @@
 title = "Do Not Track"
 [---]
+[---]
 {% extends "templates/about.html" %}
 {% block page %}
 

--- a/www/about/faq.html.spt
+++ b/www/about/faq.html.spt
@@ -1,6 +1,7 @@
 # encoding: utf8
 title = "Frequently Asked Questions"
 [---]
+[---]
 {% extends "templates/about.html" %}
 {% block page %}
 <div class="col1">

--- a/www/about/fraud/index.html.spt
+++ b/www/about/fraud/index.html.spt
@@ -1,5 +1,6 @@
 title = "Fraud"
 [---]
+[---]
 {% extends "templates/about.html" %}
 {% block page %}
 

--- a/www/about/index.html.spt
+++ b/www/about/index.html.spt
@@ -1,5 +1,6 @@
 title = "About"
 [---]
+[---]
 {% extends "templates/about.html" %}
 {% block page %}
 <div class="col">

--- a/www/about/privacy/index.html.spt
+++ b/www/about/privacy/index.html.spt
@@ -1,5 +1,6 @@
 title = "Privacy Policy"
 [---]
+[---]
 {% extends "templates/about.html" %}
 {% block page %}
 <div class="col0">

--- a/www/about/teams/index.html.spt
+++ b/www/about/teams/index.html.spt
@@ -1,6 +1,7 @@
 # encoding: utf8
 title = "About teams"
 [---]
+[---]
 {% extends "templates/about.html" %}
 {% block page %}
 <div class="col0">

--- a/www/about/terms/index.html.spt
+++ b/www/about/terms/index.html.spt
@@ -1,5 +1,6 @@
 title = "Terms and Conditions"
 [---]
+[---]
 {% extends "templates/about.html" %}
 
 {% block page %}

--- a/www/about/terms/of-service.html.spt
+++ b/www/about/terms/of-service.html.spt
@@ -1,5 +1,6 @@
 title = "Terms of Service"
 [---]
+[---]
 {% extends "templates/about.html" %}
 
 {% block page %}


### PR DESCRIPTION
My editor's syntax highlighting doesn't handle 2-page simplates correctly.

(In case you're wondering I used `grep -cE '^\[-{3,}\]' **/*.spt | grep :1` to find the simplates.)
