### PR TITLE
Move the Stop Giving button under the Edit state

### DIFF
--- a/templates/your-tip.html
+++ b/templates/your-tip.html
@@ -12,8 +12,7 @@
             <div class="view">
                 <span class="amount">{{ format_currency(tip, 'USD') }}</span>
                 <div class="per-week">{{ _("per week") }}</div>
-                <button class="edit {{ 'not-zero' if tip > 0 }}">{{ _("Edit") }}</button><br>
-                <button class="stop {{ 'zero' if not tip }}">{{ _("Stop giving") }}</button>
+                <button class="edit {{ 'not-zero' if tip > 0 }}">{{ _("Edit") }}</button>
             </div>
             <form class="edit" action="/{{ tippee }}/tip.json">
                 $
@@ -22,6 +21,7 @@
                 <div class="per-week">{{ _("per week") }}</div>
                 <button class="save">{{ _("Save") }}</button>
                 <button class="cancel">{{ _("Cancel") }}</button>
+                <button class="stop {{ 'zero' if not tip }}">{{ _("Stop Giving") }}</button>
             </form>
         </div>
 


### PR DESCRIPTION
Instead of loudly advertising to users that they should stop giving to someone they're actively giving to, let's not show the Stop Giving button until the user clicks Edit.

### From

![screen shot 2015-01-07 at 10 42 59 pm](https://cloud.githubusercontent.com/assets/134455/5657570/a141d304-96be-11e4-8f66-fa86dad4e2f6.png) ![screen shot 2015-01-07 at 10 43 16 pm](https://cloud.githubusercontent.com/assets/134455/5657572/a6470d24-96be-11e4-90ab-384ae663c334.png)

### To

![screen shot 2015-01-07 at 10 45 00 pm](https://cloud.githubusercontent.com/assets/134455/5657595/e000b7b8-96be-11e4-9172-8be5f8afa56b.png) ![screen shot 2015-01-07 at 10 45 34 pm](https://cloud.githubusercontent.com/assets/134455/5657600/f58512b4-96be-11e4-9646-8ae2c0302582.png)
