### PR TITLE
Fix grammar on home page by changing , to ;

### DIFF
--- a/i18n/eo.po
+++ b/i18n/eo.po
@@ -616,7 +616,7 @@ msgstr "Sekva paŝojn:"
 
 #: www/index.html.spt:97
 msgid ""
-"Start tipping people, you can find great people to tip by browsing {0}our "
+"Start tipping people; you can find great people to tip by browsing {0}our "
 "communities{1}."
 msgstr ""
 "Komencu doni trinkmonojn al homoj! Vi povas trovi homojn doni trinkmonoj laŭ "

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -621,7 +621,7 @@ msgstr "Étapes suivantes:"
 
 #: www/index.html.spt:97
 msgid ""
-"Start tipping people, you can find great people to tip by browsing {0}our"
+"Start tipping people; you can find great people to tip by browsing {0}our"
 " communities{1}."
 msgstr ""
 "Commencer à donner, vous pouvez {0}explorer nos communautés{1} pour "

--- a/i18n/ko.po
+++ b/i18n/ko.po
@@ -602,7 +602,7 @@ msgstr ""
 
 #: www/index.html.spt:97
 msgid ""
-"Start tipping people, you can find great people to tip by browsing {0}our"
+"Start tipping people; you can find great people to tip by browsing {0}our"
 " communities{1}."
 msgstr ""
 

--- a/i18n/zh.po
+++ b/i18n/zh.po
@@ -587,7 +587,7 @@ msgstr ""
 
 #: www/index.html.spt:97
 msgid ""
-"Start tipping people, you can find great people to tip by browsing {0}our"
+"Start tipping people; you can find great people to tip by browsing {0}our"
 " communities{1}."
 msgstr ""
 

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -103,7 +103,7 @@ from gratipay.security.user import SESSION_TIMEOUT
         {% if user.participant.giving == user.participant.receiving == 0 %}
             <p>{{ _("Next steps:") }}</p>
             <ol>
-                <li>{{ _("Start tipping people, you can find great people to tip by browsing {0}our communities{1}.",
+                <li>{{ _("Start tipping people; you can find great people to tip by browsing {0}our communities{1}.",
                          "<a href='/for/'>", "</a>") }}</li>
                 <li>{{ _("{0}Add a credit card{1} to make sure your weekly tips go through this Thursday.",
                         "<a href='/credit-card.html'>", "</a>") }}</li>


### PR DESCRIPTION
Affects this section of the [home page](https://gratipay.com/):

![section of home page with grammar error](https://cloud.githubusercontent.com/assets/79168/4230969/f9a475b0-398a-11e4-913f-0ff97180dc87.png)

I double-checked correctness of the change against the grammar rules in “Purdue Online Writing Lab”’s [Commas vs. Semicolons in Compound Sentences](https://owl.english.purdue.edu/owl/resource/607/04/).

_keywords:_ comma to semicolon
