### PR TITLE
Fix handling of year in credit card form

### DIFF
--- a/js/gratipay/payments.js
+++ b/js/gratipay/payments.js
@@ -401,7 +401,8 @@ Gratipay.payments.cc.submit = function(e) {
                            };
 
     credit_card.expiration_month = val('expiration_month');
-    credit_card.expiration_year = '20' + val('expiration_year');
+    var year = val('expiration_year');
+    credit_card.expiration_year = year.length == 2 ? '20' + year : year;
 
     if (!balanced.card.isCardNumberValid(credit_card.number)) {
         $('button#save').css('opacity', 1);


### PR DESCRIPTION
Fixes #3203 by prefixing the year with `20` only if its length is 2.