### PR TITLE
stop Python-interpolating payday.sql

### DIFF
--- a/gratipay/billing/payday.py
+++ b/gratipay/billing/payday.py
@@ -149,7 +149,7 @@ class Payday(object):
         money internally between participants.
         """
         with self.db.get_cursor() as cursor:
-            self.prepare(cursor, self.ts_start)
+            self.prepare(cursor)
             holds = self.create_card_holds(cursor)
             self.process_payment_instructions(cursor)
             self.transfer_takes(cursor, self.ts_start)
@@ -172,10 +172,10 @@ class Payday(object):
 
 
     @staticmethod
-    def prepare(cursor, ts_start):
+    def prepare(cursor):
         """Prepare the DB: we need temporary tables with indexes and triggers.
         """
-        cursor.run(PAYDAY, dict(ts_start=ts_start))
+        cursor.run(PAYDAY)
         log('Prepared the DB.')
 
 

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+    CREATE FUNCTION current_payday() RETURNS paydays AS $$
+        SELECT *
+          FROM paydays
+         WHERE ts_end='1970-01-01T00:00:00+00'::timestamptz;
+    $$ LANGUAGE sql;
+
+    CREATE FUNCTION current_payday_id() RETURNS int AS $$
+        -- This is a function so we can use it in DEFAULTS for a column.
+        SELECT id FROM current_payday();
+    $$ LANGUAGE sql;
+
+END;

--- a/sql/payday.sql
+++ b/sql/payday.sql
@@ -18,7 +18,7 @@ CREATE TABLE payday_participants AS
           , braintree_customer_id
       FROM participants p
      WHERE is_suspicious IS NOT true
-       AND claimed_time < %(ts_start)s
+       AND claimed_time < (SELECT ts_start FROM current_payday())
   ORDER BY claimed_time;
 
 CREATE UNIQUE INDEX ON payday_participants (id);
@@ -51,14 +51,14 @@ DROP TABLE IF EXISTS payday_payments_done;
 CREATE TABLE payday_payments_done AS
     SELECT *
       FROM payments p
-     WHERE p.timestamp > %(ts_start)s;
+     WHERE p.timestamp > (SELECT ts_start FROM current_payday());
 
 DROP TABLE IF EXISTS payday_payment_instructions;
 CREATE TABLE payday_payment_instructions AS
     SELECT s.id, participant, team, amount, due
       FROM ( SELECT DISTINCT ON (participant, team) *
                FROM payment_instructions
-              WHERE mtime < %(ts_start)s
+              WHERE mtime < (SELECT ts_start FROM current_payday())
            ORDER BY participant, team, mtime DESC
            ) s
       JOIN payday_participants p ON p.username = s.participant

--- a/tests/py/test_billing_payday.py
+++ b/tests/py/test_billing_payday.py
@@ -171,17 +171,16 @@ class TestPayday(BillingHarness):
         self.make_participant('carl', balance=10, claimed_time='now')
 
         payday = Payday.start()
-        ts_start = payday.ts_start
 
         get_participants = lambda c: c.all("SELECT * FROM payday_participants")
 
         with self.db.get_cursor() as cursor:
-            payday.prepare(cursor, ts_start)
+            payday.prepare(cursor)
             participants = get_participants(cursor)
 
         expected_logging_call_args = [
             ('Starting a new payday.'),
-            ('Payday started at {}.'.format(ts_start)),
+            ('Payday started at {}.'.format(payday.ts_start)),
             ('Prepared the DB.'),
         ]
         expected_logging_call_args.reverse()
@@ -191,13 +190,12 @@ class TestPayday(BillingHarness):
         log.reset_mock()
 
         # run a second time, we should see it pick up the existing payday
-        payday = Payday.start()
-        second_ts_start = payday.ts_start
+        second_payday = Payday.start()
         with self.db.get_cursor() as cursor:
-            payday.prepare(cursor, second_ts_start)
+            payday.prepare(cursor)
             second_participants = get_participants(cursor)
 
-        assert ts_start == second_ts_start
+        assert payday.ts_start == second_payday.ts_start
         participants = list(participants)
         second_participants = list(second_participants)
 
@@ -207,7 +205,7 @@ class TestPayday(BillingHarness):
 
         expected_logging_call_args = [
             ('Picking up with an existing payday.'),
-            ('Payday started at {}.'.format(second_ts_start)),
+            ('Payday started at {}.'.format(second_payday.ts_start)),
             ('Prepared the DB.'),
         ]
         expected_logging_call_args.reverse()
@@ -238,7 +236,7 @@ class TestPayin(BillingHarness):
     def create_card_holds(self):
         payday = Payday.start()
         with self.db.get_cursor() as cursor:
-            payday.prepare(cursor, payday.ts_start)
+            payday.prepare(cursor)
             return payday.create_card_holds(cursor)
 
     @mock.patch.object(Payday, 'fetch_card_holds')
@@ -369,7 +367,7 @@ class TestPayin(BillingHarness):
         """)
         payday = Payday.start()
         with self.db.get_cursor() as cursor:
-            payday.prepare(cursor, payday.ts_start)
+            payday.prepare(cursor)
             cursor.run("""
                 UPDATE payday_participants
                    SET new_balance = -50
@@ -398,7 +396,7 @@ class TestPayin(BillingHarness):
 
         payday = Payday.start()
         with self.db.get_cursor() as cursor:
-            payday.prepare(cursor, payday.ts_start)
+            payday.prepare(cursor)
             payday.process_payment_instructions(cursor)
             assert cursor.one("select balance from payday_teams where slug='TheEnterprise'") == D('0.51')
             assert cursor.one("select balance from payday_teams where slug='TheTrident'") == 0
@@ -429,7 +427,7 @@ class TestPayin(BillingHarness):
         # have already been processed
         for i in range(3):
             with self.db.get_cursor() as cursor:
-                payday.prepare(cursor, payday.ts_start)
+                payday.prepare(cursor)
                 payday.transfer_takes(cursor, payday.ts_start)
                 payday.update_balances(cursor)
 
@@ -453,7 +451,7 @@ class TestPayin(BillingHarness):
 
         payday = Payday.start()
         with self.db.get_cursor() as cursor:
-            payday.prepare(cursor, payday.ts_start)
+            payday.prepare(cursor)
             payday.process_payment_instructions(cursor)
             payday.transfer_takes(cursor, payday.ts_start)
             payday.process_draws(cursor)
@@ -491,7 +489,7 @@ class TestPayin(BillingHarness):
         alice.set_tip_to(bob, 18)
         payday = Payday.start()
         with self.db.get_cursor() as cursor:
-            payday.prepare(cursor, payday.ts_start)
+            payday.prepare(cursor)
             bruce = self.make_participant('bruce', claimed_time='now')
             bruce.take_over(('twitter', str(bob.id)), have_confirmation=True)
             payday.process_payment_instructions(cursor)


### PR DESCRIPTION
Using Python string interpolation on the `payday.sql` file introduces complexity that leads to bugs. The one I hit was using `%` for interpolation in a Postgres `RAISES` clause: it would've had to be escaped to make it through the Python interpolation.

I cherry-picked this from 364d066bb4e7f69b7a2febc31230fdb8e57b05a6 in #3653.

See reference in https://github.com/gratipay/gratipay.com/issues/3780#issuecomment-139909299.