### PR TITLE
Fix long PayPal emails breaking surrounding layout

### DIFF
--- a/www/%username/account/index.html.spt
+++ b/www/%username/account/index.html.spt
@@ -126,11 +126,10 @@ emails = participant.get_emails()
                     <td class="account-type">
                         <img src="{{ website.asset('paypal.png') }}" />
                     </td>
-                    <td class="account-details">
+                    <td colspan="2" class="account-details">
                         <div class="account-type">Paypal</div>
                         <span>{{ participant.paypal_email }}</span>
                     </td>
-                    <td class="account-action"></td>
                 </tr>
                 {% endif %}
             </table>


### PR DESCRIPTION
Fixes #3130. I just remove the unused `.account-action` cell used in the PayPal section and adjust the `.account-detail` field accordingly. So now no weird table column snafus happen with long PayPal addresses.

![screen shot 2015-03-04 at 8 56 15 pm](https://cloud.githubusercontent.com/assets/65468/6497681/ed3f9732-c2b0-11e4-85f0-e712dd15b66a.png)
