### PR TITLE
Check for null billing_address in billing/instruments.py

### DIFF
--- a/gratipay/billing/instruments.py
+++ b/gratipay/billing/instruments.py
@@ -29,7 +29,7 @@ class CreditCard:
                 expiration_month=card.expiration_month,
                 expiration_year=card.expiration_year,
                 cardholder_name=card.cardholder_name,
-                address_postal_code=card.billing_address.postal_code
+                address_postal_code=getattr(card.billing_address, 'postal_code', '')
             )
         else:
             assert route.network == 'balanced-cc'


### PR DESCRIPTION
#3533

I'm not adding extra tests for this, checked that it works by setting `card.billing_address = None` just before where I made the change.