### PR TITLE
fix cwd conflict between masspay and payday

### DIFF
--- a/bin/masspay.py
+++ b/bin/masspay.py
@@ -28,6 +28,7 @@ import sys
 from decimal import Decimal as D, ROUND_HALF_UP
 
 import requests
+from gratipay import wireup
 from httplib import IncompleteRead
 
 
@@ -119,7 +120,6 @@ class Payee(object):
 
 
 def compute_input_csv():
-    from gratipay import wireup
     db = wireup.db(wireup.env())
     participants = db.all("""
 


### PR DESCRIPTION
The payday module assumes a certain cwd on import: it tries to read a file at `./fake_payday.sql`. The masspay script was changing the current working directory before (implicitly) importing `gratipay.billing.payday`, causing the import to fail on trying to read the file. This commit works around the issue by moving the import in masspay before the chdir in masspay.
