### PR TITLE
Also redirect when account is closed

### DIFF
--- a/www/on/%platform/%user_name/index.html.spt
+++ b/www/on/%platform/%user_name/index.html.spt
@@ -11,12 +11,12 @@ from gratipay.models.account_elsewhere import *
 [-----------------------------------------------------------------------------]
 
 platform, account = get_account_elsewhere(website, request)
+participant = account.participant
 
-if account.participant.is_claimed:
-    request.redirect('/%s/' % account.participant.username)
+if participant.is_claimed or participant.is_closed:
+    request.redirect('/%s/' % participant.username)
 
 title = username = user_name = account.user_name
-participant = account.participant
 locked = participant.goal == -1
 is_team = account.is_team
 allow_pledges = not locked and (not is_team or platform.allows_team_connect)


### PR DESCRIPTION
Closed accounts cannot be pledged to, so we don't want to show the pledge page.