### PR TITLE
fix default for nusers in update_cta

### DIFF
--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -136,7 +136,7 @@ def update_cta(website):
     nusers = website.db.one("""
         SELECT nusers FROM paydays
         ORDER BY ts_end DESC LIMIT 1
-    """, default=(0.0, 0))
+    """, default=0)
     nreceiving_from = website.db.one("""
         SELECT nreceiving_from
           FROM teams


### PR DESCRIPTION
The `update_cta` function updates the statistics we use in our global call to action (cta). We have defaults for development, where the database can be empty. This runs in a thread and was causing logspam and actually a test failure on forthcoming commits for #3788.

Fixes #3771.