### PR TITLE
rejected -> closed

### DIFF
--- a/gratipay/models/team.py
+++ b/gratipay/models/team.py
@@ -82,7 +82,7 @@ class Team(Model):
     @property
     def status(self):
         return { None: 'unreviewed'
-               , False: 'rejected'
+               , False: 'closed'
                , True: 'approved'
                 }[self.is_approved]
 

--- a/www/%team/index.html.spt
+++ b/www/%team/index.html.spt
@@ -37,7 +37,7 @@ title = name = team.name
 <div class="col0">
     {% if team.is_approved in (None, False) %}
     {% if team.is_approved == None %}unreviewed{% endif %}
-    {% if team.is_approved == False %}rejected{% endif %} |
+    {% if team.is_approved == False %}closed{% endif %} |
     {{ team.homepage }}
     {% else %}
     <a href="{{ team.homepage }}">{{ team.homepage }}</a>

--- a/www/%team/index.html.spt
+++ b/www/%team/index.html.spt
@@ -36,9 +36,7 @@ title = name = team.name
 {% block content %}
 <div class="col0">
     {% if team.is_approved in (None, False) %}
-    {% if team.is_approved == None %}unreviewed{% endif %}
-    {% if team.is_approved == False %}closed{% endif %} |
-    {{ team.homepage }}
+    {{ team.status }} | {{ team.homepage }}
     {% else %}
     <a href="{{ team.homepage }}">{{ team.homepage }}</a>
     {% endif %} |


### PR DESCRIPTION
"Rejecting" teams is too harsh a term for the situation we want to optimize for, wherein we reach a decision collaboratively together with team owners about whether they and we are a good fit for each other. I think we should use the term "close" instead. That leaves ambiguous the circumstances surrounding the closing, whereas "rejected" only covers the harshest case, wherein Gratipay acts despite the owner's intention. A "closed" account could be closed by the owner's decision, by Gratipay's, or by both agreeing together.