### PR TITLE
here's a Team class

### DIFF
--- a/gratipay/models/team.py
+++ b/gratipay/models/team.py
@@ -1,0 +1,37 @@
+"""Teams on Gratipay are plural participants with members.
+"""
+from postgres.orm import Model
+
+
+class Team(Model):
+    """Represent a Gratipay team.
+    """
+
+    typname = 'teams'
+
+
+    # Constructors
+    # ============
+
+    @classmethod
+    def from_id(cls, id):
+        """Return an existing team based on id.
+        """
+        return cls._from_thing("id", id)
+
+    @classmethod
+    def from_slug(cls, slug):
+        """Return an existing team based on slug.
+        """
+        return cls._from_thing("slug_lower", slug.lower())
+
+    @classmethod
+    def _from_thing(cls, thing, value):
+        assert thing in ("id", "slug_lower")
+        return cls.db.one("""
+
+            SELECT teams.*::teams
+              FROM teams
+             WHERE {}=%s
+
+        """.format(thing), (value,))

--- a/gratipay/wireup.py
+++ b/gratipay/wireup.py
@@ -32,6 +32,7 @@ from gratipay.models.account_elsewhere import AccountElsewhere
 from gratipay.models.community import Community
 from gratipay.models.exchange_route import ExchangeRoute
 from gratipay.models.participant import Participant
+from gratipay.models.team import Team
 from gratipay.models import GratipayDB
 from gratipay.utils.emails import compile_email_spt
 from gratipay.utils.http_caching import asset_etag
@@ -50,7 +51,7 @@ def db(env):
     maxconn = env.database_maxconn
     db = GratipayDB(dburl, maxconn=maxconn)
 
-    for model in (AccountElsewhere, Community, ExchangeRoute, Participant):
+    for model in (AccountElsewhere, Community, ExchangeRoute, Participant, Team):
         db.register_model(model)
     gratipay.billing.payday.Payday.db = db
 

--- a/tests/py/test_teams.py
+++ b/tests/py/test_teams.py
@@ -3,9 +3,29 @@ from gratipay.models._mixin_team import StubParticipantAdded
 
 from gratipay.testing import Harness
 from gratipay.security.user import User
+from gratipay.models.team import Team
 
 
-class Tests(Harness):
+class TestNewTeams(Harness):
+
+    def test_harness_can_make_a_team(self):
+        team = self.make_team()
+        assert team.name == 'The A Team'
+        assert team.owner == 'hannibal'
+
+    def test_can_construct_from_slug(self):
+        self.make_team()
+        team = Team.from_slug('TheATeam')
+        assert team.name == 'The A Team'
+        assert team.owner == 'hannibal'
+
+    def test_can_construct_from_id(self):
+        team = Team.from_id(self.make_team().id)
+        assert team.name == 'The A Team'
+        assert team.owner == 'hannibal'
+
+
+class TestOldTeams(Harness):
 
     def setUp(self):
         Harness.setUp(self)


### PR DESCRIPTION
For #3399. cc: @rohitpaulk 

On #3400 I tried promoting `MixinTeam` to `Team` in one fell swoop. It occurs to me that it will be easier to develop if we let them live side by side for a time. This PR therefore adds a `Team` class without touching `MixinTeam`. We can move functionality over from the one to the other piecemeal in other PRs, and remove `MixinTeam` once it's finally empty.