### PR TITLE
Clarifies that Gratipay doesn't take a cut of payments

### DIFF
--- a/www/about/index.spt
+++ b/www/about/index.spt
@@ -30,5 +30,13 @@ example = website.db.one("""
     and the <i>total</i> amount you receive is public (you can opt out of
     sharing this info).</p>
 
+    <p title="Gratipay does pass credit card processing fees to donors. See Features for more information.">
+    Gratipay does not take a cut of payments. Recipients receive the
+    <b>full face value</b> of payments. Rather than charge outright, Gratipay is
+    itself <a href="http://gratipay.com/gratipay">funded via its own Gratipay
+    account</a> through the generosity of the people and organizations that use 
+    and depend on the service. We suggest a 2%-10% donation in our 
+    [pricing guide](/about/pricing). </p>
+
 </div>
 {% endblock %}

--- a/www/about/index.spt
+++ b/www/about/index.spt
@@ -33,10 +33,10 @@ example = website.db.one("""
     <p title="Gratipay does pass credit card processing fees to donors. See Features for more information.">
     Gratipay does not take a cut of payments. Recipients receive the
     <b>full face value</b> of payments. Rather than charge outright, Gratipay is
-    itself <a href="http://gratipay.com/gratipay">funded via its own Gratipay
-    account</a> through the generosity of the people and organizations that use 
-    and depend on the service. We suggest a 2%-10% donation in our 
-    [pricing guide](/about/pricing). </p>
+    itself <a href="/Gratipay/">funded via its own Gratipay
+    account</a> through the generosity of the people and organizations that use
+    and depend on the service. We suggest a 2%-10% donation in our
+    <a href="/about/pricing">pricing guide</a>.</p>
 
 </div>
 {% endblock %}

--- a/www/about/index.spt
+++ b/www/about/index.spt
@@ -31,12 +31,10 @@ example = website.db.one("""
     sharing this info).</p>
 
     <p title="Gratipay does pass credit card processing fees to donors. See Features for more information.">
-    Gratipay does not take a cut of payments. Recipients receive the
-    <b>full face value</b> of payments. Rather than charge outright, Gratipay is
-    itself <a href="/Gratipay/">funded via its own Gratipay
-    account</a> through the generosity of the people and organizations that use
-    and depend on the service. We suggest a 2%-10% donation in our
-    <a href="/about/pricing">pricing guide</a>.</p>
+    Gratipay does not take a cut of payments, recipients get the <b>full face
+    value</b>. Instead of taking a cut, Gratipay is funded by the voluntary
+    payments of our users to <a href="/Gratipay/">our own Gratipay account</a>.
+    See our <a href="/about/pricing">pricing page</a> for more information.</p>
 
 </div>
 {% endblock %}


### PR DESCRIPTION
This is stated on the [FAQ - "How is Gratipay funded?"](https://gratipay.com/about/faq), but it's not very clear there, nor is it explicitly stated *anywhere* that Gratipay doesn't make money unless users pay it like any other account.

The FAQ probably could be updated, too, if the language I've proposed here is acceptable there, too.