### PR TITLE
Add a (formerly Gittip) reference to about page

### DIFF
--- a/www/about/index.html.spt
+++ b/www/about/index.html.spt
@@ -6,7 +6,7 @@ title = "About"
 <div class="col">
     <h2>What Is Gratipay?</h2>
 
-    <p>Gratipay is a way to give <b>small weekly cash gifts</b> to people you
+    <p>Gratipay (formerly Gittip) is a way to give <b>small weekly cash gifts</b> to people you
     love and are inspired by.</p>
 
     <p>Gifts are <b>weekly</b>. The intention is for people to depend on money


### PR DESCRIPTION
Currently there is a lot of 3rd party places that still reference gittip, and generally it will take a while for the name change to become common knowledge. A lot of articles, press, and links that have already been written, will maintain the old Gittip name.

As such, it is important that Gratipay makes reference that it was once Gittip to maintain the trust. As say someone reads an article on gittip, or goes to donate via a gittip link, now they are taken to Gratipay, wait what, is this a scam? Who the hell is Gratipay, I wanted Gittip.

Hopefully this minor change is a first step to solving that confusion, but more steps are probably needed.
