### PR TITLE
Fake data - subscriptions and payments

### DIFF
--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -219,7 +219,7 @@ def fake_payment(db, participant, team, amount, direction):
                       , timestamp=faker.date_time_this_year()
                       , participant=participant
                       , team=team
-                      , amount=amount	
+                      , amount=amount
                       , direction=direction
                        )
 
@@ -316,7 +316,12 @@ def clean_db(db):
     """)
 
 
+<<<<<<< HEAD
 def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=5000, num_communities=20):
+=======
+def populate_db(db, num_participants=100, num_tips=200, num_teams=25, num_transfers=5000,
+        num_communities=20):
+>>>>>>> 7828f7b... Increase the number of teams to 25
     """Populate DB with fake data.
     """
     print("Making Participants")
@@ -355,12 +360,16 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         for team in teams:
             #eliminate self-payment
             if participant.username != team.owner:
+<<<<<<< HEAD
                 npayment_instructions += 1
                 if npayment_instructions > ntips:
                     break
                 fake_payment_instruction(db, participant, team)
         if npayment_instructions > ntips:
             break
+=======
+                subscriptions.append(fake_subscription(db, participant, team))
+>>>>>>> 7828f7b... Increase the number of teams to 25
 
     print("Making Elsewheres")
     for p in participants:
@@ -394,7 +403,7 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         participant = subscription['subscriber']
         team = Team.from_slug(subscription['team'])
         amount = subscription['amount']
-        if participant != team.owner: 
+        if participant != team.owner:
             paymentcount += 1
             sys.stdout.write("\rMaking Payments (%i)" % (paymentcount))
             sys.stdout.flush()
@@ -418,13 +427,13 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
 
     # Paydays
     # First determine the boundaries - min and max date
-    min_date = min(min(x['ctime'] for x in subscriptions), 
-                   min(x['timestamp'] for x in payments), 
-                   min(x['ctime'] for x in tips), 
+    min_date = min(min(x['ctime'] for x in subscriptions),
+                   min(x['timestamp'] for x in payments),
+                   min(x['ctime'] for x in tips),
                    min(x['timestamp'] for x in transfers))
-    max_date = max(max(x['ctime'] for x in subscriptions), 
-                   max(x['timestamp'] for x in payments), 
-                   max(x['ctime'] for x in tips), 
+    max_date = max(max(x['ctime'] for x in subscriptions),
+                   max(x['timestamp'] for x in payments),
+                   max(x['ctime'] for x in tips),
                    max(x['timestamp'] for x in transfers))
     # iterate through min_date, max_date one week at a time
     payday_counter = 1
@@ -442,10 +451,10 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         week_participants = filter(lambda x: x.ctime.replace(tzinfo=None) < end_date, participants)
         for p in week_participants:
             transfers_in = filter(lambda x: x['tippee'] == p.username, week_transfers)
-            payments_in = filter(lambda x: (x['participant'] == p.username) & 
+            payments_in = filter(lambda x: (x['participant'] == p.username) &
                 (x['direction'] == 'to-participant'), week_payments)
             transfers_out = filter(lambda x: x['tipper'] == p.username, week_transfers)
-            payments_out = filter(lambda x: (x['participant'] == p.username) & 
+            payments_out = filter(lambda x: (x['participant'] == p.username) &
                 (x['direction'] == 'to-team'), week_payments)
             amount_in = sum([t['amount'] for t in transfers_in])
             amount_in = amount_in + sum([t['amount'] for t in payments_in])
@@ -475,7 +484,7 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         # week_subscriptions
         actives.update(x['subscriber'] for x in week_subscriptions)
         tippers.update(x['subscriber'] for x in week_subscriptions)
-       
+
         # week_payments
         actives.update(x['participant'] for x in week_payments)
         tip_payments = filter(lambda x: x['direction'] == 'to-team', week_payments)
@@ -484,8 +493,18 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         payday = {
             'ts_start': date,
             'ts_end': end_date,
+<<<<<<< HEAD
             'nusers': len(actives),
             'volume': sum(x['amount'] for x in week_transfers)
+=======
+            'ntips': len(week_tips) + len(week_subscriptions),
+            'ntransfers': len(week_transfers) + len(week_payments),
+            'nparticipants': len(week_participants),
+            'ntippers': len(tippers),
+            'nactive': len(actives),
+            'transfer_volume': sum(x['amount'] for x in week_transfers)
+                + sum(x['amount'] for x in week_payments)
+>>>>>>> 7828f7b... Increase the number of teams to 25
         }
         insert_fake_data(db, "paydays", **payday)
         date = end_date

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -355,16 +355,12 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         for team in teams:
             #eliminate self-payment
             if participant.username != team.owner:
-<<<<<<< HEAD
                 npayment_instructions += 1
                 if npayment_instructions > ntips:
                     break
                 fake_payment_instruction(db, participant, team)
         if npayment_instructions > ntips:
             break
-=======
-                subscriptions.append(fake_subscription(db, participant, team))
->>>>>>> 7828f7b... Increase the number of teams to 25
 
     print("Making Elsewheres")
     for p in participants:
@@ -488,18 +484,8 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         payday = {
             'ts_start': date,
             'ts_end': end_date,
-<<<<<<< HEAD
             'nusers': len(actives),
             'volume': sum(x['amount'] for x in week_transfers)
-=======
-            'ntips': len(week_tips) + len(week_subscriptions),
-            'ntransfers': len(week_transfers) + len(week_payments),
-            'nparticipants': len(week_participants),
-            'ntippers': len(tippers),
-            'nactive': len(actives),
-            'transfer_volume': sum(x['amount'] for x in week_transfers)
-                + sum(x['amount'] for x in week_payments)
->>>>>>> 7828f7b... Increase the number of teams to 25
         }
         insert_fake_data(db, "paydays", **payday)
         date = end_date

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -214,11 +214,10 @@ def fake_elsewhere(db, participant, platform):
 def fake_payment(db, participant, team):
     """Create fake payment
     """
-    direction = ['to-team','to-participant']
     if participant.username == team.owner:
         direction = 'to-participant'
     else:
-        direction = random.sample(['to-team','to-participant'],1)[0]
+        direction = 'to-team'
     return _fake_thing( db
                       , "payments"
                       , timestamp=faker.date_time_this_year()
@@ -416,13 +415,13 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
 
     # Paydays
     # First determine the boundaries - min and max date
-    min_date = min(min(x['ctime'] for x in subscriptions), \
-                   min(x['timestamp'] for x in payments), \
-                   min(x['ctime'] for x in tips), \
+    min_date = min(min(x['ctime'] for x in subscriptions), 
+                   min(x['timestamp'] for x in payments), 
+                   min(x['ctime'] for x in tips), 
                    min(x['timestamp'] for x in transfers))
-    max_date = max(max(x['ctime'] for x in subscriptions), \
-                   max(x['timestamp'] for x in payments), \
-                   max(x['ctime'] for x in tips), \
+    max_date = max(max(x['ctime'] for x in subscriptions), 
+                   max(x['timestamp'] for x in payments), 
+                   max(x['ctime'] for x in tips), 
                    max(x['timestamp'] for x in transfers))
     # iterate through min_date, max_date one week at a time
     payday_counter = 1

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -14,7 +14,6 @@ from gratipay import wireup, MAX_TIP, MIN_TIP
 from gratipay.elsewhere import PLATFORMS
 from gratipay.models.participant import Participant
 from gratipay.models.team import slugize, Team
-from gratipay.models import community
 from gratipay.models import check_db
 from gratipay.exceptions import InvalidTeamName
 
@@ -178,20 +177,6 @@ def fake_payment_instruction(db, participant, team):
                             )
 
 
-def fake_community(db, creator):
-    """Create a fake community
-    """
-    name = faker.city()
-    if not community.name_pattern.match(name):
-        return fake_community(db, creator)
-
-    slug = community.slugize(name)
-
-    creator.insert_into_communities(True, name, slug)
-
-    return community.Community.from_slug(slug)
-
-
 def fake_tip_amount():
     amount = ((D(random.random()) * (MAX_TIP - MIN_TIP))
             + MIN_TIP)
@@ -338,7 +323,7 @@ def clean_db(db):
         DROP FUNCTION IF EXISTS process_payment() CASCADE;
         """)
 
-def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=5000, num_communities=20):
+def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=5000):
     """Populate DB with fake data.
     """
     print("Making Participants")
@@ -392,14 +377,6 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         for platform_name in random.sample(PLATFORMS, num_elsewheres):
             fake_elsewhere(db, p, platform_name)
 
-    print("Making Communities")
-    for i in xrange(num_communities):
-        creator = random.sample(participants, 1)
-        community = fake_community(db, creator[0])
-
-        members = random.sample(participants, random.randint(1, 3))
-        for p in members:
-            p.insert_into_communities(True, community.name, community.slug)
 
     print("Making Tips")
     tips = []

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -5,6 +5,7 @@ from decimal import Decimal as D
 import random
 import string
 import sys
+from collections import defaultdict
 
 from faker import Factory
 from psycopg2 import IntegrityError
@@ -84,6 +85,7 @@ def fake_participant(db, is_admin=False, random_identities=True):
                          )
         participant = Participant.from_username(username)
 
+        fake_exchange_route(db, participant)
         if random_identities:
             if random.randrange(100) < 66:
                 fake_participant_identity(participant)
@@ -97,6 +99,21 @@ def fake_participant(db, is_admin=False, random_identities=True):
 
     return participant
 
+
+def fake_exchange_route(db, participant, network=None):
+    
+    if not network:
+        networks = ["balanced-ba", "balanced-cc", "paypal", "bitcoin"]
+        network = random.sample(networks, 1)[0]
+
+    insert_fake_data( db
+                    , "exchange_routes"
+                    , participant = participant.id
+                    , network = network 
+                    , address = participant.email_address
+                    , error = "None" 
+                    )
+        
 
 def fake_participant_identity(participant, verification=None):
     """Pick a country and make an identity for the participant there.
@@ -214,14 +231,14 @@ def fake_elsewhere(db, participant, platform):
 def fake_payment(db, participant, team, amount, direction):
     """Create fake payment
     """
-    return _fake_thing( db
-                      , "payments"
-                      , timestamp=faker.date_time_this_year()
-                      , participant=participant
-                      , team=team
-                      , amount=amount
-                      , direction=direction
-                       )
+    return insert_fake_data( db
+                            , "payments"
+                            , timestamp=faker.date_time_this_year()
+                            , participant=participant
+                            , team=team
+                            , amount=amount
+                            , direction=direction
+                            )
 
 def fake_transfer(db, tipper, tippee):
     return insert_fake_data( db
@@ -242,11 +259,17 @@ def fake_exchange(db, participant, amount, fee, timestamp):
                            , amount=amount
                            , fee=fee
                            , status='succeeded'
+                           , route=get_exchange_route(db, participant.id)
                             )
 
 
+def get_exchange_route(db, participant):
+    return db.one("SELECT id FROM exchange_routes WHERE participant={}"
+                    .format(participant), participant)
+
 def random_country_id(db):
     return db.one("SELECT id FROM countries ORDER BY random() LIMIT 1")
+
 
 
 def prep_db(db):
@@ -312,7 +335,8 @@ def clean_db(db):
     db.run("""
         DROP FUNCTION IF EXISTS process_transfer() CASCADE;
         DROP FUNCTION IF EXISTS process_exchange() CASCADE;
-
+        DROP FUNCTION IF EXISTS process_payment() CASCADE;
+        """)
 
 def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=5000, num_communities=20):
     """Populate DB with fake data.
@@ -349,6 +373,7 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
 
     print("Making Payment Instructions")
     npayment_instructions = 0
+    payment_instructions = []
     for participant in participants:
         for team in teams:
             #eliminate self-payment
@@ -356,7 +381,7 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
                 npayment_instructions += 1
                 if npayment_instructions > ntips:
                     break
-                fake_payment_instruction(db, participant, team)
+                payment_instructions.append(fake_payment_instruction(db, participant, team))
         if npayment_instructions > ntips:
             break
 
@@ -386,15 +411,15 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
     payments = []
     paymentcount = 0
     team_amounts = defaultdict(int)
-    for subscription in subscriptions:
-        participant = subscription['subscriber']
-        team = Team.from_slug(subscription['team'])
-        amount = subscription['amount']
-        assert participant != team.owner
+    for payment_instruction in payment_instructions:
+        participant = Participant.from_id(payment_instruction['participant_id'])
+        team = Team.from_id(payment_instruction['team_id'])
+        amount = payment_instruction['amount']
+        assert participant.username != team.owner
         paymentcount += 1
         sys.stdout.write("\rMaking Payments (%i)" % (paymentcount))
         sys.stdout.flush()
-        payments.append(fake_payment(db, participant, team.slug, amount, 'to-team'))
+        payments.append(fake_payment(db, participant.username, team.slug, amount, 'to-team'))
         team_amounts[team.slug] += amount
     for team in teams:
         paymentcount += 1
@@ -414,9 +439,9 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
 
     # Paydays
     # First determine the boundaries - min and max date
-    min_date = min(min(x['ctime'] for x in subscriptions + tips),
+    min_date = min(min(x['ctime'] for x in payment_instructions + tips),
                    min(x['timestamp'] for x in payments + transfers))
-    max_date = max(max(x['ctime'] for x in subscriptions + tips),
+    max_date = max(max(x['ctime'] for x in payment_instructions + tips),
                    max(x['timestamp'] for x in payments + transfers))
     # iterate through min_date, max_date one week at a time
     payday_counter = 1
@@ -429,7 +454,7 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         end_date = date + datetime.timedelta(days=7)
         week_tips = filter(lambda x: date <= x['ctime'] < end_date, tips)
         week_transfers = filter(lambda x: date <= x['timestamp'] < end_date, transfers)
-        week_subscriptions = filter(lambda x: date <= x['ctime'] < end_date, subscriptions)
+        week_payment_instructions = filter(lambda x: date <= x['ctime'] < end_date, payment_instructions)
         week_payments = filter(lambda x: date <= x['timestamp'] < end_date, payments)
         week_payments_to_teams = filter(lambda x: x['direction'] == 'to-team', week_payments)
         week_payments_to_owners = filter(lambda x: x['direction'] == 'to-participant', week_payments)
@@ -461,9 +486,9 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
             actives.update(x['tippee'] for x in xfers)
             tippers.update(x['tipper'] for x in xfers)
 
-        # week_subscriptions
-        actives.update(x['subscriber'] for x in week_subscriptions)
-        tippers.update(x['subscriber'] for x in week_subscriptions)
+        # week_payment_instructions
+        actives.update(x['participant_id'] for x in week_payment_instructions)
+        tippers.update(x['participant_id'] for x in week_payment_instructions)
 
         # week_payments
         actives.update(x['participant'] for x in week_payments)

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -387,9 +387,7 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
     # Payments
     payments = []
     paymentcount = 0
-    teamamounts = {}
-    for team in teams:
-        teamamounts[team.slug] = 0
+    team_amounts = defaultdict(int)
     for subscription in subscriptions:
         participant = subscription['subscriber']
         team = Team.from_slug(subscription['team'])
@@ -399,12 +397,12 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         sys.stdout.write("\rMaking Payments (%i)" % (paymentcount))
         sys.stdout.flush()
         payments.append(fake_payment(db, participant, team.slug, amount, 'to-team'))
-        teamamounts[team.slug] = teamamounts[team.slug] + amount
+        team_amounts[team.slug] += amount
     for team in teams:
         paymentcount += 1
         sys.stdout.write("\rMaking Payments (%i)" % (paymentcount))
         sys.stdout.flush()
-        payments.append(fake_payment(db, team.owner, team.slug, teamamounts[team.slug], 'to-participant'))
+        payments.append(fake_payment(db, team.owner, team.slug, team_amounts[team.slug], 'to-participant'))
     print("")
 
     # Transfers

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -445,10 +445,8 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
             payments_in = filter(lambda x: x['participant'] == p.username, week_payments_to_owners)
             transfers_out = filter(lambda x: x['tipper'] == p.username, week_transfers)
             payments_out = filter(lambda x: x['participant'] == p.username, week_payments_to_teams)
-            amount_in = sum([t['amount'] for t in transfers_in])
-            amount_in = amount_in + sum([t['amount'] for t in payments_in])
-            amount_out = sum([t['amount'] for t in transfers_out])
-            amount_out = amount_out + sum([t['amount'] for t in payments_out])
+            amount_in = sum([t['amount'] for t in transfers_in + payments_in])
+            amount_out = sum([t['amount'] for t in transfers_out + payments_out])
             amount = amount_out - amount_in
             fee = amount * D('0.02')
             fee = abs(fee.quantize(D('.01')))

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -433,8 +433,7 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         week_payments = filter(lambda x: date <= x['timestamp'] < end_date, payments)
         week_payments_to_teams = filter(lambda x: x['direction'] == 'to-team', week_payments)
         week_payments_to_owners = filter(lambda x: x['direction'] == 'to-participant', week_payments)
-        week_participants = filter(lambda x: x.ctime.replace(tzinfo=None) < end_date, participants)
-        for p in week_participants:
+        for p in participants:
             transfers_in = filter(lambda x: x['tippee'] == p.username, week_transfers)
             payments_in = filter(lambda x: x['participant'] == p.username, week_payments_to_owners)
             transfers_out = filter(lambda x: x['tipper'] == p.username, week_transfers)

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -281,7 +281,6 @@ def prep_db(db):
                    AND NEW.direction = 'to-team';
 
                 RETURN NULL;
-
             END;
         $$ language plpgsql;
 
@@ -313,7 +312,6 @@ def clean_db(db):
     db.run("""
         DROP FUNCTION IF EXISTS process_transfer() CASCADE;
         DROP FUNCTION IF EXISTS process_exchange() CASCADE;
-    """)
 
 
 def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=5000, num_communities=20):

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -414,14 +414,10 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
 
     # Paydays
     # First determine the boundaries - min and max date
-    min_date = min(min(x['ctime'] for x in subscriptions),
-                   min(x['timestamp'] for x in payments),
-                   min(x['ctime'] for x in tips),
-                   min(x['timestamp'] for x in transfers))
-    max_date = max(max(x['ctime'] for x in subscriptions),
-                   max(x['timestamp'] for x in payments),
-                   max(x['ctime'] for x in tips),
-                   max(x['timestamp'] for x in transfers))
+    min_date = min(min(x['ctime'] for x in subscriptions + tips),
+                   min(x['timestamp'] for x in payments + transfers))
+    max_date = max(max(x['ctime'] for x in subscriptions + tips),
+                   max(x['timestamp'] for x in payments + transfers))
     # iterate through min_date, max_date one week at a time
     payday_counter = 1
     date = min_date

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -211,6 +211,22 @@ def fake_elsewhere(db, participant, platform):
                     , extra_info=None
                      )
 
+def fake_payment(db, participant, team):
+    """Create fake payment
+    """
+    direction = ['to-team','to-participant']
+    if participant.username == team.owner:
+        direction = 'to-participant'
+    else:
+        direction = random.sample(['to-team','to-participant'],1)[0]
+    return _fake_thing( db
+                      , "payments"
+                      , timestamp=faker.date_time_this_year()
+                      , participant=participant.username
+                      , team=team.slug
+                      , amount=fake_tip_amount()	
+                      , direction=direction
+                       )
 
 def fake_transfer(db, tipper, tippee):
     return insert_fake_data( db
@@ -256,6 +272,26 @@ def prep_db(db):
 
         CREATE TRIGGER process_transfer AFTER INSERT ON transfers
             FOR EACH ROW EXECUTE PROCEDURE process_transfer();
+
+        CREATE OR REPLACE FUNCTION process_payment() RETURNS trigger AS $$
+            BEGIN
+                UPDATE participants
+                   SET balance = balance + NEW.amount
+                 WHERE username = NEW.participant
+                   AND NEW.direction = 'to-participant';
+
+                UPDATE participants
+                   SET balance = balance - NEW.amount
+                 WHERE username = NEW.participant
+                   AND NEW.direction = 'to-team';
+
+                RETURN NULL;
+
+            END;
+        $$ language plpgsql;
+
+        CREATE TRIGGER process_payment AFTER INSERT ON payments
+            FOR EACH ROW EXECUTE PROCEDURE process_payment();
 
         CREATE OR REPLACE FUNCTION process_exchange() RETURNS trigger AS $$
             BEGIN
@@ -331,7 +367,6 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         if npayment_instructions > ntips:
             break
 
-
     print("Making Elsewheres")
     for p in participants:
         #All participants get between 1 and 3 elsewheres
@@ -354,6 +389,22 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         tipper, tippee = random.sample(participants, 2)
         tips.append(fake_tip(db, tipper, tippee))
 
+    # Payments
+    payments = []
+    paymentcount = 0
+    while paymentcount <= num_payments:
+        for participant in participants:
+            for team in teams:
+                paymentcount += 1
+                if paymentcount > num_payments:
+                    break
+                sys.stdout.write("\rMaking Payments (%i/%i)" % (paymentcount, num_payments))
+                sys.stdout.flush()
+                payments.append(fake_payment(db, participant, team))
+            if paymentcount > num_payments:
+                break
+    print("")
+
     # Transfers
     transfers = []
     for i in xrange(num_transfers):
@@ -365,9 +416,13 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
 
     # Paydays
     # First determine the boundaries - min and max date
-    min_date = min(min(x['ctime'] for x in tips), \
+    min_date = min(min(x['ctime'] for x in subscriptions), \
+                   min(x['timestamp'] for x in payments), \
+                   min(x['ctime'] for x in tips), \
                    min(x['timestamp'] for x in transfers))
-    max_date = max(max(x['ctime'] for x in tips), \
+    max_date = max(max(x['ctime'] for x in subscriptions), \
+                   max(x['timestamp'] for x in payments), \
+                   max(x['ctime'] for x in tips), \
                    max(x['timestamp'] for x in transfers))
     # iterate through min_date, max_date one week at a time
     payday_counter = 1
@@ -378,15 +433,25 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         sys.stdout.flush()
         payday_counter += 1
         end_date = date + datetime.timedelta(days=7)
-        week_tips = filter(lambda x: date < x['ctime'] < end_date, tips)
-        week_transfers = filter(lambda x: date < x['timestamp'] < end_date, transfers)
+        week_tips = filter(lambda x: date <= x['ctime'] < end_date, tips)
+        week_transfers = filter(lambda x: date <= x['timestamp'] < end_date, transfers)
+        week_subscriptions = filter(lambda x: date <= x['ctime'] < end_date, subscriptions)
+        week_payments = filter(lambda x: date <= x['timestamp'] < end_date, payments)
         week_participants = filter(lambda x: x.ctime.replace(tzinfo=None) < end_date, participants)
         for p in week_participants:
             transfers_in = filter(lambda x: x['tippee'] == p.username, week_transfers)
+            payments_in = filter(lambda x: (x['participant'] == p.username) & 
+                (x['direction'] == 'to-participant'), week_payments)
             transfers_out = filter(lambda x: x['tipper'] == p.username, week_transfers)
+            payments_out = filter(lambda x: (x['participant'] == p.username) & 
+                (x['direction'] == 'to-team'), week_payments)
             amount_in = sum([t['amount'] for t in transfers_in])
+            amount_in = amount_in + sum([t['amount'] for t in payments_in])
             amount_out = sum([t['amount'] for t in transfers_out])
+            amount_out = amount_out + sum([t['amount'] for t in payments_out])
             amount = amount_out - amount_in
+            fee = amount * D('0.02')
+            fee = abs(fee.quantize(D('.01')))
             if amount != 0:
                 fee = amount * D('0.02')
                 fee = abs(fee.quantize(D('.01')))
@@ -399,10 +464,21 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
                 )
         actives=set()
         tippers=set()
+        #week_tips, week_transfers
         for xfers in week_tips, week_transfers:
             actives.update(x['tipper'] for x in xfers)
             actives.update(x['tippee'] for x in xfers)
             tippers.update(x['tipper'] for x in xfers)
+
+        # week_subscriptions
+        actives.update(x['subscriber'] for x in week_subscriptions)
+        tippers.update(x['subscriber'] for x in week_subscriptions)
+       
+        # week_payments
+        actives.update(x['participant'] for x in week_payments)
+        tip_payments = filter(lambda x: x['direction'] == 'to-team', week_payments)
+        tippers.update(x['participant'] for x in tip_payments)
+
         payday = {
             'ts_start': date,
             'ts_end': end_date,

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -316,12 +316,7 @@ def clean_db(db):
     """)
 
 
-<<<<<<< HEAD
 def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=5000, num_communities=20):
-=======
-def populate_db(db, num_participants=100, num_tips=200, num_teams=25, num_transfers=5000,
-        num_communities=20):
->>>>>>> 7828f7b... Increase the number of teams to 25
     """Populate DB with fake data.
     """
     print("Making Participants")

--- a/tests/py/test_fake_data.py
+++ b/tests/py/test_fake_data.py
@@ -8,11 +8,10 @@ class TestFakeData(Harness):
     """
     Ensure the fake_data script doesn't throw any exceptions
     """
-
     def test_fake_data(self):
         num_participants = 6
-        num_tips = 5
-        num_teams = 1
+        num_tips = 25
+        num_teams = 5
         num_transfers = 5
         fake_data.main(self.db, num_participants, num_tips, num_teams, num_transfers)
         tips = self.db.all("SELECT * FROM tips")
@@ -24,10 +23,7 @@ class TestFakeData(Harness):
         assert len(participants) == num_participants
         assert len(transfers) == num_transfers
         assert len(teams) == num_teams + 1      # +1 for the fake Gratipay team.
-        if num_tips <= num_participants - num_teams:
-            assert len(payment_instructions) == num_tips
-        else:
-            assert len(payment_instructions) == (num_participants - num_teams)
+        assert len(payment_instructions) == num_tips
 
 
     def test_fake_participant_identity(self):


### PR DESCRIPTION
Added fake subscriptions and payments. Tests have been correspondingly updated.

Tips and transfers have been left as they are, for removal later once migration is complete.

This is ready for review.

Please note one change in particular that needs to be validated, made for week_tips and week_transfers (and the new week_subscriptions and week_payments):
week_tips = filter(lambda x: date <= x['ctime'] < end_date, tips)

  was

week_tips = filter(lambda x: date < x['ctime'] < end_date, tips)

Seemed to me that transactions at min_date were being skipped in processing due to the 'date < x['ctime']' condition. This wasn't causing any issues, because this would correspondingly not have gone into exchanges as well.
