### PR TITLE
Remove paths in requirements.txt with requirement specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ env: requirements.txt requirements_tests.txt setup.py
 				--extra-search-dir=./vendor/ \
 				--always-copy \
 				./env/
-	$(pip) install -r requirements.txt --no-index
-	$(pip) install -r requirements_tests.txt --no-index
+	$(pip) install --no-index -f ./vendor/ -r requirements.txt
+	$(pip) install --no-index -f ./vendor/ -r requirements_tests.txt
 	$(pip) install -e ./
 
 clean:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,50 +1,50 @@
 
-./vendor/mimeparse-0.1.3.tar.gz
-./vendor/first-2.0.1.tar.gz
-./vendor/dependency_injection-1.1.0.tar.gz
-./vendor/algorithm-1.0.0.tar.gz
-./vendor/filesystem_tree-1.0.0.tar.gz
-./vendor/aspen-0.37.tar.bz2
+mimeparse==0.1.3
+first==2.0.1
+dependency_injection==1.1.0
+algorithm==1.0.0
+filesystem_tree==1.0.0
+aspen==0.37
 
-./vendor/gunicorn-18.0.tar.gz
+gunicorn==18.0
 
-./vendor/MarkupSafe-0.23.tar.gz
-./vendor/Jinja2-2.7.3.tar.gz
-./vendor/aspen-jinja2-0.4.tar.gz
+MarkupSafe==0.23
+Jinja2==2.7.3
+aspen-jinja2==0.4
 
-./vendor/psycopg2-2.5.1.tar.gz
-./vendor/postgres-2.1.2.tar.gz
+psycopg2==2.5.1
+postgres==2.1.2
 
-./vendor/simplejson-2.3.2.tar.gz
+simplejson==2.3.2
 
-./vendor/certifi-0.0.8.tar.gz
-./vendor/pyasn1-0.1.3.tar.gz
-./vendor/chardet-1.0.1.tar.gz
-./vendor/oauthlib-0.7.2.tar.gz
-./vendor/requests-2.6.0.tar.gz
-./vendor/requests-oauthlib-0.4.2.tar.gz
-./vendor/xmltodict-0.8.4.tar.gz
+certifi==0.0.8
+pyasn1==0.1.3
+chardet==1.0.1
+oauthlib==0.7.2
+requests==2.6.0
+requests-oauthlib==0.4.2
+xmltodict==0.8.4
 
-./vendor/wac-0.23.tar.gz
-./vendor/iso8601-0.1.4.tar.gz
-./vendor/uritemplate-0.6.tar.gz
-./vendor/balanced-1.1.1.tar.gz
+wac==0.23
+iso8601==0.1.4
+uritemplate==0.6
+balanced==1.1.1
 
-./vendor/raven-3.1.4.tar.gz
-./vendor/fake-factory-0.3.2.tar.gz
+raven==3.1.4
+fake-factory==0.3.2
 
-./vendor/six-1.8.0.tar.gz
-./vendor/libsass-0.3.0.tar.gz
-./vendor/honcho-cfcc7ebb.tar.gz
+six==1.8.0
+libsass==0.3.0
+honcho==cfcc7ebb
 
-./vendor/environment-1.0.0.tar.gz
+environment==1.0.0
 
-./vendor/invoke-0.7.0.tar.gz
+invoke==0.7.0
 
-./vendor/docopt-0.4.0.tar.gz
-./vendor/mandrill-1.0.53.tar.gz
+docopt==0.4.0
+mandrill==1.0.53
 
-./vendor/pytz-2014.7.tar.bz2
-./vendor/Babel-1.3.tar.gz
+pytz==2014.7
+Babel==1.3
 
-./vendor/misaka-1.0.2.tar.gz
+misaka==1.0.2

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,17 +1,17 @@
 
-./vendor/py-1.4.26.tar.gz
-./vendor/pytest-2.6.4.tar.gz
+py==1.4.26
+pytest==2.6.4
 
-./vendor/coverage-3.7.1.tar.gz
-./vendor/cov-core-1.15.0.tar.gz
-./vendor/pytest-cov-1.8.1.tar.gz
+coverage==3.7.1
+cov-core==1.15.0
+pytest-cov==1.8.1
 
-./vendor/execnet-1.3.0-py2.py3-none-any.whl
-./vendor/pytest-cache-1.0.tar.gz
-./vendor/pyflakes-0.8.1.tar.gz
-./vendor/mock-1.0.1.tar.gz
+execnet==1.3.0
+pytest-cache==1.0
+pyflakes==0.8.1
+mock==1.0.1
 
-./vendor/PyYAML-3.11.tar.gz
-./vendor/contextlib2-0.4.0.tar.gz
-./vendor/wrapt-1.10.2.tar.gz
-./vendor/vcrpy-1.1.3.tar.gz
+PyYAML==3.11
+contextlib2==0.4.0
+wrapt==1.10.2
+vcrpy==1.1.3


### PR DESCRIPTION
This allows to store dependencies everythere else (#1459)
and may lead to better performance if we cache wheels,
because it looks like pip still unpacks every tar.gz regardless
of if mentioned version is already installed.