### PR TITLE
Document why we don't set httponly on csrf_token

### DIFF
--- a/gratipay/security/csrf.py
+++ b/gratipay/security/csrf.py
@@ -150,6 +150,8 @@ def add_csrf_token_to_response(response, request=None):
         return  # early parsing must've failed
     csrf_token = request.context.get('csrf_token')
     if csrf_token:
+        # Don't set httponly so that we can POST using XHR.
+        # https://github.com/gratipay/gratipay.com/issues/3030
         response.set_cookie('csrf_token', csrf_token, expires=CSRF_TIMEOUT, httponly=False)
 
         # Content varies with the CSRF cookie, so set the Vary header.

--- a/js/gratipay/forms.js
+++ b/js/gratipay/forms.js
@@ -73,6 +73,8 @@ Gratipay.forms.initCSRF = function() {   // https://docs.djangoproject.com/en/de
         }
 
         if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
+            // We have to avoid httponly on the csrf_token cookie because of this.
+            // https://github.com/gratipay/gratipay.com/issues/3030
             xhr.setRequestHeader("X-CSRF-TOKEN", Gratipay.getCookie('csrf_token'));
         }
     });


### PR DESCRIPTION
Closes #3030.
