### PR TITLE
Update gravatar size in URL

### DIFF
--- a/gratipay/models/account_elsewhere.py
+++ b/gratipay/models/account_elsewhere.py
@@ -81,7 +81,7 @@ class AccountElsewhere(Model):
             fragment = ''
             if netloc.endswith('githubusercontent.com') or \
                netloc.endswith('gravatar.com'):
-                query = 's=128'
+                query = 's=160'
             i.avatar_url = urlunsplit((scheme, netloc, path, query, fragment))
 
         # Serialize extra_info

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+    UPDATE elsewhere
+       SET avatar_url = regexp_replace(avatar_url, '\?s=128$', '?s=160')
+     WHERE avatar_url ~ '\?s=128$';
+
+    UPDATE participants
+       SET avatar_url = regexp_replace(avatar_url, '\?s=128$', '?s=160')
+     WHERE avatar_url ~ '\?s=128$';
+
+END;


### PR DESCRIPTION
Fixes #3196. We fetch the 160px-sized image instead of the old 128px one.