### PR TITLE
Avoid blurry images and be retina ready

### DIFF
--- a/templates/avatar-url.html
+++ b/templates/avatar-url.html
@@ -1,6 +1,6 @@
 {% macro avatar_url(account) %}{{ account.avatar_url or website.asset('avatar-default.png') }}{% endmacro %}
 
 {% macro avatar_img(account) %}
-<img class="avatar" src="{{ avatar_url(account) }}"
+<img class="avatar" src="{{ avatar_url(account) }}?s=320"
      onerror="this.src = '{{ website.asset('avatar-default.png') }}'" />
 {% endmacro %}


### PR DESCRIPTION
Reference to issue #3381. It's described [here](https://de.gravatar.com/site/implement/images/) that you can resize gravatar images. Since 320px is the double of 160px, the gravatar should also be retina ready.  