### PR TITLE
Clean up profile where bitcoin buttons are wrapping

### DIFF
--- a/scss/elements/buttons-knobs.scss
+++ b/scss/elements/buttons-knobs.scss
@@ -21,6 +21,7 @@ button,
     font: normal 13px $Ideal;
     margin: 0 0 0 1px;
     padding: 5px 8px;
+    white-space: nowrap;
     @include border-radius(3px);
     cursor: pointer;
     display: inline;
@@ -57,4 +58,8 @@ button.close-account {
         color: white;
         text-decoration: none;
     }
+}
+
+.buttons button {
+    margin-top: 3px;
 }

--- a/scss/pages/profile-edit.scss
+++ b/scss/pages/profile-edit.scss
@@ -33,5 +33,8 @@
                 display: inline-block;
             }
         }
+        .buttons {
+            margin-top: 3px;
+        }
     }
 }


### PR DESCRIPTION
The styling for the buttons in the add a bitcoin receiving option was a bit wonky.

Before:
![screen shot 2015-04-12 at 1 26 12 pm](https://cloud.githubusercontent.com/assets/1421810/7106669/8ae882bc-e117-11e4-9272-34e185e1e782.png)

After:
![screen shot 2015-04-12 at 1 32 54 pm](https://cloud.githubusercontent.com/assets/1421810/7106701/75697b98-e118-11e4-97c9-46f82331247f.png)