### PR TITLE
"Updating..." indicator when take is updated. fixes #1416

### DIFF
--- a/js/gratipay/team.js
+++ b/js/gratipay/team.js
@@ -186,6 +186,8 @@ Gratipay.team = (function() {
                 }
                 callback = function() { Gratipay.notification('Removed!'); };
             }
+            var $updating = $('<span class="updating">Updating...</span>');
+            $('#take').parent().html($updating)
             setTake(username, take, callback);
         }
         return false;


### PR DESCRIPTION
From #1416 - 

> On a team page (ie. https://www.gittip.com/Gittip/members/) while a take is being updated there is no feedback. From where I am it takes at least 3s to get the pop up window saying your take has been updated. Actually I managed to get 5 pop ups in a row before I stopped pressing enter :grinning:

Screenshots

![screenshot from 2014-09-06 13 49 16](https://cloud.githubusercontent.com/assets/3893573/4174697/16671bfe-35a2-11e4-97f3-609462f9acbb.png)
![screenshot from 2014-09-06 13 49 21](https://cloud.githubusercontent.com/assets/3893573/4174698/169ef290-35a2-11e4-9606-d2eb9aae5db2.png)
![screenshot from 2014-09-06 13 49 26](https://cloud.githubusercontent.com/assets/3893573/4174699/16d49846-35a2-11e4-9d68-22e0ab1e6306.png)
