### PR TITLE
Move search up over "Large Communities" for better usability and access

### DIFF
--- a/www/for/index.html.spt
+++ b/www/for/index.html.spt
@@ -72,6 +72,19 @@ title = _("Browse Communities")
 </style>
 <div class="col0">
 
+    <h2>{{ _("All Communities") }}</h2>
+    <form class="communities">
+        <select data-placeholder="{{ _("Find or add a community ...") }}" tabindex="1">
+            <option></option>
+            {% for community in communities %}
+            <option value="{{ community.slug }}">{{ community.name }} -
+            {% set n = community.nmembers %}
+            {{ ngettext("{0}{n}{1} Member", "{0}{n}{1} Members", n, "", "").lower() }}
+            </option>
+            {% endfor %}
+        </select>
+    </form>
+
     <h2>{{ _("Large Communities") }}</h2>
     <ul class="community memberships">
         {% for community in communities[:18] %}
@@ -85,17 +98,5 @@ title = _("Browse Communities")
         {% endfor %}
     </ul>
 
-    <h2>{{ _("All Communities") }}</h2>
-    <form class="communities">
-        <select data-placeholder="{{ _("Find or add a community ...") }}" tabindex="1">
-            <option></option>
-            {% for community in communities %}
-            <option value="{{ community.slug }}">{{ community.name }} -
-            {% set n = community.nmembers %}
-            {{ ngettext("{0}{n}{1} Member", "{0}{n}{1} Members", n, "", "").lower() }}
-            </option>
-            {% endfor %}
-        </select>
-    </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
I just did this, and would find it better if the search was placed higher up on the page (especially on my screen). I had to scroll to the bottom for the search to be usable.

![output](https://cloud.githubusercontent.com/assets/334273/4873595/c3032e2a-621b-11e4-84ff-d424c6cc95ca.gif)

This is how it looks after my change:

![screenie_1414881729_1173959](https://cloud.githubusercontent.com/assets/334273/4873553/75824548-6219-11e4-84d0-3dbe689da368.png)

I think this is better, let me know what you think.
- Kasper
