### PR TITLE
fix intermittent test failure

### DIFF
--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -348,7 +348,7 @@ class Tests(Harness):
         """helper method to chooses a restricted username for testing """
         from gratipay import RESTRICTED_USERNAMES
         random_item = random.choice(RESTRICTED_USERNAMES)
-        while random_item.startswith('%'):
+        while any(map(random_item.startswith, ('%', '~'))):
             random_item = random.choice(RESTRICTED_USERNAMES)
         return random_item
 


### PR DESCRIPTION
The problem is that we introduced `~` as a restricted name (it's a directory name), but it's also an invalid character, and the invalid character was getting flagged in the test for name restriction.

Fixes #3696.