### PR TITLE
Improve our docker experience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 # Dockerfile to build and run Gratipay
-# Version 0.1 (April 15, 2014)
+# Version 0.2 (March 10, 2015)
 
 ################################################## General Information ##################################################
 
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 MAINTAINER Mihir Singh (@citruspi)
 
 ENV DEBIAN_FRONTEND noninteractive
 
 ################################################## Install Dependencies #################################################
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get -y install wget
 
@@ -29,26 +29,26 @@ RUN apt-get -y install \
     python-pip \
     postgresql-9.3 \
     postgresql-contrib-9.3 \
-    unzip \
     language-pack-en
 
 ################################################## Configure Postgres #################################################
 
 RUN /etc/init.d/postgresql start && su postgres -c "createuser --superuser root" && su postgres -c "createdb gratipay"
 
-################################################# Clone + Setup Gratipay ################################################
+################################################# Copy files + Setup Gratipay ##########################################
 
-RUN cd /srv && wget --quiet https://github.com/gratipay/gratipay.com/archive/master.zip && unzip master.zip
-RUN cd /srv/gratipay.com-master && make env && /etc/init.d/postgresql start && make schema && make schema data
+COPY ./ /srv/gratipay.com/
+WORKDIR /srv/gratipay.com
+RUN make env && /etc/init.d/postgresql start && make schema && make schema data
 
 ################################################ Create a Launch Script ###############################################
 
-RUN echo "#!/bin/bash" >> /usr/bin/gratipay
-RUN echo "/etc/init.d/postgresql start" >> /usr/bin/gratipay
-RUN echo "cd /srv/gratipay.com-master && make run" >> /usr/bin/gratipay
-RUN chmod +x /usr/bin/gratipay
+RUN echo "#!/bin/bash" >> /usr/bin/gratipay && \
+    echo "/etc/init.d/postgresql start" >> /usr/bin/gratipay && \
+    echo "cd /srv/gratipay.com && make run" >> /usr/bin/gratipay && \
+    chmod +x /usr/bin/gratipay
 
-################################################### Set an Entrypoint #################################################
+################################################### Launch command #####################################################
 
-ENTRYPOINT ["/usr/bin/gratipay"]
+CMD ["/usr/bin/gratipay"]
 

--- a/README.md
+++ b/README.md
@@ -268,13 +268,7 @@ Docker
 
 You can also install/run Gratipay with Docker.
 
-Either pull the image from the Docker Index:
-
-```
-$ docker pull citruspi/gratipay
-```
-
-or build it with the included Dockerfile:
+Build it with the included Dockerfile:
 
 ```
 $ git clone git@github.com:gratipay/gratipay.com.git
@@ -282,45 +276,42 @@ $ cd gratipay.com
 $ docker build -t gratipay .
 ```
 
-Once you have the image, get the Image ID with
+Once you've built the image, you can launch a container:
+
 
 ```
-$ docker images
+$ docker run -d -p 8537:8537 gratipay
 ```
 
+Check it out at [localhost:8537](http://localhost:8537/)!
 
-You can then run it in the foreground:
 
-```
-$ docker run -p 8537:8537 [image_id]
-```
-
-or in the background:
+To edit files and have those changes reflect in the running container, mount your local folder when you execute the run command:
 
 ```
-$ docker run -d -p 8537:8537 [image_id]
+$ docker run -d -v $PWD:/srv/gratipay.com -p 8537:8537 gratipay
 ```
 
-Check it out at [localhost:8537](localhost:8537)!
+You can get the running container's ID with `docker ps`. With that, you can
 
-If you run it in the background, you can get the Container ID with
-
-```
-$ docker ps
-```
-
-With that, you can view the logs:
+- view the logs:
 
 ```
 $ docker logs [container_id]
 ```
 
-or kill the detached container with:
+- run commands within the project root:
+
+```
+$ docker exec [container_id] make schema
+$ docker exec [container_id] make data
+```
+
+Once you're done, kill the running container:
 
 ```
 $ docker kill [container_id]
 ```
-
 
 Help!
 -----
@@ -513,7 +504,7 @@ for your project!
 
 ### Renamed to Gratipay
 
- - [Ruby: gratitude](https://github.com/JohnKellyFerguson/gratitude): a simple 
+ - [Ruby: gratitude](https://github.com/JohnKellyFerguson/gratitude): a simple
    ruby wrapper for the Gratipay API
 
  - [php-curl-class](https://github.com/php-curl-class/php-curl-class/blob/master/examples/gratipay_send_tip.php): a php class to tip using the Gratipay API


### PR DESCRIPTION
- Our [docker image on Docker Hub](https://registry.hub.docker.com/u/citruspi/gittip/) is outdated. Unless we setup [automated builds](http://docs.docker.com/docker-hub/builds/) or find someone who is willing to update the image regularly, a pre-built image doesn't make sense. So, I've removed the documentation for pulling from Docker Hub.

- Our `Dockerfile` now copies the repository files from context, not by cloning our GitHub repository. Before this, we were asking the user to clone our GitHub repository first, and then clone it again during the build process.

- It's now possible to execute commands such as `make schema` and `make data` within the container, documentation has been added too. Also added documentation for mounting a local folder, that's the only way people can actually hack on Gratipay using Docker. 