### PR TITLE
Add script for migrating tips to new teams

### DIFF
--- a/bin/migrate-tips.py
+++ b/bin/migrate-tips.py
@@ -1,0 +1,20 @@
+from gratipay.wireup import db, env
+from gratipay.models.team import Team, AlreadyMigrated
+
+db = db(env())
+
+slugs = db.all("""
+    SELECT slug
+      FROM teams
+     WHERE is_approved IS TRUE
+""")
+
+for slug in slugs:
+    team = Team.from_slug(slug)
+    try:
+        team.migrate_tips()
+        print("Migrated tips for '%s'" % slug)
+    except AlreadyMigrated:
+        print("'%s' already migrated." % slug)
+
+print("Done.")


### PR DESCRIPTION
This is the script from https://github.com/gratipay/gratipay.com/issues/3486#issuecomment-106630168. 

Since we're going to run this every week until the period for migrating to teams ends, I thought storing it in the repo would be a good idea. 