### PR TITLE
added break-word wrapping. fixes #2728

### DIFF
--- a/scss/modules.scss
+++ b/scss/modules.scss
@@ -261,6 +261,7 @@ ul.memberships {
         margin: 0;
         width: 33%;
         float: left;
+        word-wrap: break-word;
 
         div.fine {
             display: block;


### PR DESCRIPTION
Issue: #2728 

There are two ways to make this better - 

1) https://github.com/gratipay/gratipay.com/issues/2728#issue-41956593

2) Let the wrapping break long words

This is an implementation of the second. (I think that the second option breaks less of the layout.)

![screenshot from 2014-09-06 22 36 56](https://cloud.githubusercontent.com/assets/3893573/4175848/c3d47c3c-35e8-11e4-8bd7-e955fbc8b22b.png)
