### PR TITLE
Change Balanced API key

### DIFF
--- a/defaults.env
+++ b/defaults.env
@@ -10,7 +10,7 @@ GITTIP_ASSET_URL=/assets/-
 GITTIP_CACHE_STATIC=no
 GITTIP_COMPRESS_ASSETS=no
 
-BALANCED_API_SECRET=ak-test-WnxyA067ZXwBlanqmgNfotmAOyJlFnke
+BALANCED_API_SECRET=ak-test-2zFgxfVijBzn4xC9dLRtLkxoB38iNKNKR
 
 DEBUG=1 # Used by oauthlib to bypass security checks. We need it because when
         # running locally the OAuth callbacks are http:, not https:. Of course


### PR DESCRIPTION
I'm cleaning up our test Balanced marketplaces and API keys. I'm not seeing where I can actually access the API key that we're currently using in development, so I'm replacing it with one that I do have access to from the vendors@gittip.com account.
