### PR TITLE
Do not parse emphasis inside of words.

### DIFF
--- a/gratipay/utils/markdown.py
+++ b/gratipay/utils/markdown.py
@@ -2,6 +2,6 @@ import misaka as m  # http://misaka.61924.nl/
 
 def render(markdown):
     return m.html( markdown
-                 , extensions=m.EXT_AUTOLINK | m.EXT_STRIKETHROUGH
+                 , extensions=m.EXT_AUTOLINK | m.EXT_STRIKETHROUGH | m.EXT_NO_INTRA_EMPHASIS
                  , render_flags=m.HTML_SKIP_HTML | m.HTML_TOC | m.HTML_SMARTYPANTS
                   )

--- a/tests/py/test_utils.py
+++ b/tests/py/test_utils.py
@@ -148,6 +148,11 @@ class Tests(Harness):
         actual = markdown.render('http://google.com/')
         assert expected == actual
 
+    def test_markdown_render_no_intra_emphasis(self):
+        expected = '<p>Examples like this_one and this other_one.</p>\n'
+        actual = markdown.render('Examples like this_one and this other_one.')
+        assert expected == actual
+
     @pytest.mark.xfail
     def test_srau_retries_work_with_db(self):
         # XXX This is raising InternalError because the transaction is ended or something.


### PR DESCRIPTION
This changeset adds the [EXT_NO_INTRA_EMPHASIS](http://misaka.61924.nl/api/) Markdown extension to avoid
parsing emphasis inside words as it leads frequently to undesired results.
