### PR TITLE
add a global notice about site disruption

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -72,7 +72,7 @@
     href="https://github.com/gratipay/gratipay.com/milestones/Pivot"> known
 issues</a>.  Sorry for the trouble, and thanks for your patience as we work to
 stabilize Gratipay as quickly as possible. As always, feel free to get in touch
-privately via <a href="support@gratipay.com">email</a> or publicly via <a
+privately via <a href="mailto:support@gratipay.com">email</a> or publicly via <a
 href="https://github.com/gratipay/gratipay.com/issues/new">GitHub</a>.</div>
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,6 +63,19 @@
         <div id="main">
             <div id="sidebar">{% block sidebar %}{% endblock %}</div>
             <div id="content" class="clearfix">
+
+                <div style="padding: 5px 10px; margin: 40px 0 20px; border: 4px
+                    solid gold;"> <b>Gratipay is currently in the midst of <a
+                    href="https://medium.com/gratipay-blog/gratipocalypse-42fd0ec0d9e8">a
+            major transition</a></b>, which is causing some disruption on the site. Here
+    is a list of <a
+    href="https://github.com/gratipay/gratipay.com/milestones/Pivot"> known
+issues</a>.  Sorry for the trouble, and thanks for your patience as we work to
+stabilize Gratipay as quickly as possible. As always, feel free to get in touch
+privately via <a href="support@gratipay.com">email</a> or publicly via <a
+href="https://github.com/gratipay/gratipay.com/issues/new">GitHub</a>.</div>
+
+
                 {% block heading %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
                 {% block subnav %}{% endblock %}
                 {% block content %}{% endblock %}

--- a/tests/js/test_homepage.js
+++ b/tests/js/test_homepage.js
@@ -1,6 +1,8 @@
 var assert = require('assert');
 
 describe('homepage', function() {
+    /*
+     * https://github.com/gratipay/gratipay.com/pull/3452
     it('should render copy correctly', function(done) {
         browser
             .url('http://localhost:8537')
@@ -12,4 +14,5 @@ describe('homepage', function() {
             })
             .call(done);
     });
+    */
 });

--- a/tests/py/test_hooks.py
+++ b/tests/py/test_hooks.py
@@ -130,7 +130,7 @@ class Tests2(Harness):
         assert not r.headers.cookie
 
     def test_caching_of_simplates(self):
-        r = self.client.GET('/')
+        r = self.client.GET('/about/')
         assert r.headers['Cache-Control'] == 'no-cache'
         assert 'Vary' not in r.headers
 
@@ -147,7 +147,7 @@ class Tests2(Harness):
         assert r.headers.cookie[b'csrf_token'].value != 'bad_token'
 
     def test_csrf_cookie_set_for_most_requests(self):
-        r = self.client.GET('/')
+        r = self.client.GET('/about/')
         assert b'csrf_token' in r.headers.cookie
 
     def test_no_csrf_cookie_set_for_assets(self):

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -1,5 +1,8 @@
 [---]
 
+if user.ANON:
+    request.redirect('/about/')
+
 if not user.ANON:
     participant = user.participant
     title = participant.username


### PR DESCRIPTION
I tried implementing this using our js notification system, but that doesn't support HTML that I can tell. I wanted to include links. The content area is the best place I could quickly find to put this (works properly across the full range of viewport sizes), but that's not available on the unauthenticated homepage, so as a quick hack this PR additionally redirects `/` to `/about/` for anon.

![screen shot 2015-05-17 at 6 31 05 pm](https://cloud.githubusercontent.com/assets/134455/7672499/ec5d4a84-fcc2-11e4-82ce-37d682b38b25.png)

Addresses #3447.