### PR TITLE
Rename `make data` to `make fake`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ schema-diff: test-schema
 	diff -uw prod.sql local.sql
 	rm prod.sql local.sql
 
-data:
+fake:
 	$(honcho_run) $(env_bin)/fake_data fake_data
 
 run: env

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ If you haven't run Gratipay for a while, you can reinstall the dependencies:
 Add the necessary schemas and insert dummy data into postgres:
 
     $ make schema
-    $ make data
+    $ make fake
 
 
 Launching
@@ -310,7 +310,7 @@ $ docker logs [container_id]
 
 ```
 $ docker exec [container_id] make schema
-$ docker exec [container_id] make data
+$ docker exec [container_id] make fake
 ```
 
 Once you're done, kill the running container:
@@ -405,7 +405,7 @@ Which populates the database named by `DATABASE_URL` with the schema from `sql/s
 The gratipay database created in the last step is empty. To populate it with
 some fake data, so that more of the site is functional, run this command:
 
-    $ make data
+    $ make fake
 
 
 API


### PR DESCRIPTION
We introduced a `data` directory in #3329, which masks our phony target for populating the database with fake data. This cherry-picks d6372ed21e370bb83ea99ac45e90605e6074b405 from #3400.