### PR TITLE
fix regression in status icons on Team pages

### DIFF
--- a/www/%team/index.html.spt
+++ b/www/%team/index.html.spt
@@ -88,11 +88,11 @@ suppress_sidebar = not(team.is_approved or user.ADMIN)
 
     <a href="{{ team.review_url }}">
         {% if team.status == 'approved' %}
-        <span class="status-icon">&#xe008;</span> {{ _("Approved") }}
+        <span class="status-icon approved">&#xe008;</span> {{ _("Approved") }}
         {% elif team.status == 'unreviewed' %}
-        <span class="status-icon">&#xe009;</span> {{ _("Under Review") }}
+        <span class="status-icon unreviewed">&#xe009;</span> {{ _("Under Review") }}
         {% elif team.status == 'rejected' %}
-        <span class="status-icon">&#xe010;</span> {{ _("Rejected") }}
+        <span class="status-icon rejected">&#xe010;</span> {{ _("Rejected") }}
         {% endif %}
     </a> |
 


### PR DESCRIPTION
## Was

![screen shot 2015-09-10 at 9 56 15 pm](https://cloud.githubusercontent.com/assets/134455/9805435/e3837dc6-5806-11e5-88fe-cecbc79eb963.png)

## Now

![screen shot 2015-09-10 at 9 56 19 pm](https://cloud.githubusercontent.com/assets/134455/9805436/ebee4d88-5806-11e5-8aaf-c7148bd004fd.png)
