### PR TITLE
Change SSN field to password field

### DIFF
--- a/www/%username/identity.spt
+++ b/www/%username/identity.spt
@@ -137,7 +137,7 @@ else:
 
     <label class="half left">
         <span>{{ _("Last four SSN digits") }} {{ _("(Not required)") }}</span>
-        <input name="ssn_last4" value="{{ account.ssn_last4 or '' }}" />
+        <input name="ssn_last4" type="password" value="{{ account.ssn_last4 or '' }}" />
     </label>
 
     <div class="clear"></div>


### PR DESCRIPTION
It seems to make sense that this field wouldn't be shown on-screen while you're punching your info in.