### PR TITLE
Removed misleading "i.e it's public domain"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,7 @@ Don't be afraid that it's a dumb idea or a duplicate of another issue or an
 unwanted change or whatever. Maybe it is! We're still glad to have you! :^)
 
 **License.** Gratipay is [licensed under
-CC0](https://github.com/gratipay/gratipay.com/tree/master/COPYING), i.e.,
-it's public domain. 
+CC0](https://github.com/gratipay/gratipay.com/tree/master/COPYING).
 
 **More info.** If you want to really get involved, then check out our full
 documentation for contributors:


### PR DESCRIPTION
Check this from the [CC0 webpage](https://creativecommons.org/publicdomain/zero/1.0/legalcode):

>  Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.

As you can see, the CC0 license in indeed used in countries which do not have a public domain law Thus, under the laws of those countries, CC0 is a *license*

Any country which **does have** public domain law, that country, shall not regard CC0 as a license, as stated by the CC0 page in the part which I had quoted above.