### PR TITLE
automate the weekly tweet

### DIFF
--- a/bin/tweet.py
+++ b/bin/tweet.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# encoding: utf8
+from __future__ import absolute_import, division, unicode_literals, print_function
+from gratipay import wireup
+from gratipay.elsewhere.twitter import Twitter
+
+env = wireup.env()
+
+twitter = Twitter(
+    env.twitter_consumer_key,
+    env.twitter_consumer_secret,
+    env.twitter_callback,
+)
+
+status = "d whit537 Gratipay {npayday:,}—{nusers:,} users exchanged ${volume:,}: " \
+         "https://gratipay.com/about/stats."
+status = status.format(npayday=136, nusers=2924, volume=10582)
+
+print("Really tweet the following as @Gratipay?")
+print("=" * 78)
+print()
+print(status)
+print()
+print("=" * 78)
+
+proceed = raw_input("(y/n) ") == 'y'
+
+if not proceed:
+    raise SystemExit
+
+print("Okay! Here we go ...")
+sess = twitter.get_auth_session()
+response = sess.post('https://api.twitter.com/1.1/statuses/update.json', {"status": status})
+import pdb; pdb.set_trace()

--- a/bin/tweet.py
+++ b/bin/tweet.py
@@ -14,6 +14,13 @@ twitter = Twitter(
     env.twitter_consumer_secret,
     env.twitter_callback,
 )
+sess = twitter.get_auth_session()
+response = sess.get('https://api.twitter.com/1.1/account/settings.json')
+print(response.status_code)
+print(response.json())
+import pdb; pdb.set_trace()
+screen_name = response.json()['screen_name']
+
 
 paydays = requests.get('https://gratipay.com/about/charts.json').json()
 npayday = len(paydays)
@@ -25,7 +32,8 @@ status = "d whit537 Gratipay {npayday:,}—{nusers:,} users exchanged ${volume:,
          "https://gratipay.com/about/stats."
 status = status.format(npayday=npayday, nusers=nusers, volume=volume)
 
-print("Really tweet the following as @Gratipay?")
+
+print("Really tweet the following as @{}?".format(screen_name))
 print("=" * 78)
 print()
 print(status)
@@ -39,6 +47,5 @@ if not proceed:
     raise SystemExit
 
 print("Okay! Here we go ...")
-sess = twitter.get_auth_session()
 response = sess.post('https://api.twitter.com/1.1/statuses/update.json', {"status": status})
 import pdb; pdb.set_trace()

--- a/bin/tweet.py
+++ b/bin/tweet.py
@@ -4,6 +4,9 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 from gratipay import wireup
 from gratipay.elsewhere.twitter import Twitter
 
+import requests
+
+
 env = wireup.env()
 
 twitter = Twitter(
@@ -12,9 +15,15 @@ twitter = Twitter(
     env.twitter_callback,
 )
 
+paydays = requests.get('https://gratipay.com/about/charts.json').json()
+npayday = len(paydays)
+nusers = int(paydays[0]['active_users'])
+volume = int(round(float(paydays[0]['weekly_gifts'])))
+
+
 status = "d whit537 Gratipay {npayday:,}—{nusers:,} users exchanged ${volume:,}: " \
          "https://gratipay.com/about/stats."
-status = status.format(npayday=136, nusers=2924, volume=10582)
+status = status.format(npayday=npayday, nusers=nusers, volume=volume)
 
 print("Really tweet the following as @Gratipay?")
 print("=" * 78)
@@ -23,9 +32,10 @@ print(status)
 print()
 print("=" * 78)
 
-proceed = raw_input("(y/n) ") == 'y'
+proceed = raw_input("(y/N) ") == 'y'
 
 if not proceed:
+    print("Cancelled.")
     raise SystemExit
 
 print("Okay! Here we go ...")


### PR DESCRIPTION
Every week during [payday](http://inside.gratipay.com/howto/run-payday) we send out a tweet like this:

> Week 136—2,924 users exchanged $10,581: https://gratipay.com/about/stats.

https://twitter.com/Gratipay/status/553248050957664257

We want to automate that.