### PR TITLE
opt out of search should also opt out of browse

### DIFF
--- a/tests/py/test_privacy_json.py
+++ b/tests/py/test_privacy_json.py
@@ -2,6 +2,7 @@ from __future__ import print_function, unicode_literals
 
 from aspen import json
 from gratipay.testing import Harness
+from gratipay.models.participant import Participant
 
 
 class Tests(Harness):
@@ -43,3 +44,13 @@ class Tests(Harness):
     def test_participant_doesnt_show_up_on_search(self):
         self.hit_privacy('POST', data={'toggle': 'is_searchable'})
         assert 'alice' not in self.client.GET("/search?q=alice").body
+
+    def test_team_participant_does_show_up_on_explore_teams(self):
+        alice = Participant.from_username('alice')
+        self.make_participant('A-Team', number='plural').add_member(alice)
+        assert 'A-Team' in self.client.GET("/explore/teams/").body
+
+    def test_team_participant_doesnt_show_up_on_explore_teams(self):
+        alice = Participant.from_username('alice')
+        self.make_participant('A-Team', number='plural', is_searchable=False).add_member(alice)
+        assert 'A-Team' not in self.client.GET("/explore/teams/").body

--- a/www/explore/teams/index.spt
+++ b/www/explore/teams/index.spt
@@ -18,7 +18,8 @@ teams = website.db.all("""
             ) AS t
       JOIN participants p 
         ON p.username = t.name
-     WHERE p.goal >= 0 OR p.goal IS NULL
+     WHERE (p.goal >= 0 OR p.goal IS NULL)
+       AND p.is_searchable
   ORDER BY dollars_per_member DESC, nmembers ASC
 
 """)


### PR DESCRIPTION
Just after we implemented search (#3066), we implemented the ability to opt out of search (#3077). This PR extends the `is_searchable` boolean to also govern inclusion in the new teams listing (#3172). When we convert communities to tags (#3127), we should extend this to govern inclusion in tag browsing as well.