### PR TITLE
Add a line break to API on account page

### DIFF
--- a/www/%username/account/index.html.spt
+++ b/www/%username/account/index.html.spt
@@ -163,7 +163,7 @@ emails = participant.get_emails()
           <h2>{{ _("API Credentials") }}</h2>
           <div>{{ _("User ID:") }} <span>{{ participant.id }}</span></div>
           <div class="key">
-            {{ _("API Key:") }} <span>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</span>
+            {{ _("API Key:") }} <span>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</span><br>
             <button class="show">{{ _("Show Key") }}</button>
             <button class="hide" style="display: none">{{ _("Hide Key") }}</button>
             <button class="recreate">{{ _("Recreate") }}</button>


### PR DESCRIPTION
Fixes this:

![screen shot 2015-02-12 at 4 10 11 pm](https://cloud.githubusercontent.com/assets/134455/6177090/ad2e28f0-b2d1-11e4-87d6-859d668243fa.png)
