### PR TITLE
move Members over one

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -15,8 +15,8 @@
 {% set show_receiving = (user.participant == participant or not participant.anonymous_receiving) and participant.accepts_tips %}
 {% set show_profile = show_members or show_receiving %}
 {% set pages = [ ('/',           _('Profile'),      True,           show_profile)
-               , ('/receiving/', _('Receiving'),    True,           show_receiving)
                , ('/members/',   _('Members'),      show_members,   show_members)
+               , ('/receiving/', _('Receiving'),    True,           show_receiving)
                , ('/giving/',    _('Giving'),       True,           False)
                , ('/history/',   _('History'),      True,           False)
                , ('/widgets/',   _('Widgets'),      True,           False)


### PR DESCRIPTION
In general I like the reordering of profile subnav that @Changaco did in c0275a527fe26db698c7cb359752fb886be0a7f4 on #2938. However, I think Members shouldn't come between Receiving and Giving, because Receiving and Giving go together conceptually, and Members is actually less private than Receiving, since Receiving can be hidden but Members can't (once you're a team).