### PR TITLE
Removed widgets link on profile

### DIFF
--- a/templates/profile-subnav.html
+++ b/templates/profile-subnav.html
@@ -8,7 +8,6 @@
                , ('/~'+u+'/',           _('Profile'),   True,           show_profile)
                , ('/~'+u+'/giving/', _('Giving'), True,   False)
                , ('/~'+u+'/history/',   _('History'),   True,           False)
-               , ('/~'+u+'/widgets/',   _('Widgets'),   True,           False)
                , ('/~'+u+'/settings/',  _('Settings'),  True,           False)
                , ('/~'+u+'/events/',    _('Events'),    False,          False)
                 ] %}


### PR DESCRIPTION
Removed link to widgets because widgets are not currently correct and
not hooked up to teams.  https://github.com/gratipay/grtp.co/issues/103