### PR TITLE
actually, let's use rejected

### DIFF
--- a/gratipay/models/team.py
+++ b/gratipay/models/team.py
@@ -82,7 +82,7 @@ class Team(Model):
     @property
     def status(self):
         return { None: 'unreviewed'
-               , False: 'closed'
+               , False: 'rejected'
                , True: 'approved'
                 }[self.is_approved]
 


### PR DESCRIPTION
Sorry for the run-around on this, @mattbk @rohitpaulk et al. This PR backs out #3678. The reason is that I tried using the word "closed" ... somewhere (can't find it atm), and it sounded like doublespeak. Like, if we *did* reject someone but said the account was "closed" then that implies *they* closed their account—otherwise how are we going to distinguish that case? Let's use "rejected" for when we reject a team, and "closed" for when the owner closes the team, which could be before or after we review them. This PR reinstates "rejected", and we'll need #3602 for closing.