### PR TITLE
tinker with automated Team review ticket

### DIFF
--- a/gratipay/models/team.py
+++ b/gratipay/models/team.py
@@ -75,8 +75,9 @@ class Team(Model):
         """POST to GitHub, and return the URL of the new issue.
         """
         api_url = "https://api.github.com/repos/{}/issues".format(self.review_repo)
-        data = json.dumps({ "title": "review {}".format(self.name)
-                          , "body": "https://gratipay.com/{}/".format(self.slug)
+        data = json.dumps({ "title": self.name
+                          , "body": "https://gratipay.com/{}/\n\n".format(self.slug) +
+                                    "(This application will remain open for at least a week.)"
                            })
         r = requests.post(api_url, auth=self.review_auth, data=data)
         if r.status_code == 201:


### PR DESCRIPTION
Drop the redundant "review" (we now have a dedicate repo) and add the helpful note about it taking a week.

Follow-on from #3568.