### PR TITLE
Fixed loading prod envvars in tasks.

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -91,6 +91,6 @@ def load_prod_envvars():
 
     for envvar in envvars:
         if envvar:
-            key, val = envvar.split("=")
+            key, val = envvar.split("=", 1)
             os.environ[key] = val
             print("Loaded " + key + ".")


### PR DESCRIPTION
This handles cases where environment variables have '=' sign(s) in them.

example : `GUNICORN_OPTS=--workers=1`
