### PR TITLE
Adds FAQ about why payments can decrease

### DIFF
--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -91,6 +91,35 @@ title = "Frequently Asked Questions"
 
         </dd>
 
+        <dt id="why-did-my-receipts-decrease">Why did my donations decrease?</dt>
+
+        <dd>We know that it can be disappointing for your donations received
+          weekly to decrease, for any reason at all. Gratipay itself will never
+          halt donations to you without first contacting you about our <a
+          href="https://gratipay.com/about/terms/">terms of use</a>, unless
+          required to do so by law. If your donations decreased, one of the
+          following happened, ordered by decreasing likelihood:
+
+          <ol>
+            <li>A donor to you manually decreased or entirely removed their
+              donation to you, or their Gratipay account was closed. As Gratipay
+              gifts are anonymous, we cannot tell you who.</li>
+
+            <li>A donor to you had insufficient funds in their Gratipay balance
+              to satisfy their pledges, and their credit card, if configured,
+              was unable to be charged. It will be reattempted the following
+              week.</li>
+
+            <li>You have violated our <a
+             href="https://gratipay.com/about/terms/">terms of use</a>. We will
+             have contacted you before terminating your account.</li>
+
+            <li>We received a legal document ordering Gratipay to cease 
+             donations to you. We will contact you unless prohibited by court
+             order.</li>
+
+          </ol>
+        </dd>
     </dl>
 </div>
 <div class="col2">


### PR DESCRIPTION
This plainly establishes the mechanisms by which donations can decrease.

The aim is to eliminate accusations that anyone involved in the Gratipay
machine can wantonly interfere with someone else's donations unchecked
without prior notice, where unprohibited by law.
