### PR TITLE
Fix an i18n bug

### DIFF
--- a/gratipay/utils/i18n.py
+++ b/gratipay/utils/i18n.py
@@ -107,6 +107,8 @@ def get_text(context, loc, s, *a, **kw):
     msg = loc.catalog.get(s)
     if msg:
         s = msg.string or s
+        if isinstance(s, tuple):
+            s = s[0]
     if a or kw:
         if isinstance(s, bytes):
             s = s.decode('ascii')


### PR DESCRIPTION
Currently `_("Member")` returns `('Membre', 'Membres')` (with the french locale), this PR works around that Babel defect by modifying our `get_text` function to return only the first string of the tuple.
