### PR TITLE
Fix paypal bug for new teams

### DIFF
--- a/gratipay/models/participant.py
+++ b/gratipay/models/participant.py
@@ -779,7 +779,7 @@ class Participant(Model, MixinTeam):
     @property
     def has_payout_route(self):
         for network in ('balanced-ba', 'paypal'):
-            route = ExchangeRoute.from_network(self, 'balanced-ba')
+            route = ExchangeRoute.from_network(self, network)
             if route and not route.error:
                 return True
         return False


### PR DESCRIPTION
Fixes a bug reported in https://github.com/gratipay/gratipay.com/issues/3399#issuecomment-102053074. 

> I got error "400 Bad Request: You must attach a bank account or PayPal to apply for a new team." although ~NuvolaPlayer does have PayPal account attached.