### PR TITLE
Update Google+ link for rename to Gratipay

### DIFF
--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -19,7 +19,7 @@ from aspen.utils import utcnow
 [---]
 {% extends "templates/base.html" %}
 {% block head %}
-    <link rel="publisher" href="https://plus.google.com/110591317655791133884">
+    <link rel="publisher" href="https://plus.google.com/104524895706770139568">
     <meta name="description" content="Weekly payments, motivated by gratitude. Sustainably crowdfund your business, personal projects, or charity, with no extra fees." />
     <meta name="fb:app_id" content="229465400522758" />
     <meta name="og:type" content="website" />


### PR DESCRIPTION
Unfortunately Google+ doesn't allow for changing a slug once set. We have so few followers I think we should just start a new page.

https://github.com/gratipay/inside.gratipay.com/issues/73
