### PR TITLE
catch fake data up with #3730

### DIFF
--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -381,13 +381,15 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
         date = end_date
     print("")
 
-def main():
-    db = wireup.db(wireup.env())
+
+def main(db, *a, **kw):
+    clean_db(db)
     prep_db(db)
-    populate_db(db)
+    populate_db(db, *a, **kw)
     clean_db(db)
     check_db(db)
 
 
 if __name__ == '__main__':
-    main()
+    db = wireup.db(wireup.env())
+    main(db)

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -225,50 +225,12 @@ def prep_db(db):
 
         CREATE TRIGGER process_exchange AFTER INSERT ON exchanges
             FOR EACH ROW EXECUTE PROCEDURE process_exchange();
-
-        CREATE OR REPLACE FUNCTION process_payday() RETURNS trigger AS $$
-            BEGIN
-                SELECT COALESCE(SUM(amount+fee), 0)
-                  FROM exchanges
-                 WHERE timestamp > NEW.ts_start
-                   AND timestamp < NEW.ts_end
-                   AND amount > 0
-                  INTO NEW.charge_volume;
-
-                SELECT COALESCE(SUM(fee), 0)
-                  FROM exchanges
-                 WHERE timestamp > NEW.ts_start
-                   AND timestamp < NEW.ts_end
-                   AND amount > 0
-                  INTO NEW.charge_fees_volume;
-
-                SELECT COALESCE(SUM(amount), 0)
-                  FROM exchanges
-                 WHERE timestamp > NEW.ts_start
-                   AND timestamp < NEW.ts_end
-                   AND amount < 0
-                  INTO NEW.ach_volume;
-
-                SELECT COALESCE(SUM(fee), 0)
-                  FROM exchanges
-                 WHERE timestamp > NEW.ts_start
-                   AND timestamp < NEW.ts_end
-                   AND amount < 0
-                  INTO NEW.ach_fees_volume;
-
-                RETURN NEW;
-            END;
-        $$ language plpgsql;
-
-        CREATE TRIGGER process_payday BEFORE INSERT ON paydays
-            FOR EACH ROW EXECUTE PROCEDURE process_payday();
     """)
 
 def clean_db(db):
     db.run("""
-        DROP FUNCTION process_transfer() CASCADE;
-        DROP FUNCTION process_exchange() CASCADE;
-        DROP FUNCTION process_payday() CASCADE;
+        DROP FUNCTION IF EXISTS process_transfer() CASCADE;
+        DROP FUNCTION IF EXISTS process_exchange() CASCADE;
     """)
 
 

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -344,7 +344,8 @@ def populate_db(db, num_participants=100, ntips=200, num_teams=5, num_transfers=
     print("")
 
 
-def main(db, *a, **kw):
+def main(db=None, *a, **kw):
+    db = db or wireup.db(wireup.env())
     clean_db(db)
     prep_db(db)
     populate_db(db, *a, **kw)
@@ -353,5 +354,4 @@ def main(db, *a, **kw):
 
 
 if __name__ == '__main__':
-    db = wireup.db(wireup.env())
-    main(db)
+    main()

--- a/tests/py/test_fake_data.py
+++ b/tests/py/test_fake_data.py
@@ -14,7 +14,7 @@ class TestFakeData(Harness):
         num_tips = 5
         num_teams = 1
         num_transfers = 5
-        fake_data.populate_db(self.db, num_participants, num_tips, num_teams, num_transfers)
+        fake_data.main(self.db, num_participants, num_tips, num_teams, num_transfers)
         tips = self.db.all("SELECT * FROM tips")
         participants = self.db.all("SELECT * FROM participants")
         transfers = self.db.all("SELECT * FROM transfers")


### PR DESCRIPTION
We removed a number of payday stats fields in #3730, but were still trying to populate those in fake data. This PR also makes db cleaning a little more robust so we can recover from failure during `make fake`.

Fixes #3780.