### PR TITLE
Added yellow fade effect to FAQ items

### DIFF
--- a/scss/elements.scss
+++ b/scss/elements.scss
@@ -37,7 +37,19 @@ p, dd {
 }
 dt {
     font-weight: bold;
-    margin: 1em 0 0.25em;
+    padding:1em 0 0.25em;
+}
+dt:target, dt:target + dd {
+    -webkit-animation: target-fade 3s 1;
+    -moz-animation: target-fade 3s 1;
+}
+@-webkit-keyframes target-fade {
+    0% { background-color: rgba(yellow,.3); }
+    100% { background-color: rgba(yellow,0); }
+}
+@-moz-keyframes target-fade {
+    0% { background-color: rgba(yellow,.3); }
+    100% { background-color: rgba(yellow,0); }
 }
 pre {
     font: 9pt/13pt monospace;


### PR DESCRIPTION
We link to FAQ items from a couple of pages on Gratipay. Because of the two column layout, it's hard for a user to know what exactly we've linked to. This PR adds a transparent yellow background to the item. It fades out within 3s of page load. 

[Yellow fade effect](https://signalvnoise.com/archives/000558.php)

Screenshot: 
![highlight](https://cloud.githubusercontent.com/assets/3893573/4347740/909dab38-4167-11e4-90e9-51bc359fcfe6.png)
