### PR TITLE
Refund excess balances

### DIFF
--- a/tests/py/fixtures/BillingHarness.yml
+++ b/tests/py/fixtures/BillingHarness.yml
@@ -3,20 +3,20 @@ interactions:
     body: <customer></customer>
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/customers
   response:
     body:
       string: !!binary |
-        H4sIAG3ak1UAA5SRQVODMBCF7/0VmdwjSS3WdgK9+QvqxdvKLpBKApMEC/9eip3WGfTg8b0vb/fN
-        Rh8G27BP8sG0LuPqQXJGrmjRuCrjr8cX8cwP+UoXfYitJZ+vGNMG88dUPslUbnQyiYs3saIGF8Wk
-        T7vqjOUJP4bR1lh5nfykl9el8SEKB5aYM03Go++JJzNq4C9StLYDNy58smCahdvVrVvOKGFYeGd6
-        Dyb+ss8TREIBkcWxo4zjJKOxxPO1VKmQWyHVUa33arvf7N50cg/M+b7D/+Xvge/9881FaajBcKuE
-        JooCPIbrUPAexmtjQPQUAi3Y1O32gV8AAAD//wMA0gM70fMBAAA=
+        H4sIADRKDlYAA5SRwW7CMBBE73yF5bubGEoKyAm3fgG99La1N8Qidix7Q8nfN6QIKqU99DjzPLuj
+        tdpfXMvOGJPtfMnlU84Zet0Z648lfzu8ig3fVwul+0Sdw1gtGFPWVMVmvXre5i8qG8XVG5luwJMY
+        NQXSoTmaWOjV6XyKKvtJr69rGxMJDw6Zt23JKfbIswm18BfRnQvgh5mPDmw7c0PT+fmMGi4z7xM/
+        kqVf9kUEQiOAGA0BS25GSdYhr5a5XAuZi3x5yLc7KXeyeFfZIzDl+2D+l38EvvdPNxe1xdakeyVj
+        SWiIJt2GQoww3BqDMRFTwhkbu90/8AsAAP//AwB2Vt7o8wEAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"c0a8976b346e51bb42e6128bb3fac612"']
+      etag: ['"155e9aacfabfbb9f8c3f533c3391ff26"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -25,50 +25,50 @@ interactions:
     body: <customer></customer>
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/customers
   response:
     body:
       string: !!binary |
-        H4sIAG/ak1UAA5SRwW6DMBBE7/kKy3cXTEBpI0Nu/YL00tuWXcApNsg2Cfx9CY2SSrSHHmeeZ3e0
-        VofRtOxMzuvO5lw+xZyRLTvUts752/FVPPNDsVHl4ENnyBUbxpTGQso03WZJqqJZXL2ZlQ3YIGZ9
-        eqkvWJ3wc5xMg7VT0U96fV1p54OwYIhZ3eY8uIF4tKAW/iJlZ3qw08onA7pduX3T2fWMCsaVd6EP
-        r8Mv+xxBIBQQWJh6yjnOMmhDvEhimYl4J2J5lMle7vaZfFfRI7Dkhx7/l38EvvcvNxeVphb9vRLq
-        IEpw6G9DwTmYbo0B0ZH3tGJzt/sHfgEAAP//AwBna82J8wEAAA==
+        H4sIADVKDlYAA5SRzW7DIBCE73kKxJ0aXOWnEXZufYL00tsWNjGKwQjWafz2ddwoqeT20OPMx+yO
+        Fr27+JadMWXXhYqrJ8kZBtNZF44Vf9u/ig3f1Qtt+kydx1QvGNPO1uuV3JRLJXUxiqs3MtNAIDFq
+        imRic7RpZZ5P51PSxU96fX1wKZMI4JEF11acUo+8mFALfxHT+QhhmPnowbUzNzZdmM84wGXmfeJH
+        dvTLvoRAaAUQoyFixe0oyXnkdSnVUigpZLmXL1ultmr9rotHYMr30f4v/wh8759uLg4OW5vvlawj
+        YSDZfBsKKcFwawzWJswZZ2zsdv/ALwAAAP//AwBOFi3S8wEAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"b179a0644dabf894a946a41b7ca3b25f"']
+      etag: ['"89af244931b80b7c1acfe4501772cd5d"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '<payment_method><customer_id>11443524</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
+    body: !!python/unicode '<payment_method><customer_id>76082510</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods
   response:
     body:
       string: !!binary |
-        H4sIAHHak1UAA6xVTXPaMBC98ysY34U/MAnJGGV66bGXJj30kpGlNdYgS44kk/DvuzIGHAJpO+2N
-        ffu0H89Ponh4a9R0C9ZJo1dROkuiKWhuhNTrVfT0+JUsowc6KbgFIT3hzAo6mU6LUiqFFMKEsOBc
-        wBCVguavRSzFEPPOedOAJYikaZ7PF1lexGN0z6ukdZ5o1sBUS7WKvO0gioekYtdz3DQt07sLGect
-        gD/Md4EAbx60APEJRRnOlPSXyltYo2AXEq1xnimCCgK9y9PktojH0GHsTnu76yHCVFuz7OJy56z5
-        71i6Q10l/4R2TUgLzAcx/NTvWlhFAkMvG4holqQLktySJH1Ms/v09n6R/cSPeDwwVOha8XcVTgd6
-        R8UXLIU20zRP0my5DHndY8GDJLSgP6RjOMkxPmRrowTa69KqwTEoEZdM0Se90eZVY4UTNhlJZSoi
-        neuY5kCfvn8JvI+Jyb+L92fX5MQKtvToPhxqxDqigSuglP604D7cJyrWqcOcpTEKmI5oECjQ+uSe
-        2FkUnKDPOxVmHRU7z0z629RK2/cnjdG+pmlWxB/AM+YOmEWFsuQdtUePTBDns1ZMORhODN1rYMrX
-        +OnhNOYICxTZsDWQzipae9+6+zhmzoF3s9IyqcNjscZlXtluhm6IW7ZrQPvnBnxtxLMyaxNv0W2z
-        Vq8fQG+lNToQVo5pUZo3fPOO9ftuaI/g5ZLpzWmkd+jk8LTlNF0u0yIegoBje2vUyKEHoE9aaBl6
-        4ptBfPgdcNeVjlvZBhHdIBqzlu0G53uzAU3LTd2+NEW8jwLeafnS9U9H2ZsN15KVBEvzOV/maSU4
-        n/N5dXMzv1lUsEiTOYcllByv5NWjk//wIGxBN4Y4sbligGN+YFtsvb8CH7bvb9zp/+sXAAAA//8D
-        AM/WZvz1BgAA
+        H4sIADZKDlYAA6xVu3LbMBDs9RUa9hAfoiPKQ8GTJmWa2CnSZEDiSCECAQYAZfPvc6Coh2XKSSbp
+        dHuLeywXUP7w0sj5HowVWm2CeBEFc1Cl5kLVm+Dp8RPJggc6y0sDXDhSMsPpbD7PCyElUgjj3IC1
+        HkNUcNryPBR8jMvOOt2AIYisPkRZchdHeXiJHniVMNYRxRqYKyE3gTMdBOGYlOx2rtRNy1Q/kbHO
+        ALjjfBMEeHGgOPB3KFKXTAo3Vd5AjYJNJFptHZMEFQS6TuNolYeX0HHsTjnTDxBhst2yZHK5a9by
+        dyzVoa6ifId2S0gDzHkx3Nz1LWwCjqETDQQ0ieI7EkckSh6j9X0c38fZN/yIpwNjha7lf1fhfGBw
+        VDhhKbSZomkUJ1nm82rAvAeJb0G/CstwklN8zG615GivqVW9Y1CiUjBJn9RO6WeFFc7Y7EIqXRFh
+        bcdUCfTpy0fPe5uY/bt4f3ZNzixvS4fuw6EuWCfUczkUwp0XPISHRMU6eZyz0FoCUwH1AnnakDwQ
+        O4OCE/R5J/2sF8WuM7PhNrXCDP1Jo5Xb0jjJwzfgFbMHZlChJHpFHdATE/j1rBWTFsYTY/ctMOm2
+        +OnhPOYF5imiYTWQzki6da6192HIrAVnF4VhQvnHosZlnlm/QDeELesbUO57A26r+Xepax3u0W2L
+        VtUPoPbCaOUJG8sUL/QLvnmn+kM3tIf3csHU7jzSK3R2fNpSGmdZnIdj4HFsb7S8cOgRGJIGWoae
+        +KwRH3973HaFLY1ovYh2FI0Zw/rR+U7vQNFqWS9/1Hl4iDzeKfGzG56OYjAbriUqAYZW6TqL09Wq
+        WKZJmaXlah1Vq7Rg63WSpVW8xit86+jsPzwIe1CNJpbvbhjglB/ZBlsfrsCb7Ycbd/7/+gUAAP//
+        AwDcqanq9QYAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"d5c1968be63e8a7a1e806856b74d2680"']
+      etag: ['"aca26c1f969bdbb850574f18065a7edd"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]

--- a/tests/py/fixtures/TestCardHolds.yml
+++ b/tests/py/fixtures/TestCardHolds.yml
@@ -1,43 +1,43 @@
 interactions:
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>20.91</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>20.91</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAHTak1UAA9xXS2/bOBC+91cEvjOybCdxCkVBgcUCe+he+kCxl4IixxZjiVRJyrHz63coSrIU
-        UWn3sMBib9LMR3JenPmYPJ7K4uoI2gglHxbx9XJxBZIpLuT+YfHl8+9ku3hM3yVWU2kos4hK311d
-        JYKnfP/Cq00S4aeTGEttbVJa21xp8QI8iVqR09pzBamhBSRR8+lkrNYazzoTYRTBIyH98um3JJqK
-        HZiWqpY2XS2v7+Mkav+cogTNciotoYw5IUF7jM3uD5u7l5fsaaVvb56SKIRyq5XmoPHnSoriYWF1
-        DYvIG6eBWuCE2itn8MOC468VJSzQhviGLO/IMv4cr97Hd+9vbv9Cs/sFzfq64v9s/WVBGxxjFVrt
-        fny843izWd+s+oijdCe0sUTSEl7bj8qCzuuYKisqzwENlFQUAfkzZEbY0F5VrmRIvqOnSVSjoVtJ
-        JooC6+zi4ub533XOWA2ANcC5BmNC3p8sSO6yMAspFKOFsKHtNezxfoRCpPAqFL6Y7zfx8i6JhqLO
-        bKxLfZ73yqvdCkKLKqerX0Ktf4aSNeZDsGmuBulB13a15KGL0mtMW+hUa3oeKTGeg/4R2sSAtQWU
-        gBczo5blQUwuqmpYLqGa+1/WzBsZ/M8UyzA7bfMiOwEFN50/VFvBREV9813hFRhLBv1hsDKhR0NA
-        a6UJBrdS0kAwJg1uELMxOv2IM+NNQLfFON2vQH/4Xd7ENP4fj9OVU6GD7rHpP9Mzap7AXw+cI2Za
-        EUmlFcPTMA7diKUNvNnp9uvHb1sX0rdA413GpsTL5XK4fGpoQGex9NMPFWqObtzPIZrQci6cJRj8
-        KWzi61EJ5hK0w8TjCiy6DPQ0IrWb6XiKH+IzKEtPxNOFoApOUFbdjM6UKoDKRbqjhXFUpQd0nAC9
-        IIzqbkZZdQCZZoe8+lEivPnzmkzIdLOMV9uta6Ry2II2abzdIolpf9pbhpuShhp9FYZitfT/XZep
-        hPbJLJW0eRpjuifCCfYMVCPhWC1H4EbantsOZOJ6VEPvvny6jOmL9GJlroom3OHOI0q6B1LrIs2t
-        rcz7KKIGu7u5zjQV0l2ctuKvseViCzi7pv+9BKxW/r1QexUd0f/rSu4fQR6FVtIBHgyVPFMnpAf9
-        /v68WoofNbTJxzaCYIHdQ6ebNdtu4h1nbM3Wu9vb9e3NDm7i5ZrBFjKGaZld2jYsDRXFvvSncqXt
-        v70mB1rYHGOBjFUepHqWSTSQeRCHTNiL3v+2qlpjSWB97+vCcb4B6rWmn06OwApaXKADWddgz1oV
-        A0QnaBNjTI39GeerPFwwI+m436sdcVoqmSPmH9yJU0UXKsVr1nTxy+kXmQcdQZaKGH6YuWy9vp0E
-        48vWvi9ILrAy9XnENfpJ3SAAN2oj7W4oUm5UlNUv0vAe3+/w5sOmQcy9TXyBGqworXJhK1oXB7y1
-        jaS3b0CMjMKOBimtBNoxlXsvo9du9pI2NL43FjRMtOrMMC2qWSI20PedrKGBpMLBrzhBrkNcEAN3
-        /xUSzdI2iEWTX53jBgTBWRDgkFyYpvKCOvC7qO7SznSluTcK9pGpbeNNkaG5Fyn6NVO3vd7PCHxl
-        Spjuijk/uqG2A5gbR+5Y9Ux8NidaDENWa+NJMgeLz7SOWo1V4dwMGHb4+DFm8gj/RTicXACwQ+uw
-        Ge45gJWK7C60Yc1YgEBjRmZ8d55XtYVQabSjhQiJdK1uPptx6vvKd9dXkmgONCY8A0fHvGjIeWZB
-        P9+rYUk/26unUjbHIUrwerm6AzR9p8YRGzWP9N3fAAAA//8DAGbAiFvjEQAA
+        H4sIALxKDlYAA9xXQW/rNgy+91cEuau2k3RNCtfFA7YBG/B22HvdsF0K2aZjtbbkSXKavF8/yrId
+        O5bb7jBg2M0mP1EkRZGfwodjWSwOIBUT/H4ZXPvLBfBEpIzv75ePX38k2+VDdBVqSbmiiUZUdLVY
+        hCyN9lpvbzahh59GojTVtYporXMh2TdIQ68VGa0+VRApWkDoNZ9GltRS4l4nwpQguCVEPzz+GnpT
+        sQHTUtRcRyv/eheEXvtnFCXIJKdcE5okRkjQn/hZg9Kh59KZNUKmIPFnwVlxv9SyhqVnXZJANaSE
+        6oVx836Z4q9mJSxx5+CGBD7xV1/93V2wvluv/kRn+wXN+rpK/9n684I2JUoL9Nr82CzffudvVzeB
+        3+UZpRmTShNOS7j0H5UFndcloqwoPzk0UFJWOOSvECumXbaqXHCXPKPHSVa9YVhhzIoCq+scYpX+
+        u8EpLQGwBtJUglKu6I8aeGpOYRZSiIQWTLvMS9jjrXClSOAFKGwJ7zaBfxt6Q1HnNtalPM1HZdVm
+        BaFFldPVh1Dr91C8xvNgyfSsBseDoWU1T10XpdeottCplPQ0UmI+B13DZaSiUjNMhwKtCygBL+h4
+        hcv4ucG8Z35gNqY6yZ2YnFXVsBpdJf2/LMk3CuQ/U4vD02l7I8kYFKnq4jEVlLCK2t6+whs2lgza
+        z2BlSA+KgJRCEkxuJbgCZ04a3CBnY3T0GQfRm4DOxPi4L0A/WStvYpr4D4fpyqnQQPc4U17pCTXP
+        YK8Hjik1rYiwkiLB3TAP3bWiDbyx9Mfnm9+//xlT+hZobGXsSuD7/nD51FGHTmPpR58q1BwMh5hD
+        NKlNU2Y8weRPYZNYD4Il5oAyPHhcgUUXg5xmpDaUAXexHGEGpemRWA7iVMERyqqjALEQBVC+jDJa
+        KMN/ekBHOTAKklDZjUAtXoBH2Xq/ft4jvPmzmpjxaOMHq+3W9Gk+bEGbKNhukRm1P+0tQ6Ok4Vu/
+        MUWxWvr/rstUTNrDLAXXeRTgDZoIJ9gTUIl8ZuWPwI203bed98T0qIYzPn45s4Cz9OxlLoom3e7O
+        w0q6B1LLIsq1rtSd51GF3V1dx5Iybi5OW/HX2HKxBZxM038qAas1fSrEXngHjP+64vsH4AcmBTeA
+        e0V5Gosjso/efttWJFQUu8cvwhSg/baaHGihc/QYokf+wsUrD72BzIJSiJk+6+1vq6olHhxW4b4u
+        DPEboC41/QwxLBbH5Bk6kHVt8CRFMUB0gjZ9StXYRXEK8pczZiQdd2WREaOlPMEwv3wyO04VXapE
+        WidNrz3vfpZZUM3ZXzW0lwnFmHyG3VhG2Wa3DTa3t/F6s0q2m+R252e3m5judqvtJgt2SJDnllrL
+        B+ClICp9mblsvb6dBOPL1j5aSM6wMuVpxDb6Sd0gAA21Z2huKDJ6VJTVB1l+j+8tvPlaahBzDx6b
+        UIUZ6F45zU/v2oATKYHNDCJaMXRhKrcBepcR9pI2K7YtFtTNsepYJZJVsxxsoO+bWEMwSYUzX6QE
+        aQ4x+XNc+wskuiW1E4suX+xjZgPBMeAgkClTTTk7dWCtiK6+ZhrS3OsHW8jUt7FRJGfmhYtxzZRs
+        r7fjAd+vHKZW8cwPZp5lAHOTyGwrXok9zYkW0xDXUll+nILGB2DHqsYq99kMyLV7+zFm8qj/IByO
+        JgHYnKXbDfPQwEpFYucyWCeJgzvjiczEbiKvarxVjtJopwphHJlabR8rZpLalvJkWkrozYHGXGcQ
+        6JgSDenOLOh9Ww1Bes9Wz6J0jvOT4PUydQfoeibGGRs1j+jqbwAAAP//AwDxNysPMxIAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"94ec61fecdef62415a9b56bf77b0d630"']
+      etag: ['"960b5efe2ffef993bfabb46177cfe619"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -46,83 +46,83 @@ interactions:
     body: <transaction><amount>10.0</amount></transaction>
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/dgzdp4/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/gtt854/submit_for_settlement
   response:
     body:
       string: !!binary |
-        H4sIAHXak1UAA9xYS2/jNhC+768IfGck2U7iLBQtFigK9LC97ANFLwFFjSyuJVJLUo6dX9+hKMlS
-        RGUDFC2K3qyZj+S8+M3Q8YdTVV4dQWkuxcMqug5XVyCYzLjYP6y+fvmV7FYfknexUVRoygyikndX
-        VzHPkmz/nNXbOMCfVqINNY1OdJNW3BjIHnOpHjUYU0IFwsRBB7BYc64h0bSEOGh/WhlrlMKTz4Rr
-        SdAASL5+/iUO5mILppVshEmi8DoM46D7sooKFCuoMIQyZoUErdMmvT9s756f0+9rdXvzPQ58KLta
-        qgwUflwJXj6sjGpgFTjjFFD0iVBzZQ1+WGX4aXgFq2QdRjckvCNh9CVav4/u3t/c/olmDwva9U2d
-        vX39Ha6/LOiCo41Eq+2Hi34Ubbebm/UQf5TmXGlDBK3gpf2oLOmyjsmqpuLs0UBFeemRP0GqufHt
-        VRdS+OQ5Pc2iGozdilNellh1Fxe3T/+sc9ooAKyBLFOgtc/7kwGR2SwsQkrJaMmNb3sFe7wtvhBJ
-        vAqlK+b7bRTexcFY1JuNdanOy145tV1BaFkXdP0m1OZnKNFgPjib52qUHnQtb0TmuyiDRneFTpWi
-        54kS4zliE98mF9YgKTWs8GIKXtfjcvHV3P+yZl7J4H+mWMbZ6ciL5BzKTPf+UGU44zV15LvGKzCV
-        jPhhtDKmR01AKakIBreWQoM3Ji1uFLMpOvmEPeNVQL/FNN0vQL+5XV7FtP4fj/OVc6GF7pH0n+gZ
-        Nd/BXQ/sI3peEXGtJMPTMA60MYVU/Jm28Han22+f/tjZkL4Gmu4yNSUKbVtd0i6sNFj6yccaNUfI
-        vKtbRBvaLOPWEgz+HDbz9Sg5swnKMfG4AosuBTWPSGN7Op7imvgCytATceOCVwUnqOq+R6dSlkDF
-        Kslpqe2oMgD6mQC9IIyqvkcZeQCRpIei/lEhvP1ympSLZBtG693OEqkYU9A2iXa7KA66j+6W4aak
-        HY2+cU2xWobvnmVqrlwyKylMkUSY7plwhj0DVThwrMMJuJV253YNmViOaoe9r58vbfoivVhZyLIN
-        t595eEX3QBpVJoUxtX4fBFQju+vrVFEu7MXpKv4aKRcp4GxJ/7ECrNbssZR7GRzR/+ta7D+AOHIl
-        hQU8aCqyVJ5wPBj2d+c1gv9ooEs+0giCObKHSrYbtttGecbYhm3y29vN7U0ON1G4YbCDlGFaFpd2
-        hKWgpshLv0tb2u630xRAS1NgLHBiFQchn0QcjGQOlEHKzUXvPjtVo7AksL73TWlnvhHqpWboTnaA
-        5bS8QEeynmDPSpYjRC/oEqN1g/yM/VUcLpiJdMr3MidWSwWzg/lHe+Jc0YdKZg1rWfxy+kXmQEcQ
-        lSQ6OyxctkHfdYLpZeteG6TgWJnqPJk1hk7dIgA36iJtbyiO3Kio6jeO8QN+2KF7xfSEapnu8rBp
-        Ed1rZB1e30fjt4krUI0VpWTBTU2b8oC3tpUM9o0GIy2R0SChNUc75nLnZTB38+97fvea52954I3j
-        MHuj/TtxGCRdibgeUVL/wNmkmileLw6kI/3A6O04TGocgGRGcOYjNqQeDnyBRLOU8WLR5Bfn2EZJ
-        sCd6ZumM6/YGenXgdpE9eS2w89JbDfl0btt0U5xU7csc/Vq4v4Pe9Up8bQuY74o5P9rmngMstWV7
-        rHwiLpszLYYhbZR2j4UMDD5X+xFzqvLnZvTS8B8/xcz+jHgjHE42ANiplN8M+yzCSsUp17dhw5jn
-        IYEZWfDdel43Bnyl0bVYwgWOrU37sx0rHL8+Wn6NgyXQdPAbOTqdD8ez3yLo53u10+LP9hpGSlPg
-        MEHwetm6AzQ9l9OITcgjefcXAAAA//8DAIkuCK75EgAA
+        H4sIAL1KDlYAA9xYzW7jNhC+5ykC32lJtlPbgaJggbZAC2wP3U2L9hJQ0shiIpEqSTl2n75DUZKl
+        iEoCFAsUvVkzH4czw/l1eH8qi+sjSMUEv1sES39xDTwRKeOHu8XD1x/JbnEfXYVaUq5oohEVXV1f
+        hyyNDlrvbjahhz8NRWmqaxWpOi6Z1pA+ZkI+KtC6gBK4Dr0WYLD6XEGkaAGh1/w0tKSWEm8+E6YE
+        QQUg+uHh19Cbkg2YlqLmOgr8pe+HXvtlGCXIJKdcE5okhkhQu/hJg0IFXDxzRsgUJH5cc1bcLbSs
+        YeFZlSRQtIRQfW3UvFuk+KlZCYto5Qc3JPCJv/rq72+D9e169Scq2x9oztdV+vHzazx/OdC6RGmB
+        WpsP6/Ptd/5udRP4ndeRmjGpNOG0hNf6I7Og87xElBXlZwcHSsoKB/0FYsW0S1aVC+6iZ/Q08ao3
+        NCuMWVFgrF1MrNJva5zSEgBjIE0lKOWy/qSBp+YVZiGFSGjBtEu8hAPmiMtFAhOgsCG83wT+NvSG
+        pE5tjEt5nrfKss0JQosqp6sPodbvoXiN78GS6VsNngdNy2qeuhKl56g20KmU9Dxioj8HNcQlpKJS
+        M3THpWa8OuESTmudC8n+fl/8QGxMdZI7MTmrqmE0ukL6fxmSbwTIfyYWh6/T1kaSMShS1dljIihh
+        FbW1fYUZNqYMys/gZEiPioCUQhJ0biW4AqdPGtzAZ2N09Bkb0ZuATsT4uV+BfrJS3sQ09h+P05NT
+        ooEesKe80DNynsCmB7YpNY2IsJIiwdvQD11a0QbeSPrj883v3/+MLn0LNJYyViXwTa+e486c1Bj6
+        0acKOUdInacbROPaNGVGE3T+FDax9ShYYh4ow4fHExh0McipR2ozMuAtdkaYQWl6InYGcbLgBGXV
+        jQCxEAVQvogyWigz//SAbuRAK0hCZdcCtXgGHmXrw/rpgPDmy3JixqONH6x2O1On+bAEbaJgtwtC
+        r/1oswyFkmbe+o0pitHSf3dVpmLSPmYpuM6jADNoQpxgz0AlzjMrfwRuqO29bb8npkY1E+TDl8sU
+        cKFetMxF0bjbXXlYSQ9AallEudaVuvU8qrC6q2UsKeMmcdqIX2LJxRJwNkX/sQSM1vSxEAfhHdH+
+        ZcUP98CPTApuAHeK8jQWJ5w+evltWZFQUawevwgTgPa35eRAC52jxhA98GcuXnjoDWgWlELM9IVv
+        P1tWLfHhMAoPdWEGvwHqNafvIWaKxTZ5gQ5oXRk8S1EMEB2hdZ9SNVZR7IL8+YIZUcdVWWTEcClP
+        0Mwvn8yNU0bnKpHWSVNrL7dfaBZUc/ZXDW0yIRmdz7Aayyjb7HfBZruN15tVstsk272fbTcx3e9X
+        u00W7HFAnjtqJR+Bl4Ko9Hkm2Xp+2wnGydauMCRnGJnyPJo2+k7dIAAFtW9oMhQnemSU1Qe3hB7f
+        S2hXo8swM9yWGkS74qz85T4YLjzWoQo90G05zUev2mAmUgKLGUS0YqjClG4N9KYW/nuj128Z/ZGF
+        ceiCyc73zV3QU9rAsJ2hoO4xs45VIlk1O4YO+H0db2ZsUuHYI1KCkx4x3nRUvldIVEtqJxZVfnWP
+        aY8EO6Fjhk6ZajLayQMrRXQpNlOT5xZArKJT3cZCcT41Sz7aNZO1Pd92SFzhOUyl4psfTUvPAOaa
+        sblWvBD7mhMuuiGupbIrQgoad+BusByz3G8z2C/c148xk/81PgiHk3EA9ifpVsPsWhipONu6BNZJ
+        4lgf8EVmbDeWVzVmlSM02sZKGMdhtbb7mhkmbFV9NFU19OZA43FvYOh4KhxOfLOg92U1M+J7svpB
+        Uuc4QhBMLxN3gKpnYuyxUfGIrv4BAAD//wMAbi7zlkQTAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"caa8dd66103e4cb01445503b16fb269c"']
+      etag: ['"13572388c419fa61a38ed6fb06c37974"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>20.91</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>20.91</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAHfak1UAA9xXT2+rOBC/v08R5e4SkrRNK0r1pNVKe9jVSu91D3upjJkEN2BT26RJP/2OMRAI
-        pu1lpdXeYObn8fyfcfR4LPLZAZTmUjzMw6vFfAaCyZSL3cP86eevZDN/jL9FRlGhKTOIir/NZhFP
-        45f0Zve6iQL8tBRtqKl0TCuTScXfIY2ChmS55lRCrGkOUVB/WhqrlMK7ToRrSfBKiJ9+/BIFY7IF
-        00JWwsTLxdVdGAXNn2UUoFhGhSGUMUskqI82yd1+ffv+nrws1c31SxT4UPa0VCko/JkJnj/Mjapg
-        HjjlFFADKaFmZhV+mKf4a3gBc9QhvCaLW7IIf4bL+/D2/nrzN6rdHajPV2X69fN3eP58oHGONhK1
-        tj/O32G4Xq+ul+vW40jdcqUNEbSAS/2RmdNpHpNFScXJw4GC8txDf4NEc+OTVWZS+Ohbehx5Neib
-        FSU8zzHPziau3/5d47RRAJgDaapAa5/1RwMitVGYhOSS0Zwbn3gFO6wPn4sklkLukvluHS5uo6BP
-        atXGvFSnaasc254gNC8zuvwSavUZSlQYD87GseqFB03bViL1FUrH0U2iU6XoacBEf/b6h0+IBmNy
-        KAALM6GGZV5Mxsuyny6+nPtf5swHEfzPJEs/Ok3zIlsOeapbe6gynPGSuua7xBIYUnr9oXcyogdN
-        QCmpCDq3lEKD1yc1ruezITr+HWfGh4BWxDDcF6DfnJQPMbX9h8P45JhooTts+m/0hJwXcOWBc0SP
-        MyIqlWR4G/qhHbG0hjvzwsXqTxwiH4KGUoaqhIvFon98rKiHZzD14+8lcg523E8hatemKbeaoPPH
-        sJGtB8mZDdAWA48nMOkSUGOPVHam4y1uiE+gDD0Sty54WXCEomxndCJlDlTM4y3NtV1VOkC7E6AV
-        hFHVzigj9yDiZJ+VrwXC6z/HSbiI14twudnYRir6LWgdh5sNLjHNT1NlKJTUq9FfXFPMlu6/7TIl
-        Vy6YhRQmi0OsoBFxhD0BVbhwLBcDcE1t7m0GMrE9ql7vnn6cx/SZetYyk3ntbn/n4QXdAalUHmfG
-        lPo+CKjG7q6vEkW5sIXTZPwVtlxsASfb9J8LwGxNn3O5k8EB7b8qxe4RxIErKSzgQVORJvKI60En
-        391XCf5aQRN8bCMI5tg9VLxesc063KaMrdhqe3OzurnewjXWCYMNJAzDMnm0aVgKSop96Q9pU9t9
-        O04GNDcZ+gI3VrEX8k1EQY/mQCkk3Jz57rdhVQpTAvN7V+V25+uhLjnddLILLKf5GdqjtQ32pGTe
-        Q7SEJjBaV9ifcb6K/RkzoA77vdwSy6WC2cX8u71xzGhdJdOK1V38fPuZ5kAHEIUkOt1PFFvHbybB
-        sNia9wXJOGamOg12jW5S1whAQY2nbYXiyo2MovziGt7hOwkfPmxqxNTbxCWoxoxSMuOmpFW+x6qt
-        KZ1+vcVIS+xoENOSox5jurMyuDSzozSucb0xp/5Fq0o0U7ycXMR6/K6T1WsgKXHwy5TgrkOsEz21
-        f4FEtZTxYlHli3vsgCA4Czw7ZMp1nXleHjgpsi3aia409UbBPjLWbSgUNzT7IkW7JvK247sZga9M
-        AWOpGPODHWpbgKlxZK+Vb8RFc8RFNySV0m5JTsHgM61drYYsf2x6G7b/+iFm9Aj/IhyO1gHYoZVf
-        DfscwEzF7c4nsGLMs0BjRCZst5aXlQFfajSjhXCB61pVf9bj1PWVZ9tXomAKNFx4eoYO96L+zjMJ
-        +lxWvSV9JqtbpUyGQ5Rgedm8A1R9K4ceGzSP+Ns/AAAA//8DABeuNsXjEQAA
+        H4sIAL9KDlYAA9xXQW/rNgy+91cEuau203RJCtfFO2zAMGwY1td3eJdCtulYrS15kpwm+/WjLNux
+        Y7ntDgOG3WzyE0VSFPkpfDiWxeIAUjHB75fBtb9cAE9Eyvj+fvn09SeyXT5EV6GWlCuaaERFV4tF
+        yNJos9vdHtPQw08jUZrqWkW01rmQ7C9ATSsyWn2qIFK0gNBrPo0sqaXEvU6EKUFwS4h+fPoj9KZi
+        A6alqLmOVv71Lgi99s8oSpBJTrkmNEmMkKA/8YsGpUPPpTNrhExB4s+Cs+J+qWUNS8+6JIFqSAnV
+        C+Pm/TLFX81KWOLOwS0JfOKvvvq7u+Dm7ub2OzrbL2jW11X6z9afF7QpUVqg1+anzfIP/nZ1G/hd
+        nlGaMak04bSES/9RWdB5XSLKivKTQwMlZYVD/gaxYtplq8oFd8kzepxk1RuGFcasKLC6ziFW6b8b
+        nNISAGsgTSUo5Yr+qIGn5hRmIYVIaMG0y7yEPd4KV4oEXoDClvBuHfib0BuKOrexLuVpPiqrNisI
+        Laqcrj6FuvkIxWs8D5ZMz2pwPBhaVvPUdVF6jWoLnUpJTyMl5nPQNVxGKio1w3Qo0LqAEvCCjle4
+        jJ8bzEfmB2ZjqpPciclZVQ2r0VXS/8uSfKdA/jO1ODydtjeSjEGRqi4eU0EJq6jt7Su8YWPJoP0M
+        Vob0oAhIKSTB5FaCK3DmpMENcjZGR7/iIHoX0JkYH/cF6Gdr5V1ME//hMF05FRroHmfKGz2h5gXs
+        9cAxpaYVEVZSJLgb5qG7VrSBN5Z+efx9s/2GKX0PNLYydiXwfX+4fOqoQ6ex9KMvFWoOhkPMIZrU
+        pikznmDyp7BJrAfBEnNAGR48rsCii0FOM1IbyoC7WI4wg9L0SCwHcargCGXVUYBYiAIoX0YZLZTh
+        Pz2goxwYBUmo7EagFq/Ao+xmf/OyR3jzZzUx49HaD1bbrenTfNiC1lGw3SIzan/aW4ZGScO3vjFF
+        sVr6/67LVEzawywF13kU4A2aCCfYE1CJfGblj8CNtN23nffE9KiGMz49nlnAWXr2MhdFk25352El
+        3QOpZRHlWlfqzvOowu6urmNJGTcXp634a2y52AJOpuk/l4DVmj4XYi+8A8Z/XfH9A/ADk4IbwL2i
+        PI3FEdlHb79tKxIqit3jN2EK0H5bTQ600Dl6DNETf+XijYfeQGZBKcRMn/X2t1XVEg8Oq3BfF4b4
+        DVCXmn6GGBaLY/IMHci6NniSohggOkGbPqVq7KI4BfnrGTOSjruyyIjRUp5gmI9fzI5TRZcqkdZJ
+        02vPu59lFlRz9mcN7WVCMSafYTeWUbbebYP1ZhPfrFfJdp1sdn62Wcd0t1tt11mwQ4I8t9RaPgAv
+        BVHp68xl6/XtJBhftvbRQnKGlSlPI7bRT+oGAWioPUNzQ5HRo6KsPsnye3xv4d3XUoOYe/DYhCrM
+        QPfKaX561wacSAlsZhDRiqELU7kN0LuMsJe0WbFtsaBujlXHKpGsmuVgA33fxBqCSSqc+SIlSHOI
+        yZ/j2l8g0S2pnVh0+WIfMxsIjgEHgUyZasrZqQNrRXT1NdOQ5l4/2EKmvo2NIjkzL1yMa6Zke70d
+        D/h+5TC1imd+MPMsA5ibRGZb8UbsaU60mIa4lsry4xQ0PgA7VjVWuc9mQK7d248xk0f9J+FwNAnA
+        5izdbpiHBlYqEjuXwTpJHNwZT2QmdhN5VeOtcpRGO1UI48jUavtYMZPUtpRn01JCbw405jqDQMeU
+        aEh3ZkEf22oI0ke2ehalc5yfBK+XqTtA1zMxztioeURXfwMAAP//AwB/1XPtMxIAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"9e60360062438128abc26bb1ceaaf9f1"']
+      etag: ['"682ba48c7f4b876f588aafb72d6053b3"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -131,40 +131,40 @@ interactions:
     body: <transaction><amount>20.91</amount></transaction>
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/jd6gq8/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/7995xd/submit_for_settlement
   response:
     body:
       string: !!binary |
-        H4sIAHjak1UAA9xYTW/jNhC9768IfGck2U7iBIoWCxQFemhRYHd76CWgqJHFWCK1JOXY++s7FCVZ
-        iqhsgKLAojdr5pGcL74ZOv54qsqrIyjNpXhcRdfh6goEkxkX+8fV1y+/kt3qY/IhNooKTZlBVPLh
-        6irmWfKc3e6/7eIAf1qJNtQ0OtFNWnFjIHvKpXrSYEwJFQgTBx3AYs25hkTTEuKg/WllrFEKTz4T
-        riVBAyD5+vmXOJiLLZhWshEmWYfX91EcdF9WUYFiBRWGUMaskKB12qT3h+3d9+/p81rd3jzHgQ9l
-        V0uVgcKPK8HLx5VRDawCZ5wCij4Raq6swY+rDD8Nr2CFNkQ3JLwjYfQlWj9Edw83u7/R7GFBu76p
-        s3eu3z2EIa6/LOiCo41Eq+2Hi34Ubbebm/W2jz9Kc660IYJW8Np+VJZ0WcdkVVNx9migorz0yF8g
-        1dz49qoLKXzynJ5mUQ3GbsUpL0usuouL25f/1jltFADWQJYp0Nrn/cmAyGwWFiGlZLTkxre9gj3e
-        Fl+IJF6F0hXz/TYK7+JgLOrNxrpU52WvnNquILSsC7p+F2rzI5RoMB+czXM1Sg+6ljci812UQaO7
-        QqdK0fNEifEcsYlvkwtrkJQaVngxBa/rcbn4au5/WTNvZPCnKZZxdjryIjmHMtO9P1QZznhNHfmu
-        8QpMJSN+GK2M6VETUEoqgsGtpdDgjUmLG8Vsik5+x57xJqDfYpruV6Df3C5vYlr/j8f5yrnQQvdI
-        +i/0jJpncNcD+4ieV0RcK8nwNIwDbUwhFf9OW7hzLwo3f2ITeRM03WVqShSG4Xj53FCPzmDpJ59q
-        1Bwh865uEW1os4xbSzD4c9jM16PkzCYox8TjCiy6FNQ8Io3t6XiKa+ILKENPxI0LXhWcoKr7Hp1K
-        WQIVqySnpbajygDoZwL0gjCq+h5l5AFEkh6K+luF8PbLaVIukm0YrXc7S6RiTEHbJNrtcIjpPrpb
-        hpuSdjT6i2uK1TJ89yxTc+WSWUlhiiTCGzQTzrBnoAoHjnU4AbfS7tyuIRPLUe2w9/XzpU1fpBcr
-        C1m24fYzD6/oHkijyqQwptYPQUA1sru+ThXlwl6cruKvkXKRAs6W9J8qwGrNnkq5l8ER/b+uxf4j
-        iCNXUljAo6YiS+UJx4Nhf3deI/i3BrrkI40gmCN7qGS7YbttlGeMbdgmv73d3N7kcIP3hMEOUoZp
-        WVzaEZaCmiIv/SFtabvfTlMALU2BscCJVRyEfBFxMJI5UAYpNxe9++xUjcKSwPreN6Wd+Uao15qh
-        O9kBltPyAh3JeoI9K1mOEL2gS4zWDfIz9ldxuGAm0infy5xYLRXMDuaf7IlzRR8qmTWsZfHL6ReZ
-        Ax1BVJLo7LBw2QZ91wmml617bZCCY2Wq82TWGDp1iwDcqIu0vaE4cqOiqt8xxt8jgw74YYfuFdMT
-        qmW6y8OmRSy9TVyBaqwoJQtuatqUB7y1rWSwbzQYaYmMBgmtOdoxlzsvg7mb/9Lz7gGy6Pl7Hng/
-        QRwGSVcirkeU1D9wNqlmiteLA+lIPzB6Ow6TGgcgmRGc+YgNqYcDXyHRLGW8WDT51Tm2URLsiZ5Z
-        OuO6vYFeHbhdZE9eC+y89FZDPp3bNt0UJ1X7Mke/Fu7voHe9El/bAua7Ys6PtrnnAEtt2R4rX4jL
-        5kyLYUgbpd1jIQODz9V+xJyq/LkZvTT8x08xsz8j3gmHkw0AdirlN8M+i7BSccr1bdgw5nlIYEYW
-        fLee140BX2l0LZZwgWNr0/5sxwrHr0+WX+NgCTQd/EaOTufD8ey3CPrxXu20+KO9hpHSFDhMELxe
-        tu4ATc/lNGIT8kg+/AMAAP//AwAArOyd+RIAAA==
+        H4sIAMBKDlYAA9xYQW/rNgy+91cUuau207RJCtfFO2zAMGwY1td3eJdCtulYrS15kpwm+/WjLNux
+        Y7ktMAwbdovJTxRJUeSnhA+Hsrjcg1RM8PtFcOUvLoEnImV8d794+voj2SweootQS8oVTTSioovL
+        y5Cl0Xq7vTmkoYc/jURpqmsVqToumdaQPmdCPivQuoASuA69FmCw+lhBpGgBodf8NLKklhJ3PhKm
+        BEEHIPrh6ffQm4oNmJai5jpa+lfbIPTaL6MoQSY55ZrQJDFCgt7FLxoUOuDSmTVCpiDx45Kz4n6h
+        ZQ0Lz7okgWIkhOpL4+b9IsVPzUpY4M7BDQl84i+/+tu74Pru+uY7OtsvaNbXVfr59be4/rSgTYnS
+        Ar02H23Ob/3N8ibwu6yjNGNSacJpCef+o7Kg87pElBXlR4cGSsoKh/wNYsW0y1aVC+6SZ/Qwyao3
+        DCuMWVFgrZ1CrNJ/NjilJQDWQJpKUMoV/UEDT80pzEIKkdCCaZd5CTu8I64UCbwAhS3h7Srw16E3
+        FHVuY13K43xUVm1WEFpUOV1+CnX9EYrXeB4smZ7V4HgwtKzmqeui9BrVFjqVkh5HSsznoIe4jFRU
+        aobpOPWMsxUu47TWuZDsz4/ND8zGVCe5E5OzqhpWo6uk/5cl+U6B/GdqcXg6bW8kGYMiVV08poIS
+        VlHb25d4w8aSQfsZrAzpXhGQUkiCya0EV+DMSYMb5GyMjn7BQfQuoDMxPu4z0E/WyruYJv79frpy
+        KjTQHc6UN3pEzQvY64FjSk0rIqykSHA3zEN3rWgDbyz9/PjbevMNU/oeaGxl7Erg+/5w+dRRh05j
+        6UdfKtTsIXWubhBNatOUGU8w+VPYJNa9YIk5oAwPHldg0cUgpxmpDWXAXSxHmEFpeiCWgzhVcICy
+        6ihALEQBlC+ijBbK8J8e0FEOjIIkVHYjUItX4FF2vbt+2SG8+bKamPFo5QfLzcb0aT5sQaso2GyQ
+        GbUf7S1Do6ThW9+Yolgt/XfXZSom7WGWgus8CvAGTYQT7BGoRD6z9EfgRtru2857YnpUwyCfHk8s
+        4CQ9eZmLokm3u/Owku6A1LKIcq0rded5VGF3V1expIybi9NW/BW2XGwBR9P0n0vAak2fC7ET3h7j
+        v6r47gH4nknBDeBeUZ7G4oDso7ffthUJFcXu8aswBWh/W00OtNA5egzRE3/l4o2H3kBmQSnETJ/0
+        9rNV1RIPDqtwVxeG+A1Q55p+hhgWi2PyBB3IujZ4lKIYIDpBmz6lauyiOAX56wkzko67ssiI0VKe
+        YJiPX8yOU0WXKpHWSdNrT7ufZBZUc/ZHDe1lQjEmn2E3llG22m6C1XodX6+WyWaVrLd+tl7FdLtd
+        blZZsEWCPLfUWt4DLwVR6evMZev17SQYX7b2CUNyhpUpjyO20U/qBgFoqD1Dc0OR0aOirD75Sujx
+        vYX2aXQiM8PXUoOYe/DYhCrMQPfKaT561wacSAlsZhDRiqELU7kN0JtG+PeDvn0v6M88GP/dFPSS
+        tjDsZCiom2bWsUokq2Zp6EDf9/GGY5MKaY9ICTI9YrLp6HxnSHRLaicWXT7bx4xHgpPQwaFTppob
+        7dSBtSK6KzbTk+cegNhFp76NjSI/NY98jGvm1vZ6OyHxCc9hahXPfG9GegYwN4zNtuKN2NOcaDEN
+        cS2VfSKkoPEN3BHLscp9NoP3hXv7MWbyv8Yn4XAwCcD5JN1umLcWVipyW5fBOkkczwc8kZnYTeRV
+        jbfKURrtYCWMI1mt7XvNkAnbVZ9NVw29OdCY7g0CHbPCIeObBX1sq+GIH9nqiaTOkUIQvF6m7gBd
+        z8Q4Y6PmEV38BQAA//8DAOXlBQBEEwAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"f6e2f3f32d31e9f0a38283203fc24923"']
+      etag: ['"4d9cec199944f7deaa314459c810f37e"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -173,40 +173,40 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/jd6gq8
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/7995xd
   response:
     body:
       string: !!binary |
-        H4sIAHvak1UAA9xYTW/jNhC9768IfGck2U7iBIoWCxQFemhRYHd76CWgqJHFWCK1JOXY++s7FCVZ
-        iqhsgKLAojdr5pGcL74ZOv54qsqrIyjNpXhcRdfh6goEkxkX+8fV1y+/kt3qY/IhNooKTZlBVPLh
-        6irmWfKc3e6/7eIAf1qJNtQ0OtFNWnFjIHvKpXrSYEwJFQgTBx3AYs25hkTTEuKg/WllrFEKTz4T
-        riVBAyD5+vmXOJiLLZhWshEmWYfX91EcdF9WUYFiBRWGUMaskKB12qT3h+3d9+/p81rd3jzHgQ9l
-        V0uVgcKPK8HLx5VRDawCZ5wCij4Raq6swY+rDD8Nr2CFNkQ3JLwjYfQlWj9Edw83u7/R7GFBu76p
-        s3eu3z2EIa6/LOiCo41Eq+2Hi34Ubbebm/W2jz9Kc660IYJW8Np+VJZ0WcdkVVNx9migorz0yF8g
-        1dz49qoLKXzynJ5mUQ3GbsUpL0usuouL25f/1jltFADWQJYp0Nrn/cmAyGwWFiGlZLTkxre9gj3e
-        Fl+IJF6F0hXz/TYK7+JgLOrNxrpU52WvnNquILSsC7p+F2rzI5RoMB+czXM1Sg+6ljci812UQaO7
-        QqdK0fNEifEcsYlvkwtrkJQaVngxBa/rcbn4au5/WTNvZPCnKZZxdjryIjmHMtO9P1QZznhNHfmu
-        8QpMJSN+GK2M6VETUEoqgsGtpdDgjUmLG8Vsik5+x57xJqDfYpruV6Df3C5vYlr/j8f5yrnQQvdI
-        +i/0jJpncNcD+4ieV0RcK8nwNIwDbUwhFf9OW7hzLwo3f2ITeRM03WVqShSG4Xj53FCPzmDpJ59q
-        1Bwh865uEW1os4xbSzD4c9jM16PkzCYox8TjCiy6FNQ8Io3t6XiKa+ILKENPxI0LXhWcoKr7Hp1K
-        WQIVqySnpbajygDoZwL0gjCq+h5l5AFEkh6K+luF8PbLaVIukm0YrXc7S6RiTEHbJNrtcIjpPrpb
-        hpuSdjT6i2uK1TJ89yxTc+WSWUlhiiTCGzQTzrBnoAoHjnU4AbfS7tyuIRPLUe2w9/XzpU1fpBcr
-        C1m24fYzD6/oHkijyqQwptYPQUA1sru+ThXlwl6cruKvkXKRAs6W9J8qwGrNnkq5l8ER/b+uxf4j
-        iCNXUljAo6YiS+UJx4Nhf3deI/i3BrrkI40gmCN7qGS7YbttlGeMbdgmv73d3N7kcIP3hMEOUoZp
-        WVzaEZaCmiIv/SFtabvfTlMALU2BscCJVRyEfBFxMJI5UAYpNxe9++xUjcKSwPreN6Wd+Uao15qh
-        O9kBltPyAh3JeoI9K1mOEL2gS4zWDfIz9ldxuGAm0infy5xYLRXMDuaf7IlzRR8qmTWsZfHL6ReZ
-        Ax1BVJLo7LBw2QZ91wmml617bZCCY2Wq82TWGDp1iwDcqIu0vaE4cqOiqt8xxt8jgw74YYfuFdMT
-        qmW6y8OmRSy9TVyBaqwoJQtuatqUB7y1rWSwbzQYaYmMBgmtOdoxlzsvg7mb/9Lz7gGy6Pl7Hng/
-        QRwGSVcirkeU1D9wNqlmiteLA+lIPzB6Ow6TGgcgmRGc+YgNqYcDXyHRLGW8WDT51Tm2URLsiZ5Z
-        OuO6vYFeHbhdZE9eC+y89FZDPp3bNt0UJ1X7Mke/Fu7voHe9El/bAua7Ys6PtrnnAEtt2R4rX4jL
-        5kyLYUgbpd1jIQODz9V+xJyq/LkZvTT8x08xsz8j3gmHkw0AdirlN8M+i7BSccr1bdgw5nlIYEYW
-        fLee140BX2l0LZZwgWNr0/5sxwrHr0+WX+NgCTQd/EaOTufD8ey3CPrxXu20+KO9hpHSFDhMELxe
-        tu4ATc/lNGIT8kg+/AMAAP//AwAArOyd+RIAAA==
+        H4sIAMFKDlYAA9xYQW/rNgy+91cUuau207RJCtfFO2zAMGwY1td3eJdCtulYrS15kpwm+/WjLNux
+        Y7ktMAwbdovJTxRJUeSnhA+Hsrjcg1RM8PtFcOUvLoEnImV8d794+voj2SweootQS8oVTTSioovL
+        y5Cl0Xq7vTmkoYc/jURpqmsVqToumdaQPmdCPivQuoASuA69FmCw+lhBpGgBodf8NLKklhJ3PhKm
+        BEEHIPrh6ffQm4oNmJai5jpa+lfbIPTaL6MoQSY55ZrQJDFCgt7FLxoUOuDSmTVCpiDx45Kz4n6h
+        ZQ0Lz7okgWIkhOpL4+b9IsVPzUpY4M7BDQl84i+/+tu74Pru+uY7OtsvaNbXVfr59be4/rSgTYnS
+        Ar02H23Ob/3N8ibwu6yjNGNSacJpCef+o7Kg87pElBXlR4cGSsoKh/wNYsW0y1aVC+6SZ/Qwyao3
+        DCuMWVFgrZ1CrNJ/NjilJQDWQJpKUMoV/UEDT80pzEIKkdCCaZd5CTu8I64UCbwAhS3h7Srw16E3
+        FHVuY13K43xUVm1WEFpUOV1+CnX9EYrXeB4smZ7V4HgwtKzmqeui9BrVFjqVkh5HSsznoIe4jFRU
+        aobpOPWMsxUu47TWuZDsz4/ND8zGVCe5E5OzqhpWo6uk/5cl+U6B/GdqcXg6bW8kGYMiVV08poIS
+        VlHb25d4w8aSQfsZrAzpXhGQUkiCya0EV+DMSYMb5GyMjn7BQfQuoDMxPu4z0E/WyruYJv79frpy
+        KjTQHc6UN3pEzQvY64FjSk0rIqykSHA3zEN3rWgDbyz9/PjbevMNU/oeaGxl7Erg+/5w+dRRh05j
+        6UdfKtTsIXWubhBNatOUGU8w+VPYJNa9YIk5oAwPHldg0cUgpxmpDWXAXSxHmEFpeiCWgzhVcICy
+        6ihALEQBlC+ijBbK8J8e0FEOjIIkVHYjUItX4FF2vbt+2SG8+bKamPFo5QfLzcb0aT5sQaso2GyQ
+        GbUf7S1Do6ThW9+Yolgt/XfXZSom7WGWgus8CvAGTYQT7BGoRD6z9EfgRtru2857YnpUwyCfHk8s
+        4CQ9eZmLokm3u/Owku6A1LKIcq0rded5VGF3V1expIybi9NW/BW2XGwBR9P0n0vAak2fC7ET3h7j
+        v6r47gH4nknBDeBeUZ7G4oDso7ffthUJFcXu8aswBWh/W00OtNA5egzRE3/l4o2H3kBmQSnETJ/0
+        9rNV1RIPDqtwVxeG+A1Q55p+hhgWi2PyBB3IujZ4lKIYIDpBmz6lauyiOAX56wkzko67ssiI0VKe
+        YJiPX8yOU0WXKpHWSdNrT7ufZBZUc/ZHDe1lQjEmn2E3llG22m6C1XodX6+WyWaVrLd+tl7FdLtd
+        blZZsEWCPLfUWt4DLwVR6evMZev17SQYX7b2CUNyhpUpjyO20U/qBgFoqD1Dc0OR0aOirD75Sujx
+        vYX2aXQiM8PXUoOYe/DYhCrMQPfKaT561wacSAlsZhDRiqELU7kN0JtG+PeDvn0v6M88GP/dFPSS
+        tjDsZCiom2bWsUokq2Zp6EDf9/GGY5MKaY9ICTI9YrLp6HxnSHRLaicWXT7bx4xHgpPQwaFTppob
+        7dSBtSK6KzbTk+cegNhFp76NjSI/NY98jGvm1vZ6OyHxCc9hahXPfG9GegYwN4zNtuKN2NOcaDEN
+        cS2VfSKkoPEN3BHLscp9NoP3hXv7MWbyv8Yn4XAwCcD5JN1umLcWVipyW5fBOkkczwc8kZnYTeRV
+        jbfKURrtYCWMI1mt7XvNkAnbVZ9NVw29OdCY7g0CHbPCIeObBX1sq+GIH9nqiaTOkUIQvF6m7gBd
+        z8Q4Y6PmEV38BQAA//8DAOXlBQBEEwAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"4b13142cde81a851cbcfaf7a2fb034c1"']
+      etag: ['"30cf385ba2e1f0471ca6832695478d5a"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -215,83 +215,83 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/jd6gq8/void
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/7995xd/void
   response:
     body:
       string: !!binary |
-        H4sIAHzak1UAA9xYTW/jNhC9768IfGck2U7iBIoWCxQFemhRYLs99BJQ1MhiLJFaknLs/fUdipIs
-        RVQ2QFFgsTdr5pGcL848Ov54qsqrIyjNpXhcRdfh6goEkxkX+8fVl79+JbvVx+RDbBQVmjKDqOTD
-        1VXMs+Q5u91/3cUB/rQSbahpdHKUPIMsDrpPqzHnGhJNS4iD9qeVsUYpPOdMuJYEj4Pky+df4mAu
-        tmBayUaYZB1e30dx0H1ZRQWKFVQYQhmzQoK2aJPeH7Z3376lz2t1e/McBz6UXS1VBgo/rgQvH1dG
-        NbAKnHEKqIGMUHNlDX5cZfhpeAUrtCG6IeEdCaO/ovVDdPdws/sHzR4WtOubOnvn+t1DuMX1lwVd
-        cLSRaLX9cLGOou12c7Pe9tFGac6VNkTQCl7bj8qSLuuYrGoqzh4NVJSXHvkLpJob3151IYVPntPT
-        LKrB2K045WWJNXZxcfvy/zqnjQLAGsgyBVr7vD8ZEJnNwiKklIyW3Pi2V7DHu+ELkcSrULpivt9G
-        4V0cjEW92ViX6rzslVPbFYSWdUHX70JtvocSDeaDs3muRulB1/JGZL6LMmh0V+hUKXqeKDGeo97h
-        20SDMSVUgBczpYYVXkzB63pcLr6a+ylr5o0M/jDFMs5O17xIzqHMdO8PVYYzXlPXfNd4BaaSUX8Y
-        rYzpURNQSiqCwa2l0OCNSYsbxWyKTn7HmfEmoN9imu5XoN/cLm9iWv+Px/nKudBC99j0X+gZNc/g
-        rgfOET2viLhWkuFpGAfamEIq/o22cOdeFG7+xCHyJmi6y9SUKAzD8fK5oR6dwdJPPtWoOdpxv4Ro
-        Q5tl3FqCwZ/DZr4igWA2QTkmHldg0aWg5hFp7EzHU9wQX0AZeiKOLnhVcIKq7md0KmUJVKySnJba
-        UpUB0HMC9IIwqvoZZeQBRJIeivprhfD2y2lSLpJtGK13O9tIxbgFbZNot0MS0310tww3JS01+ptr
-        itUyfPddpubKJbOSwhRJhDdoJpxhz0AVEo51OAG30u7cbiAT26Naavfl82VMX6QXKwtZtuH2dx5e
-        0T2QRpVJYUytH4KAauzu+jpVlAt7cbqKv8aWiy3gbJv+UwVYrdlTKfcyOKL/17XYfwRx5EoKC3jU
-        VGSpPCE9GPZ35zWCf22gSz62EQRz7B4q2W7YbhvlGWMbtslvbze3Nznc4D1hsIOUYVoWl3YNS0FN
-        sS/9IW1pu99OUwAtTYGxQMYqDkK+iDgYyRwog5Sbi959dqpGYUlgfe+b0nK+Eeq1ZphOlsByWl6g
-        I1nfYM9KliNEL+gSo3WD/RnnqzhcMBPptN/LnFgtFcwS80/2xLmiD5XMGtZ28cvpF5kDHUFUkujs
-        sHDZBn03CaaXrXtbkIJjZarzhGsMk7pFAG7URdreUKTcqKjqd9D4e+ygA37YoXvF9A11+rBpEUtv
-        E1egGitKyYKbmjblAW9tKxnsGxEjLbGjQUJrjnbM5c7LYO7mf/QcHyDhW57rJq24wWp8yqV6ulC1
-        nzAO27fiMH/W/gBeD5LuYrjJWFI/zW5SzRSvF2n4SD/MsfYRQGqkfTIjyHSJDaCn879ColnKeLFo
-        8qtzLD0gyAQ8L4iM67bveHXgdpF9y16YSUsvVJwic9ummyI/t/9HoF8LXWvQO4ZQUCFgvivm/Ggp
-        TQ6wREbssfKFuGzOtBiGtFHaPZEyMPhI74n1VOXPzeh95T9+ipn9BfNOOJxsAHA+K78Z9jGIlYrc
-        3rdhw5jn+YQZWfDdel43Bnyl0RELwgWS9ab92ZIpN1We7FSJgyXQlO6OHJ2y4jHjXQR9f6+WI39v
-        r4FImwIpFMHrZesO0PRcTiM2aR7Jh38BAAD//wMAYLeqXd0TAAA=
+        H4sIAMJKDlYAA9xYQW/rNgy+91cUuau207RJCtfFO2zAMGwY1td32KWQbTpWa0ueJKfJfv0oy3bs
+        Wk4LDMOGd4vJTxRJUeSnhA+Hsrjcg1RM8PtFcOUvLoEnImV8d794+voj2SweootQS8oVTTSioovL
+        y5Cl0Xq7vTmkoYc/jURpqmsV7QVLAaXtp9HoYwWRogWEXvPTyJJaStznSJgSBLeD6Ien30NvKjZg
+        Woqa62jpX22D0Gu/jKIEmeSUa0KTxAgJ+hK/aFA69Fw6s0bIFCR+XHJW3C+0rGHhWZckUA0pofrS
+        uHm/SPFTsxIWuHNwQwKf+Muv/vYuuL67vvkDne0XNOvrKv38+ltcf1rQpkRpgV6bjzbDt/5meRP4
+        XY5RmjGpNOG0hPf+o7Kg87pElBXlR4cGSsoKh/wNYsW0y1aVC+6SZ/Qwyao3DCuMWVFgZZ1CrNJ/
+        NzilJQDWQJpKUMoV/UEDT80pzEIKkdCCaZd5CTu8Ea4UCbwAhS3h7Srw16E3FHVuY13K43xUVm1W
+        EFpUOV1+CnX9EYrXeB4smZ7V4HgwtKzmqeui9BrVFjqVkh5HSsznoGO4jFRUaobpUKB1ASXgBR2v
+        cBmntc6FZH99bH5gNqY6yZ2YnFXVsBpdJf1dluSZAvnf1OLwdNreSDIGRaq6eEwFJayitrcv8YaN
+        JYP2M1gZ0r0iIKWQBJNbCa7AmZMGN8jZGB39goPoLKAzMT7ud6CfrJWzmCb+/X66cio00B3OlDd6
+        RM0L2OuBY0pNKyKspEhwN8xDd61oA28s/fz423rzDVN6DjS2MnYl8H1/uHzqqEOnsfSjLxVq9oZD
+        zCGa1KYpM55g8qewSazIShJzQBkePK7AootBTjNSG8qAu1iOMIPS9EAsB3Gq4ABl1VGAWIgCKF9E
+        GS2U4T89oKMcGAVJqOxGoBavwKPsenf9skN482U1MePRyg+Wm43p03zYglZRsNkgM2o/2luGRknD
+        t74xRbFa+u+uy1RM2sMsBdd5FOANmggn2CNQiXxm6Y/AjbTdt533xPSohi8+PZ5YwEl68jIXRZNu
+        d+dhJd0BqWUR5VpX6s7zqMLurq5iSRk3F6et+CtsudgCjqbpP5eA1Zo+F2InvD3Gf1Xx3QPwPZOC
+        G8C9ojyNxQHZR2+/bSsSKord41dhCtD+tpocaKFz9BiiJ/7KxRsPvYHMglKImT7p7WerqiUeHFbh
+        ri4M8Rug3mv6GWJYLI7JE3Qg69rgUYpigOgEbfqUqrGL4hTkryfMSDruyiIjRkt5gmE+fjE7ThVd
+        qkRaJ02vPe1+kllQzdmfNbSXCcWYfIbdWEbZarsJVut1fL1aJptVst762XoV0+12uVllwRYJ8txS
+        a3kPvBREpa8zl63Xt5NgfNnaBwvJGVamPI7YRj+pGwSgofYMzQ1FRo+KsvrkK6HH9xbap9GJzAxf
+        Sw1i7sFjE6owA90rp/noXRtwIiWwmUFEK4YuTOU2QG8a4T8P+vZc0KqOS6axxJ8zIZ9PLO37SsHm
+        XAqmL+T/NuBe0t4EOwoL6ubVdawSyapZ3j3Q94OreVSQCnmeSAlSW2Jy52j175DoltROLLr8bh/D
+        BwiOfsejIWWqaWFOHVgrouspM0No7sWLY2Pq29goEnLzrwbGNdOmer2lBDnlHKZW8cz3hsNkAHPs
+        w2wr3og9zYkW0xDXUtk3UQoaH/0dkx6r3GczeFC5tx9jJn/kfBIOB5MAHMjS7YZ5XGKlIpl3GayT
+        xPFewhOZid1EXtV4qxyl0TIJwjiy89o+UA17smPk2YyR0JsDjfntINAxDR5S3FnQx7YaUvyRrZ45
+        6xw5E8HrZeoO0PVMjDM2ah7Rxd8AAAD//wMAomXkkCMUAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"d30ef6033918c8b77b6dff79c0170550"']
+      etag: ['"7b91ab248c49a6a20d179d1af031addb"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>20.91</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>20.91</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAH7ak1UAA9xXS2/jNhC+768wfGck+ZF1FoqCBYoCPbRAu5seellQ1NhiLJFaknLs/fUdipIs
-        RVSSHgoUvUkzH4fznmH8cC6LxQmU5lLcL6ObcLkAwWTGxeF++fj1Z7JbPiQfYqOo0JQZRCUfFouY
-        Z8ndcVNud3GAn5aiDTW1Tmhtcqn4D8jioCVZrrlUkGhaQBw0n5bGaqXwrgvhWhK8EpLHLz/FwZRs
-        wbSUtTDJKry5i+Kg/bOMEhTLqTCEMmaJBPXRJkXtPv74kT6t1O32KQ58KHtaqgwU/iwEL+6XRtWw
-        DJxyCqiBjFCzsArfLzP8NbyEJeoQbUn4kYTR12j1Kdp9Cm//QrX7A835usr+2fnrgdY52kjU2v44
-        f0fRZrPerjadx5G650obImgJL/VHZkHneUyWFRUXDwdKygsP/RlSzY1PVpVL4aPv6Xni1WBoVpzy
-        osA8u5q4ef53jdNGAWAOZJkCrX3Wnw2IzEZhFlJIRgtufOIVHLA+fC6SWAqFS+a7TRR+jIMhqVMb
-        81Jd5q1ybHuC0KLK6epdqPVbKFFjPDibxmoQHjRtX4vMVyg9R7eJTpWilxET/TnoHz4hGowpoAQs
-        zJQalnsxOa+qYbr4cu5/mTOvRPA/kyzD6LTNi+w5FJnu7KHKcMYr6prvCktgTBn0h8HJmJ40AaWk
-        IujcSgoNXp80uIHPxujkV5wZrwI6EeNwvwD94qS8imnsP52mJ6dECz1g03+mF+Q8gSsPnCN6mhFx
-        pSTD29AP3YilDbyRFN798fX2d3Tpa6CxlLEqURiGw+NTRT08g6mffK6Qc7Ljfg7RuDbLuNUEnT+F
-        TWw9Sc5sgPYYeDyBSZeCmnqktjMdb3FDfAZl6Jm4dcHLgjOUVTejUykLoGKZ7Gmh7arSA7qdAK0g
-        jKpuRhl5BJGkx7z6XiK8+XOclItkE0ar3c42UjFsQZsk2u1wiWl/2ipDoaRZjf7kmmK29P9dl6m4
-        csEspTB5EmEFTYgT7AWowoVjFY7ADbW9tx3IxPaoZr17/HId01fqVctcFo27/Z2Hl/QApFZFkhtT
-        6U9BQDV2d32TKsqFLZw242+w5WILuNim/60EzNbsWyEPMjih/TeVODyAOHElhQXcayqyVJ5xPejl
-        u/tqwb/X0AYf2wiCOXYPlWzWbLeJ9hlja7be396ub7d72EbhmsEOUoZhmT3aNiwFFcW+9Ju0qe2+
-        HScHWpgcfYEbqzgK+SziYEBzoAxSbq5899uyaoUpgfl9qAu78w1QLzn9dLILLKfFFTqgdQ32omQx
-        QHSENjBa19ifcb6K4xUzoo77vdwTy6WC2cX8s71xyuhcJbOaNV38evuV5kAnEKUkOjvOFFvPbyfB
-        uNja9wXJOWamuox2jX5SNwhAQa2nbYXiyo2MsnrnGt7jewmvPmwaxNzbxCWoxoxSMuemonVxxKpt
-        KL1+g8VIS+xokNCKox5TurMyeGlmT2ld43pjQf2LVp1qpng1u4gN+H0na9ZAUuHglxnBXYdYJ3pq
-        /wUS1VLGi0WVX9xjBwTBWeDZITOum8zz8sBJkV3RznSluTcK9pGpbmOhuKHZFynaNZO3Pd/NCHxl
-        CphKxZif7FDbA8yNI3utfCYumhMuuiGtlXZLcgYGn2ndajVm+WMz2LD9148xk0f4O+Fwtg7ADq38
-        atjnAGYqbnc+gTVjngUaIzJju7W8qg34UqMdLYQLXNfq5rMZp66vfLN9JQ7mQOOFZ2DoeC8a7jyz
-        oLdlNVvSW7L6VcrkOEQJlpfNO0DV93LssVHzSD78DQAA//8DAI5f6fXjEQAA
+        H4sIAMRKDlYAA9xXwW7jNhC971cYvjOSbKe2A0XBHlqghxbo7mYL7CWgpJHFRCJVknLsfn2HoiRL
+        FpXkUqDoTZp5HM4MhzOP4cOpLBZHkIoJfr8MbvzlAngiUsYP98vHb7+Q3fIh+hRqSbmiiUZU9Gmx
+        CFkarV+26b4KPfw0EqWprlVEa50Lyf6GNPRakdHqcwWRogWEXvNpZEktJe51JkwJgltC9PPjl9Cb
+        ig2YlqLmOlr5N/sg9No/oyhBJjnlmtAkMUKC/sTPGpQOPZfOrBEyBYk/C86K+6WWNSw965IEqiEl
+        VC+Mm/fLFH81K2GJOwe3JPCJv/rm7++C9d16/wOd7Rc06+sq/fD6jY/rLwvalCgt0GvzY7O8/cnf
+        rW4Dv8szSjMmlSaclnDtPyoLOq9LRFlRfnZooKSscMhfIVZMu2xVueAueUZPk6x6w7DCmBUFVtcl
+        xCr9d4NTWgJgDaSpBKVc0Z808NScwiykEAktmHaZl3DAW+FKkcALUNgS3m8Cfxt6Q1HnNtalPM9H
+        ZdVmBaFFldPVh1Dr91C8xvNgyfSsBseDoWU1T10XpdeottCplPQ8UmI+B13DZaSiUjNMhwKtCygB
+        L+h4hcv4pcG8Z35gNqY6yZ2YnFXVsBpdJf2/LMk3CuQ/U4vD02l7I8kYFKnq4jEVlLCK2t6+whs2
+        lgzaz2BlSI+KgJRCEkxuJbgCZ04a3CBnY3T0Gw6iNwGdifFxX4F+tVbexDTxH4/TlVOhgR5wprzS
+        M2qewV4PHFNqWhFhJUWCu2EeumtFG3hj6cvtnz/+2GFK3wKNrYxdCXzfHy6fOurQaSz96HOFmqPh
+        EHOIJrVpyownmPwpbBLrUbDEHFCGB48rsOhikNOM1IYy4C6WI8ygND0Ry0GcKjhBWXUUIBaiAMqX
+        UUYLZfhPD+goB0ZBEiq7EajFC/AoWx/WzweEN39WEzMebfxgtduZPs2HLWgTBbsdMqP2p71laJQ0
+        fOs7UxSrpf/vukzFpD3MUnCdRwHeoIlwgj0DlchnVv4I3Ejbfdt5T0yPajjj49cLC7hIL17momjS
+        7e48rKQHILUsolzrSt15HlXY3dVNLCnj5uK0FX+DLRdbwNk0/acSsFrTp0IchHfE+G8qfngAfmRS
+        cAO4V5SnsTgh++jtt21FQkWxe/wuTAHab6vJgRY6R48heuQvXLzy0BvILCiFmOmL3v62qlriwWEV
+        HurCEL8B6lrTzxDDYnFMXqADWdcGz1IUA0QnaNOnVI1dFKcgf7lgRtJxVxYZMVrKEwzz62ez41TR
+        pUqkddL02svuF5kF1Zz9VUN7mVCMyWfYjWWUbfa7YLPdxuvNKtltku3ez7abmO73q90mC/ZIkOeW
+        WstH4KUgKn2ZuWy9vp0E48vWPlpIzrAy5XnENvpJ3SAADbVnaG4oMnpUlNUHWX6P7y28+VpqEHMP
+        HptQhRnoXjnNT+/agBMpgc0MIloxdGEqtwF61xH2kjYrti0W1M2x6lglklWzHGyg75tYQzBJhTNf
+        pARpDjH5c1z7KyS6JbUTiy5f7WNmA8Ex4CCQKVNNOTt1YK2Irr5mGtLc6wdbyNS3sVEkZ+aFi3HN
+        lGyvt+MB368cplbxzI9mnmUAc5PIbCteiT3NiRbTENdSWX6cgsYHYMeqxir32QzItXv7MWbyqP8g
+        HE4mAdicpdsN89DASkVi5zJYJ4mDO+OJzMRuIq9qvFWO0minCmEcmVptHytmktqW8mRaSujNgcZc
+        ZxDomBIN6c4s6H1bDUF6z1bPonSO85Pg9TJ1B+h6JsYZGzWP6NM/AAAA//8DAI42eQwzEgAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"cf179f240b042b2fc85a1c5e2c993c1a"']
+      etag: ['"e9a6306686bd72b98aad83ba8745b158"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -300,40 +300,40 @@ interactions:
     body: <transaction><amount>15.76</amount></transaction>
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/9k4m58/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/3k7d9p/submit_for_settlement
   response:
     body:
       string: !!binary |
-        H4sIAITak1UAA9xYS2/jNhC+51cYvjOS/IqzULRYoCjQQwu0u9lDLwFFjSyuJVJLUo6dX9+hXpYi
-        KhugaFH0Zs18JOfFb4YOP56LfHECpbkUD8vg1l8uQDCZcHF4WD5++Znslx+jm9AoKjRlBlHRzWIR
-        8iS6P26K7T708KeVaENNpSNdxQU3BpKnVKonDcbkUIAwodcCLNZcSog0zSH06p9Wxiql8OQL4VoS
-        NACix88/hd5UbMG0kJUwUbC9vduFXvtlFQUollFhCGXMCglap02Mtt69vMTfVmq3/RZ6LpRdLVUC
-        Cj8WgucPS6MqWHqNcQoo+kSoWViDH5YJfhpewDJa+cGW+HfED74Eqw/B/oO/+xPN7hfU66syeff6
-        YIXrrwva4Ggj0Wr70UQ/CDab9Xa16eKP0pQrbYigBby2H5U5ndcxWZRUXBwaKCjPHfJniDU3rr3K
-        TAqXPKXnSVS9oVthzPMcq+7q4ub5n3VOGwWANZAkCrR2eX82IBKbhVlILhnNuXFtr+CAt8UVIolX
-        IW+K+X4T+HehNxR1ZmNdqsu8V43ariA0LzO6ehdq/SOUqDAfnE1zNUgPupZWInFdlF6j20KnStHL
-        SInxHLCJa5Mra5CYGpY5MRkvy2G5uGruf1kzb2TwP1Msw+y05EVSDnmiO3+oMpzxkjbku8IrMJYM
-        +GGwMqQnTUApqQgGt5RCgzMmNW4QszE6+hV7xpuAbotxul+Bfml2eRNT+386TVdOhRZ6QNJ/phfU
-        fIPmemAf0dOKCEslGZ6GcaCVyaTiL7SG1zv593982f2OIX0LNN5lbErg+/5w+dRQh85g6UefStSc
-        IHGurhF1aJOEW0sw+FPYxNeT5MwmKMXE4wosuhjUNCKV7el4StPEZ1CGnkkzLjhVcIai7Hp0LGUO
-        VCyjlObajio9oJsJ0AvCqOp6lJFHEFF8zMrvBcLrr0YTcxFt/GC131siFUMK2kTBfh+EXvvR3jLc
-        lNSj0VeuKVZL/92xTMlVk8xCCpNFAd6giXCCvQBVOHCs/BG4lrbntg2ZWI6qh73Hz9c2fZVercxk
-        XofbzTy8oAcglcqjzJhSf/A8qpHd9W2sKBf24rQVf4uUixRwsaT/VABWa/KUy4P0Tuj/bSkOH0Gc
-        uJLCAh40FUkszzge9Ps351WCf6+gTT7SCII5soeKNmu23wRpwtiardPdbr3bprAN/DWDPcQM0zK7
-        tCUsBSVFXvpN2tJufjeaDGhuMowFTqziKOSzCL2BrAElEHNz1TefrapSWBJY34cqtzPfAPVa03cn
-        O8Byml+hA1lHsBcl8wGiE7SJ0bpCfsb+Ko5XzEg65nuZEqulgtnB/JM9caroQiWTitUsfj39KmtA
-        JxCFJDo5zly2Xt92gvFla18bJONYmeoymjX6Tl0jADdqI21vKI7cqCjKd47xPb7foX3FdIRqme76
-        sKkR7Wtk5d/eB8O3SVOgGitKyYybklb5EW9tLentGwxGWiKjQURLjnZM5Y2X3tTNv+15/QCZ9fw9
-        D7xhHCZvtH8nDr2kLZGmR+TUPXBWsWaKl7MD6UDfM3o9DpMSByCZEJz5iA2pgwNfIdEsZZxYNPnV
-        ObZREuyJjlk64bq+gU4dNLvIjrxm2HnurYZ8OrVtvClOqvZljn7N3N9e3/RKfG0LmO6KOT/Z5p4C
-        zLVle6x8Jk02J1oMQ1wp3TwWEjD4XO1GzLHKnZvBS8N9/Bgz+TPinXA42wBgp1JuM+yzCCsVp1zX
-        hhVjjocEZmTGd+t5WRlwlUbbYgkXOLZW9c96rGj49cnya+jNgcaD38DR8Xw4nP1mQT/eq54Wf7RX
-        P1KaDIcJgtfL1h2g6akcR2xEHtHNXwAAAP//AwDct7JM+RIAAA==
+        H4sIAMVKDlYAA9xYUW/jNgx+768o8q7aTtJLUrgu7mED9rABu7tuwL0Usk3Ham3Jk+Q02a8fZdmO
+        HcttgeGAYW8x+YkiKYr8lPDhWBbXB5CKCX6/CG78xTXwRKSM7+8Xj99+JtvFQ3QVakm5oolGVHR1
+        fR2yNFq9bNJdFXr400iUprpWkarjkmkN6VMm5JMCrQsogevQawEGq08VRIoWEHrNTyNLailx5xNh
+        ShB0AKKfHr+E3lRswLQUNddRcHuz+RR67ZdRlCCTnHJNaJIYIUHv4mcNCh1w6cwaIVOQ+HHNWXG/
+        0LKGhWddkkAxEkL1tXHzfpHip2YlLKKlH9ySwCf+8pu/uwtWd6vdd3S2X9Csr6v0w+vXAa4/L2hT
+        orRAr82Hzfnmk79d3gZ+l3WUZkwqTTgt4dJ/VBZ0XpeIsqL85NBASVnhkL9CrJh22apywV3yjB4n
+        WfWGYYUxKwqstXOIVfpjg1NaAmANpKkEpVzRHzXw1JzCLKQQCS2YdpmXsMc74kqRwAtQ2BLerQN/
+        E3pDUec21qU8zUdl1WYFoUWV0+WHUKv3ULzG82DJ9KwGx4OhZTVPXRel16i20KmU9DRSYj4HPcRl
+        pKJSM0zHuWdcrHAZp7XOhWR/v29+YDamOsmdmJxV1bAaXSX9vyzJNwrkP1OLw9NpeyPJGBSp6uIx
+        FZSwitrevsQbNpYM2s9gZUgPioCUQhJMbiW4AmdOGtwgZ2N09CsOojcBnYnxcV+AfrFW3sQ08R8O
+        05VToYHucaa80hNqnsFeDxxTaloRYSVFgrthHrprRRt4Y+nL7Z/ff99iSt8Cja2MXQl83x8unzrq
+        0Gks/ehzhZoDpM7VDaJJbZoy4wkmfwqbxHoQLDEHlOHB4wosuhjkNCO1oQy4i+UIMyhNj8RyEKcK
+        jlBWHQWIhSiA8kWU0UIZ/tMDOsqBUZCEym4EavECPMpW+9XzHuHNl9XEjEdrP1hut6ZP82ELWkfB
+        dhuEXvvR3jI0Shq+9QdTFKul/+66TMWkPcxScJ1HAd6giXCCPQGVyGeW/gjcSNt923lPTI9qGOTj
+        1zMLOEvPXuaiaNLt7jyspHsgtSyiXOtK3XkeVdjd1U0sKePm4rQVf4MtF1vAyTT9pxKwWtOnQuyF
+        d8D4byq+fwB+YFJwA7hXlKexOCL76O23bUVCRbF7/CZMAdrfVpMDLXSOHkP0yF+4eOWhN5BZUAox
+        02e9/WxVtcSDwyrc14UhfgPUpaafIYbF4pg8Qweyrg2epCgGiE7Qpk+pGrsoTkH+csaMpOOuLDJi
+        tJQnGObXz2bHqaJLlUjrpOm1593PMguqOfurhvYyoRiTz7Abyyhb77bBerOJV+tlsl0nm52fbdYx
+        3e2W23UW7JAgzy21lg/AS0FU+jJz2Xp9OwnGl619wpCcYWXK04ht9JO6QQAaas/Q3FBk9Kgoqw+w
+        fB9Zfo/vLbRPozOZGb6WGkT7xFn6N7tg+OCxCVWYge6V03z0rg04kRLYzCCiFUMXpnIboDeN8N8H
+        HbwV9EcejMMUTN58PzwFvaQtDDsZCuqmmXWsEsmqWRo60Pd9vOHYpELaI1KCTI+YbDo63wUS3ZLa
+        iUWXL/Yx45HgJHRw6JSp5kY7dWCtiO6KzfTkuQcgdtGpb2OjyE/NIx/jmrm1vd5OSHzCc5haxTM/
+        mJGeAcwNY7OteCX2NCdaTENcS2WfCClofAN3xHKscp/N4H3h3n6Mmfyv8UE4HE0CcD5JtxvmrYWV
+        itzWZbBOEsfzAU9kJnYTeVXjrXKURjtYCeNIVmv7XjNkwnbVJ9NVQ28ONKZ7g0DHrHDI+GZB79tq
+        OOJ7tnoiqXOkEASvl6k7QNczMc7YqHlEV/8AAAD//wMAGHlQmUQTAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"28baf59c4a3e1b380c1822545a184649"']
+      etag: ['"03559a3ddcf74a1327932f4b2eef2c9c"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -342,83 +342,83 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/9k4m58/void
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/3k7d9p/void
   response:
     body:
       string: !!binary |
-        H4sIAIbak1UAA9xYS2/jNhC+51cEvjOS/IqzULRYoCjQQwu0u+mhl4CiRhbXEqklKcfOr+9QL0sR
-        5Q1QFNj2Zs18JOfFmY8OP56K/PYISnMpHhfBnb+4BcFkwsX+cfH05WeyW3yMbkKjqNCUGURFN7e3
-        IU+ih8O62OxCD39aiTbUVDo6Sp5AEnrtp9WYcwmRpjmEXv3TylilFJ5zJlxLgsdB9PT5p9Cbii2Y
-        FrISJgo2d/fb0Gu/rKIAxTIqDKGMWSFBW7SJ0bL719f461JtN19Dz4Wyq6VKQOHHreD548KoChZe
-        Y5wCaiAh1Nxagx8XCX4aXsAiWvrBhvj3xA++BMsPwe6Dv/0Lze4X1OurMnn3+mCN6y8L2uBoI9Fq
-        +9HEOgjW69Vmue6ijdKUK22IoAW8tR+VOZ3XMVmUVJwdGigozx3yF4g1N669ykwKlzylp0lUvaFb
-        YczzHGvs4uL65d91ThsFgDWQJAq0dnl/MiASm4VZSC4Zzblxba9gj3fDFSKJVyFvivlhHfj3oTcU
-        dWZjXarzvFeN2q4gNC8zunwXavU9lKgwH5xNczVID7qWViJxXZReo9tCp0rR80iJ8Rz0DtcmGozJ
-        oQC8mDE1LHNiMl6Ww3Jx1dz/smauZPCHKZZhdtrmRVIOeaI7f6gynPGSNs13iVdgLBn0h8HKkB41
-        AaWkIhjcUgoNzpjUuEHMxujoV5wZVwHdFuN0vwH90uxyFVP7fzxOV06FFrrHpv9Cz6j5Cs31wDmi
-        pxURlkoyPA3jQCuTScVfaQ2vd/If/viy/R1Deg003mVsSuD7/nD51FCHzmDpR59K1BztuJ9D1KFN
-        Em4tweBPYRNfkUAwm6AUE48rsOhiUNOIVHam4ynNEJ9BGXoiDV1wquAERdnN6FjKHKhYRCnNtaUq
-        PaDjBOgFYVR1M8rIA4goPmTltwLh9VejibmI1n6w3O1sIxXDFrSOgt0uCL32o71luCmpqdGfXFOs
-        lv676zIlV00yCylMFgV4gybCCfYMVCHhWPojcC1tz20HMrE9qqZ2T58vY/oivViZybwOt7vz8ILu
-        gVQqjzJjSv3B86jG7q7vYkW5sBenrfg7bLnYAs626T8XgNWaPOdyL70j+n9Xiv1HEEeupLCAR01F
-        EssT0oN+/+a8SvBvFbTJxzaCYI7dQ0XrFdutgzRhbMVW6Xa72m5S2AT+isEOYoZpmV3aNiwFJcW+
-        9Ju0pd38bjQZ0NxkGAtkrOIg5IsIvYGsASUQc3PRN5+tqlJYEljf+yq3nG+Aeqvpp5MlsJzmF+hA
-        1jXYs5L5ANEJ2sRoXWF/xvkqDhfMSDru9zIlVksFs8T8kz1xquhCJZOK1V38cvpF1oCOIApJdHKY
-        uWy9vp0E48vWvi1IxrEy1XnENfpJXSMAN2ojbW8oUm5UFOU7aXyP73doXzFdQx0/bGpE+xpZ+ncP
-        wfBt0hSoxopSMuOmpFV+wFtbS3r7BsRIS+xoENGSox1TeeOlN3XzH3seLK95rqu44Aar8TmV6vlC
-        1ebiMHmj/XfisL4Wh+mz9gfwupe0F6OZjDl10+wq1kzxcpaGD/T9HKsfAaRE2icTgkyX2AA6Ov8b
-        JJqljBOLJr85x9IDgkzA8YJIuK77jlMHzS6ya9kzM2nuhYpTZGrbeFPk5/b/CPRrpmv1+oYhZFQI
-        mO6KOT9aSpMCzJERe6x8IU02J1oMQ1wp3TyREjD4SO+I9Vjlzs3gfeU+foyZ/AXzTjicbABwPiu3
-        GfYxiJWK3N61YcWY4/mEGZnx3XpeVgZcpdESC8IFkvWq/lmTqWaqPNupEnpzoDHdHTg6ZsVDxjsL
-        +v5eNUf+3l49kTYZUiiC18vWHaDpqRxHbNQ8opu/AQAA//8DAIxFnn3dEwAA
+        H4sIAMZKDlYAA9xYTW/jNhC9768IfGck2c7aDhQFe2iBHlqgu5stsJeAkkYWE4lUScqx++s7FCVZ
+        iignQFH042bNPA5nhsOZR4f3x7K4OoBUTPC7RXDtL66AJyJlfH+3ePj6I9ku7qMPoZaUK5poREUf
+        rq5Clkar5026q0IPfxqJ0lTXKjoIlkIaeu2n0ehTBZGiBYRe89PIklpK3OdEmBIEt4Poh4fPoTcV
+        GzAtRc11FNxcbz6GXvtlFCXIJKdcE5okRkjQl/hJg9Kh59KZNUKmIPHjirPibqFlDQvPuiSBakgJ
+        1VfGzbtFip+albCIln5wQwKf+Muv/u42WN2udt/R2X5Bs76u0nevXwe4/rygTYnSAr02HzbDm4/+
+        dnkT+F2OUZoxqTThtITX/qOyoPO6RJQV5SeHBkrKCof8BWLFtMtWlQvukmf0OMmqNwwrjFlRYGWd
+        Q6zSvzc4pSUA1kCaSlDKFf1RA0/NKcxCCpHQgmmXeQl7vBGuFAm8AIUt4d068DehNxR1bmNdytN8
+        VFZtVhBaVDldvgu1egvFazwPlkzPanA8GFpW89R1UXqNagudSklPIyXmc9AxXEYqKjXDdCjQuoAS
+        8IKOV7iM01rnQrI/3jY/MBtTneROTM6qaliNrpL+X5bkhQL519Ti8HTa3kgyBkWqunhMBSWsora3
+        L/GGjSWD9jNYGdKDIiClkASTWwmuwJmTBjfI2Rgd/YyD6CKgMzE+7legn6yVi5gm/sNhunIqNNA9
+        zpQXekLNE9jrgWNKTSsirKRIcDfMQ3etaANvLH2++e37r1tM6SXQ2MrYlcD3/eHyqaMOncbSjz5V
+        qDkYDjGHaFKbpsx4gsmfwiaxIitJzAFlePC4AosuBjnNSG0oA+5iOcIMStMjsRzEqYIjlFVHAWIh
+        CqB8EWW0UIb/9ICOcmAUJKGyG4FaPAOPstV+9bRHePNlNTHj0doPltut6dN82ILWUbDdBqHXfrS3
+        DI2Shm99Y4pitfTfXZepmLSHWQqu8yjAGzQRTrAnoBL5zNIfgRtpu28774npUQ1ffPhyZgFn6dnL
+        XBRNut2dh5V0D6SWRZRrXalbz6MKu7u6jiVl3FyctuKvseViCziZpv9YAlZr+liIvfAOGP91xff3
+        wA9MCm4Ad4ryNBZHZB+9/batSKgodo9fhClA+9tqcqCFztFjiB74MxcvPPQGMgtKIWb6rLefraqW
+        eHBYhfu6MMRvgHqt6WeIYbE4Js/QgaxrgycpigGiE7TpU6rGLopTkD+fMSPpuCuLjBgt5QmG+eWT
+        2XGq6FIl0jppeu1597PMgmrOfq+hvUwoxuQz7MYyyta7bbDebOLVepls18lm52ebdUx3u+V2nQU7
+        JMhzS63lA/BSEJU+z1y2Xt9OgvFlax8sJGdYmfI0Yhv9pG4QgIbaMzQ3FBk9KsrqHSzfR5bf43sL
+        7dPoTGaGr6UG0T5xlv71Lhg+eGxCFWage+U0H71rA06kBDYziGjF0IWp3AboTSP860EHl4JWdVwy
+        jSX+mAn5eGZpcymYvPn+EylYXkrB9IX8zwbcS9qbYEdhQd28uo5VIlk1y7sH+n5wNY8KUiHPEylB
+        aktM7hyt/hUS3ZLaiUWXX+1j+ADB0e94NKRMNS3MqQNrRXQ9ZWYIzb14cWxMfRsbRUJu/tXAuGba
+        VK+3lCCnnMPUKp75wXCYDGCOfZhtxQuxpznRYhriWir7JkpB46O/Y9JjlftsBg8q9/ZjzOSPnHfC
+        4WgSgANZut0wj0usVCTzLoN1kjjeS3giM7GbyKsab5WjNFomQRhHdl7bB6phT3aMPJoxEnpzoDG/
+        HQQ6psFDijsLettWQ4rfstUzZ50jZyJ4vUzdAbqeiXHGRs0j+vAnAAAA//8DALddn+IjFAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"09a8be3f241f4f80c11e1ffbdc4b013e"']
+      etag: ['"955766bde92033f80aab765d581a94fb"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>20.91</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>20.91</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAIjak1UAA9xXzW7jNhC+5ykC3xlZtpM4gaJgi6JAC7SH7qZAewkoamwxlkgtSTl2nn6HoiRL
-        FpXkUqDoTZr5OJz/GUaPhyK/3IPSXIqHWXg1n12CYDLlYvswe/r2C1nPHuOLyCgqNGUGUfHF5WXE
-        05itX5d36yjAT0vRhppKx7QymVT8DdIoaEiWa44lxJrmEAX1p6WxSim860i4lgSvhPjp689RMCZb
-        MC1kJUy8mF/dhVHQ/FlGAYplVBhCGbNEgvpok9ztVrdvb8nLQt1cv0SBD2VPS5WCwp9LwfOHmVEV
-        zAKnnAJqICXUXFqFH2Yp/hpewAx1CK/J/JbMw2/h4j5c34fX/6Da3YH6fFWmnz9/g+dPBxrnaCNR
-        a/vj/B2Gq9XyerFqPY7UDVfaEEELONcfmTmd5jFZlFQcPRwoKM899FdINDc+WWUmhY++oYeRV4O+
-        WVHC8xzz7GTi6vXfNU4bBYA5kKYKtPZZfzAgUhuFSUguGc258YlXsMX68LlIYinkLpnvVuH8Ngr6
-        pFZtzEt1nLbKse0JQvMyo4tPoZYfoUSF8eBsHKteeNC0TSVSX6F0HN0kOlWKHgdM9Gevf/iEaDAm
-        hwKwMBNqWObFZLws++niy7n/Zc68E8H/TLL0o9M0L7LhkKe6tYcqwxkvqWu+CyyBIaXXH3onI7rX
-        BJSSiqBzSyk0eH1S43o+G6Lj33FmvAtoRQzDfQb61Ul5F1Pbv9+PT46JFrrFpv9Kj8h5AVceOEf0
-        OCOiUkmGt6Ef2hFLa3gtafHbn3//hEPkXdBQylCVcD6f94+PFfXwDKZ+/KVEzt6O+ylE7do05VYT
-        dP4YNrJ1LzmzAdpg4PEEJl0CauyRys50vMUN8QmUoQfi1gUvCw5QlO2MTqTMgYpZvKG5tqtKB2h3
-        ArSCMKraGWXkDkSc7LLye4Hw+s9xEi7i1TxcrNe2kYp+C1rF4XqNS0zz01QZCiX1avQX1xSzpftv
-        u0zJlQtmIYXJ4hAraEQcYY9AFS4ci/kAXFObe5uBTGyPqte7p6+nMX2inrTMZF672995eEG3QCqV
-        x5kxpb4PAqqxu+urRFEubOE0GX+FLRdbwNE2/ecCMFvT51xuZbBH+69KsX0EsedKCgt40FSkiTzg
-        etDJd/dVgn+voAk+thEEc+weKl4t2XoVblLGlmy5ublZ3lxv4DqcLxmsIWEYlsmjTcNSUFLsS39I
-        m9ru23EyoLnJ0Be4sYqdkK8iCno0B0oh4ebEd78Nq1KYEpjf2yq3O18Pdc7pppNdYDnNT9AerW2w
-        RyXzHqIlNIHRusL+jPNV7E6YAXXY7+WGWC4VzC7mX+yNY0brKplWrO7ip9tPNAfagygk0eluotg6
-        fjMJhsXWvC9IxjEz1XGwa3STukYACmo8bSsUV25kFOUn1/AO30l492FTI6beJi5BNWaUkhk3Ja3y
-        HVZtTen06y1GWmJHg5iWHPUY052VwbmZHaVxjeuNOfUvWlWimeLl5CLW43edrF4DSYmDX6YEdx1i
-        neip/TMkqqWMF4sqn91jBwTBWeDZIVOu68zz8sBJkW3RTnSlqTcK9pGxbkOhuKHZFynaNZG3Hd/N
-        CHxlChhLxZjv7VDbAEyNI3utfCUumiMuuiGplHZLcgoGn2ntajVk+WPT27D91w8xo0f4J+FwsA7A
-        Dq38atjnAGYqbnc+gRVjngUaIzJhu7W8rAz4UqMZLYQLXNeq+rMep66vPNu+EgVToOHC0zN0uBf1
-        d55J0Mey6i3pI1ndKmUyHKIEy8vmHaDqGzn02KB5xBc/AAAA//8DAIXvkqvjEQAA
+        H4sIAMdKDlYAA9xXTXOjOBC951e4fFcAx7O2U4TUHHaqtvbjMJPMYS8pAY1RAhIjCcfeX78tBBiM
+        SLKHrdraG3Q/tbpbre6n8P5YFosDSMUEv1sG1/5yATwRKeP7u+XjwxeyXd5HV6GWlCuaaERFV4tF
+        yNJo82PzvElDDz+NRGmqaxXRWudCsr8ANa3IaPWpgkjRAkKv+TSypJYS9zoRpgTBLSH6+fFr6E3F
+        BkxLUXMdrfzrXRB67Z9RlCCTnHJNaJIYIUF/4mcNSoeeS2fWCJmCxJ8FZ8XdUssalp51SQLVkBKq
+        F8bNu2WKv5qVsMSdg08k8Im/evB3t8HN7frmT3S2X9Csr6v0n60/L2hTorRAr81Pm+Wf/O3qU+B3
+        eUZpxqTShNMSLv1HZUHndYkoK8pPDg2UlBUO+SvEimmXrSoX3CXP6HGSVW8YVhizosDqOodYpf9u
+        cEpLAKyBNJWglCv6owaemlOYhRQioQXTLvMS9ngrXCkSeAEKW8K7deBvQm8o6tzGupSn+ais2qwg
+        tKhyuvoQ6uY9FK/xPFgyPavB8WBoWc1T10XpNaotdColPY2UmM9B13AZqajUDNOhQOsCSsALOl7h
+        Mn5uMO+ZH5iNqU5yJyZnVTWsRldJ/y9L8o0C+c/U4vB02t5IMgZFqrp4TAUlrKK2t6/who0lg/Yz
+        WBnSgyIgpZAEk1sJrsCZkwY3yNkYHf2Og+hNQGdifNwXoF+slTcxTfyHw3TlVGige5wpr/SEmmew
+        1wPHlJpWRFhJkeBumIfuWtEG3lj68uvX3/wHTOlboLGVsSuB7/vD5VNHHTqNpR99rlBzMBxiDtGk
+        Nk2Z8QSTP4VNYj0IlpgDyvDgcQUWXQxympHaUAbcxXKEGZSmR2I5iFMFRyirjgLEQhRA+TLKaKEM
+        /+kBHeXAKEhCZTcCtXgBHmU3+5vnPcKbP6uJGY/WfrDabk2f5sMWtI6C7RaZUfvT3jI0Shq+9Z0p
+        itXS/3ddpmLSHmYpuM6jAG/QRDjBnoBK5DMrfwRupO2+7bwnpkc1nPHx25kFnKVnL3NRNOl2dx5W
+        0j2QWhZRrnWlbj2PKuzu6jqWlHFzcdqKv8aWiy3gZJr+UwlYrelTIfbCO2D81xXf3wM/MCm4Adwp
+        ytNYHJF99PbbtiKhotg9/hCmAO231eRAC52jxxA98hcuXnnoDWQWlELM9Flvf1tVLfHgsAr3dWGI
+        3wB1qelniGGxOCbP0IGsa4MnKYoBohO06VOqxi6KU5C/nDEj6bgri4wYLeUJhvnts9lxquhSJdI6
+        aXrtefezzIJqzn7U0F4mFGPyGXZjGWXr3TZYbzbxzXqVbNfJZudnm3VMd7vVdp0FOyTIc0ut5QPw
+        UhCVvsxctl7fToLxZWsfLSRnWJnyNGIb/aRuEICG2jM0NxQZPSrK6oMsv8f3Ft58LTWIuQePTajC
+        DHSvnOand23AiZTAZgYRrRi6MJXbAL3LCHtJmxXbFgvq5lh1rBLJqlkONtD3TawhmKTCmS9SgjSH
+        mPw5rv0FEt2S2olFly/2MbOB4BhwEMiUqaacnTqwVkRXXzMNae71gy1k6tvYKJIz88LFuGZKttfb
+        8YDvVw5Tq3jmBzPPMoC5SWS2Fa/EnuZEi2mIa6ksP05B4wOwY1VjlftsBuTavf0YM3nUfxAOR5MA
+        bM7S7YZ5aGClIrFzGayTxMGd8URmYjeRVzXeKkdptFOFMI5MrbaPFTNJbUt5Mi0l9OZAY64zCHRM
+        iYZ0Zxb0vq2GIL1nq2dROsf5SfB6mboDdD0T44yNmkd09TcAAAD//wMAaPcVqjMSAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"83934ea4071831ab16f72a0f993aa473"']
+      etag: ['"75969662633ada035e435f56bb57c751"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -427,38 +427,38 @@ interactions:
     body: <transaction><amount>20.92</amount></transaction>
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/c8w398/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/7q7j7d/submit_for_settlement
   response:
     body:
       string: !!binary |
-        H4sIAInak1UAA+RYS4/bNhC+768wfOfK8mPjDbQKUhQFWqA9NEmB9rKgpJHFtUQqJOW18+s71JOS
-        KWfRQ1GgN3Hm43A4HM58VPDhXOSLE0jFBH9a+ver5QJ4LBLGD0/LL59/Ivvlh/AuoCUjIKWQRIIq
-        BVcQ3i0WQS1S5rMfLPSlhKcllZJell6r0pJyRWONizQSN7zTddphjBJ0CsJHf7deB179bSup1pJF
-        lYbWnroUkciXIS1ExXXg9frRrAKUogcIP4HWORTA9aKZsGDomBCLnMoD3AdeBxz880YOtsMuEt5k
-        v7Y6KKmkhboRmMaFcL26f8SttiO3YYNuBqqKCqafUyGfVb8bnG1DY8G1FHkOMrTsKBPOXnHXBkbG
-        GeWasCR8eTy8JulLcjxfiiw5SBONQdvg8SPev24e94HXyAJv2OY/CvN1ZK4XQZnSVFcqpJXOhGTf
-        IAm8VtTGF7MhVDQHDJ35bANRSYlZfiFMCVLn0pdPP2IYrsR30wPxJwfSh4LGsRGbkCgdPR637759
-        i17W8mH3YgXMQjXzhUxA4nDBWf601LKC/s7EEqiGhFDd5nSCQ80KWKIn/o6s3pGV/9lfv/f37/3d
-        X+h+P6G1UJXJ2y08oIVhQh8opUUBQ56j476/3W526+1wCihPmVSacFrA9U5QndNb2lgUJeUXpw4K
-        ynKn5hUixbTbYpkJ7tak9OyItTfeaBCxPMcKaG97+/rvbFhpCYCZkiRYaZU7JmcNPDHndAOUi5jm
-        TLsXkXDAe+UOncALlDfp/7j1V+/wKluiYQuYx/Jya48NwMwiNC8zun4jbvN9HK/wrFjsOsnR0eFG
-        04on7gvW69w9q1FjlK1K5DY0FFwSUR1nM6iMleU4qdwZ+j/IrJsn/J9LqfHJtUWRpAzyRA27o1Kz
-        mJVtX1zXHdCWjCrNaHZAT2rCrmaiVCOtOI7x4a/YnW4CBiPjZJjAfm7s3MS0sTidrudeCxvwAZvL
-        K72g7gWa64QdS7myJSiliHFNjEjX2mk9oba2/uX3P3/AdnUTNLUzdshfrVa2AZe7Dq3GCxJ+LFFz
-        MlRjDtGGOUmY8QeP4hro2PNJsNgcWIqpgHMwISOQrthUhk3gWg15mMVpeiYtz3Ir4QxF2XGDSIgc
-        KF+GKc2VoUs9YOAjuB8SUzl0QS2OwMPomJVfC5xSjzpdxHi4Xfnr/d4UZT4uYNvQ3++RTLWD/kai
-        cVITtT+YophJ/XioUCWTzTEXyFqz0MebdiV0oC9AJdKe9WoEr6X96i0JIKbC1cTzy6eBGgxS29tM
-        5PUhzNUsViChJZXMw0zrUr33PKqwX6j7SFLGzQVrb8U9lm4sGRfTRp4LwHxOnnNxEN4JI3Ff8sMH
-        4CcmBTeAJ0V5EokzUpLefrdixdnXCtq0wMKDcIbVRobbTbzf+mkSx5t4kz48bB52Kez81SaGPUQx
-        HtPs1L7ISSgp1rLfhEn+5rvTZUBznWFMkE3zIxevPPAsWQdLIGJ6QDTDXllJTBW8A4cqN0zUwk01
-        Vscz9JrRfABbsqE8X8wLZ8B0gv6glKqwxmMH58cBNZJO+4ZIidFTHpsHxEez7rViCJ1IqrjuBIMP
-        g6yDnYAXgqjkOHMte33fT6bXsn0TkYxh3sqL84HdYQDN9dE39xkfB6gqyjc+GHq8ZeM7T7KmNM6+
-        qJoUVphzUmRMl7TKj3jDa4nlp0XJlMB6CCEt2eh53Mn7F/r1lntZG6quvuZ0juhVkYolK29QQQth
-        VcKakpISCYZICDIsYgLrrBcTLDoo9Qwa3b9azTQdgv3FyWgTpuoMndFCY8v6qzFb1ebfV1iJXJ5O
-        jSNPNK9t3OlMnvf6rvvg+5mDyzZmxsk0zhRgvt2Z5cUrac7bocfQRJVUDYlPQOOjc6B2Y+XcyVmv
-        gDk3xqir3w1vngBnEw6s+3LOGfN0wbxGjuk2WsWxk97jSc1GwsShrDS406dtXYRxpI1V/Vk37qY+
-        PZv6FHhzoCnhsjY9ZmY255oFvcVazdO+Z80iczrDVk3wQpq8BNxAKqbRm/ydw7rm+Gn6NwAAAP//
-        AwAhVJCGcRUAAA==
+        H4sIAMhKDlYAA+RYS3PjNgy+51d4fFck2c7a3lGU2UN3ptPHYXezh14ylARZTCRSS1KO3V9fUE9K
+        ppy0h05nehOBjyDxEQRABQ+nIl8cQUjK2f3Sv/WWC2AxTyg73C8fv312dsuH8CYgJXVACC4cAbLk
+        TEJ4s1gEtUjqz36wUOcS7pdECHJeuq1KCcIkiRUu0kjs8E7XaYcxSnBTEO79u9UqcOtvU0mUEjSq
+        FLT25LmIeL4MScErpgK3149mFSAlOUD4FZTKoQCmFs2EBcWNcb7IiTjAbeB2wGF/7miD7bBjwp34
+        a6qDkghSyCvENFsIV97tHl1tR3bDGt0MZBUVVD2lXDzJ3hucbUJjzpTgeQ4iNOxITWevuGmJEXFG
+        mHJoEqpSxWV2SMSHeP1yfBGajUHb4PFj+2P7vE0Ct5EF7uDmP6L5kpnLRVAmFVGVDEmlMi7on4C6
+        VtTyi9EQSpIDUqc/WyIqITDKzw6V3Klj6afHL0jDhfhmeiD+5EB6Kkgca7GmJHpWIJVBk6FrZnGR
+        gMDhgtH8fqlEBf1NiQUQBYlDVBvJCQ4VLWCJ6/t3ju853uqbt//orz9u1n/gpvsJrYWqTP6ehWFC
+        T49UvIAhujXzH7zd6s73Bu5RnlIhlcNIAZeeoDon17QxL0rCzlYdFITmVs0rRJIqu8Uy48yuScnJ
+        wrU7djSIaJ5j3jPdLpN/x2GpBABGSpJgfpV2Tk4KWKLP6Qoo5zHJqbIvIuCAt8lOHcdrkzdBv9/4
+        3hYvsCEaXMA4FudrPjYAPcsheZmR1Ttx67dxrMKzorHtJEdHh46mFUvsF6zX2StVo0aWjfxjN4QJ
+        TlEkaEi3kzn2BYZU9fYShumIqDibQWW0LMdxa78E/4PgvRpE/7moHZ9cm3edlEKeyME7HWcxLduC
+        u6pLqykZJbPR7IAc5aRtm2GpRho8jvHhb1j2rgIGI+NgmMB+buxcxbRcHI+Xcy+FDfiA9euVnFH3
+        DM11wqIobdESlILHuCYy0l1EUk+orX3+5cuv3jck+Bpoame8Id/zPNOAbbsWrcILEn4qUXPUPcwc
+        oqU5SajeDx7FJdDi85HTWB9YiqGAczAgIxA2birdsOBaTX8yi1Pk5LQNnF0JJyjKrv2IOM+BsGWY
+        klzqPqwHDC0P+uPERAyFVvEXYGG6PqyfDzilHnW6iLJw4/mr3U7nfTZOYJvQ3+2wS2sH/Y1E407d
+        AX6nkmAk9eMhQ5VUNMdcYDuchT7etAuhBX0GIrCzWnkjeC3tV2/7DEdnuLqjffw6dB+D1NxtxvP6
+        EOZyFi2wU3YqkYeZUqX86LpEYr2Qt5EglOkL1t6KW0zdmDLOuow8FYDxnDzl/MDdIzJxW7LDA7Aj
+        FZxpwL0kLIn4Cbue3n6fiASUBPPN71wHaPPd6TIgucpw3xA+shfGX1ngGrIOlkBE1YBohr2yEnic
+        GKeHKtcNqYGbaoyqpLtsLMMD2JANKfSsnzcDphP0ZEpZYR7GKsteBtRIOs3tPHW0nrAYXf76Sa97
+        qRio40kV19l62MMg62AVoz8qaC8eKvBAKOZzEaab/c7fbLfRerOKd5t4u/fS7SYi+/1qt0n9PTbx
+        c1M720dgBXdk8jJzLXt9X0+m17J9bDkZxbgVZ+vLvcMAmutPVt9nfH+gqijf+Sbp8YaNN956TWqc
+        fao1BEtkpHuf1QNji0Y3JjmmQghJSUdP7k7ev/ovve1lLUtdas3JXI9XRTIWtLzSBRoIIwnWDa9T
+        Ym/BEwebK0dzak0VEyxuUKgZNG7/YjVdbxwsLdZ2NqGyDvwZLTS2jD8lswlt/vWGSci206lxbBH1
+        Cx49nQnxXt8VHnydM7DZxsg46pqZAsxXOr08f3Wa87bokZqoErLp3xNQ+KQdurqxcu7kjAfA3DbG
+        qItfGO+eACdNB6Z8MbcZ/TDCuMb20m60imNrZ48nNcuE5qGs8D5aw6etWg5l2DFWzRNL1+wmNT3p
+        1BS4c6Bpr2U4PW7KzHZrFvQea3WL9pY1o49TGVZpBy+kjktAB1I+ZW/yxw9TmuVH7F8AAAD//wMA
+        VwdlAMUVAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
@@ -471,40 +471,40 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/c8w398/void
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/7q7j7d/void
   response:
     body:
       string: !!binary |
-        H4sIAIvak1UAA9xYTW/jNhC951cYvjOybCdxAkXBFkWBFmgP3U2B9hJQ1NhiLJFaknLs/fU7FCVZ
-        iqgkQFFg0Zs180jOF2ceHT0ci3x2AKW5FPfz8HIxn4FgMuVidz9//PIL2cwf4ovIKCo0ZQZR8cVs
-        FvE0ZpuX1e0mCvCnlWhDTaXjg+QppFHQfFqNOZUQa5pDFNQ/rYxVSuE5J8K1JHgcxI+ff46CsdiC
-        aSErYeLl4vI2jILmyyoKUCyjwhDKmBUStEWb5Ha/vvn2LXlequur5yjwoexqqVJQ+DETPL+fG1XB
-        PHDGKaAGUkLNzBp8P0/x0/AC5mhDeEUWN2QRfgmXd+HmLrz6B83uFtTrqzL9+PoNrj8vaIKjjUSr
-        7YeLdRiu16ur5bqNNkq3XGlDBC3gtf2ozOm0jsmipOLk0UBBee6Rv0CiufHtVWZS+ORbehxFNei7
-        FSU8z7HGzi6uX/5b57RRAFgDaapAa5/3RwMitVmYhOSS0Zwb3/YKdng3fCGSeBVyV8y363BxEwV9
-        UWs21qU6TXvl1HYFoXmZ0eWHUKv3UKLCfHA2zlUvPejathKp76J0Gt0UOlWKngZKjGevd/g20WBM
-        DgXgxUyoYZkXk/Gy7JeLr+b+lzXzRgZ/mGLpZ6dpXmTLIU916w9VhjNeUtd8l3gFhpJef+itjOhB
-        E1BKKoLBLaXQ4I1JjevFbIiOf8eZ8Sag3WKY7legX90ub2Jq/w+H8cqx0EJ32PRf6Ak1z+CuB84R
-        Pa6IqFSS4WkYB1qZTCr+jdbweqflb3/+/RMOkTdBw12GpoSLxaK/fGyoR2ew9ONPJWoOdtxPIerQ
-        pim3lmDwx7CRr0ggmE3QFhOPK7DoElDjiFR2puMpbohPoAw9EkcXvCo4QlG2MzqRMgcq5vGW5tpS
-        lQ7QcgL0gjCq2hll5B5EnOyz8muB8PrLaRIu4vUiXG42tpGKfgtax+FmgySm+WhuGW5Kamr0F9cU
-        q6X7brtMyZVLZiGFyeIQb9BIOMKegCokHMvFAFxLm3ObgUxsj6qp3ePn85g+S89WZjKvw+3vPLyg
-        OyCVyuPMmFLfBQHV2N31ZaIoF/biNBV/iS0XW8DJNv2nArBa06dc7mRwQP8vS7F7AHHgSgoLuNdU
-        pIk8Ij3o9nfnVYJ/raBJPrYRBHPsHiper9hmHW5TxlZstb2+Xl1fbeEqXKwYbCBhmJbJpU3DUlBS
-        7Et/SFva7rfTZEBzk2EskLGKvZAvIgp6MgdKIeHmrHefjapSWBJY37sqt5yvh3qt6aaTJbCc5mdo
-        T9Y22JOSeQ/RCprEaF1hf8b5KvZnzEA67PdyS6yWCmaJ+Sd74ljRhkqmFau7+Pn0s8yBDiAKSXS6
-        n7hsnb6ZBMPL1rwtSMaxMtVpwDW6SV0jADdqIm1vKFJuVBTlB2j4NXbQDt/t0Lxi2oY6fNjUiKm3
-        iStQjRWlZMZNSat8j7e2lnT29YiRltjRIKYlRzvGcudlMHbz33u+ecvz8XPuB/C6kzQF4SZCTv30
-        sko0U7ycpJ89fde/a/JLSqQ7MiXI8IgNoKfjvUKiWcp4sWjyq3PsWCQ4AT3MOeW6vm9eHbhdZNuq
-        Jnrx1MsMu+fYtuGmyEvtOxz9mritnd5NRnxbCxjvijk/2FG+BZgawvZY+UJcNkdaDENSKe2eBikY
-        fJy2hHKo8uem967wHz/EjP56+CAcjjYAOJeU3wz7CMJKRU7r27BizPNswIxM+G49LysDvtJoBirh
-        AklqVf+sSYTrpk+2m0bBFGhI83qODtlgn+lNgt7fq+aG7+3VEUiTIXUgeL1s3QGavpXDiA2aR3zx
-        HQAA//8DAIr+0QLVEgAA
+        H4sIAMlKDlYAA9xYz3OrNhC+56/w+K4AjlPbGULmHfpmOv1xeC95h14yAhajBCSeJBy7f31XCDAE
+        kaTT6bTTm9n9tNpd7a4+Obw7lsXiAFIxwW+XwaW/XABPRMr4/nb5cP+ZbJd30UWoJeWKJhpR0cVi
+        EbI02nzfPG3S0MOfRqI01bWKDoKlgNL202j0qYJI0QJCr/lpZEktJe5zIkwJgttB9OPDl9Cbig2Y
+        lqLmOlr5l7sg9NovoyhBJjnlmtAkMUKCvsRPGpQOPZfOrBEyBYkfC86K26WWNSw965IEqiElVC+M
+        m7fLFD81K2GJOwfXJPCJv7r3dzfB1c366nd0tl/QrK+r9K+tPy9oU6K0QK/NR5vhH/zt6jrwuxyj
+        NGNSacJpCa/9R2VB53WJKCvKTw4NlJQVDvkLxIppl60qF9wlz+hxklVvGFYYs6LAyjqHWKX/bHBK
+        SwCsgTSVoJQr+qMGnppTmIUUIqEF0y7zEvbYEa4UCWyAwpbwbh34m9Abijq3sS7laT4qqzYrCC2q
+        nK4+hLp6D8VrPA+WTM9qcDwYWlbz1NUovUa1hU6lpKeREvM5mBguIxWVmmE6FGhdQAnYoOMVLuO0
+        1rmQ7I/3zQ/MxlQnuROTs6oaVqOrpP+XJflGgfxnanF4Ou1sJBmDIlVdPKaCElZRO9tX2GFjyWD8
+        DFaG9KAISCkkweRWgitw5qTBDXI2Rke/4kX0JqAzMT7uV6CfrJU3MU38h8N05VRooHu8U17oCTVP
+        YNsDryk1rYiwkiLB3TAPXVvRBt5Y+vzzl1/8e0zpW6CxlbErge/7w+VTRx06jaUffapQczAcYg7R
+        pDZNmfEEkz+FTWJFVpKYA8rw4HEFFl0McpqR2lAG3MVyhBmUpkdiOYhTBUcoq44CxEIUQPkyymih
+        DP/pAR3lwChIQmV3BWrxDDzKrvZXT3uEN19WEzMerf1gtd2aOc2HI2gdBdstMqP2o+0yNEoavvWN
+        KYrV0n93U6Zi0h5mKbjOowA7aCKcYE9AJfKZlT8CN9J23/a+J2ZGNXzx4euZBZylZy9zUTTpdk8e
+        VtI9kFoWUa51pW48jyqc7uoylpRx0zhtxV/iyMURcDJD/7EErNb0sRB74R0w/suK7++AH5gU3ABu
+        FeVpLI7IPnr77ViRUFGcHr8JU4D2t9XkQAudo8cQPfBnLl546A1kFpRCzPRZbz9bVS3x4LAK93Vh
+        iN8A9VrT3yGGxeI1eYYOZN0YPElRDBCdoE2fUjVOUbwF+fMZM5KOp7LIiNFSnmCYXz+ZHaeKLlUi
+        rZNm1p53P8ssqObsew1tM6EYk89wGssoW++2wXqzia/Wq2S7TjY7P9usY7rbrbbrLNghQZ5bai0f
+        gJeCqPR5ptl6fXsTjJutfbCQnGFlytOIbfQ3dYMANNSeoelQZPSoKKsPsvwe31ton0ZnMjN8LTWI
+        uQePTajCDHSvnOajd23AiZTAYQYRrRi6MJXbAL1phH8/6Ou3gp4+D//dgHtJWwb2Hiiom1TWsUok
+        q2ZJ50DfT+2GUZMKSY5ICfI6YnLnmHOvkOiW1E4suvxqH3MZErz3HIw5ZarpX6cOrBXRNdTMBJ57
+        7uHMnPo2Nops1DzpMa6ZHu319j7EBzuHqVU884O5wDOAuavXbCteiD3NiRbTENdS2QdBChpfvB2N
+        HKvcZzN4Tbi3H2Mm/2J8EA5HkwC8jaTbDfOywkpFJusyWCeJ47GAJzITu4m8qrGrHKXRXqOEcaSm
+        tX2dGepgZ+ijmaGhNwcak7tBoGMOOOR3s6D3bTWM8D1bPW3UORIGgu1l6g7Q9UyMMzYaHtHFnwAA
+        AP//AwA/mmk5IBMAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"4cf34ff8d564ff5e10d08754517722f2"']
+      etag: ['"cea00d356a76097d926c6c024fdd45dc"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -513,91 +513,91 @@ interactions:
     body: !!python/unicode '<customer><custom_fields><participant_id type="integer">4</participant_id></custom_fields></customer>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/customers
   response:
     body:
       string: !!binary |
-        H4sIAIzak1UAA5SRzVKDMBSF930KJvtIYOpIO4HufIK6cXflXiAtCUwSLLy9BHHqiC5cnnPy3b/I
-        06jb6J2sU53JWfIgWESm7FCZOmcv52eesVOxk+XgfKfJFrsokgqLTIi9yMRBxrMI3pyVDRjPZ305
-        1DesLngdJ91gbWX8PQ2vK2Wd5wY0RUa1OfN2IBYvUQt/JWWnezDTxicNqt24fdOZbY0Kxo13ozen
-        /C/9LIEn5OAjP/WUM5ylV5pYkYrkkYsnLpJzkh6T7JiKVxnfgYUfevwffwc++y8355WiFl1wwlZg
-        vSpVv95yL+MfTgDjDRl2QeV5CRbdOg1YC9O6KiBaco422Vet8PMfAAAA//8DANWk1gksAgAA
+        H4sIAMtKDlYAA5SRy26DMBBF9/kK5L3Ls1ESGbLLF6Sb7qb2EKyAsewhDX9fTKlSlXbR5b3XZ14W
+        x3vXRjd0XvemZOlTwiI0slfaXEr2cj7xHTtWGyEHT32HrtpEkdCqyvZ5nm6LnYgnEbwpkw0Y4pMm
+        S9I2F+W2Mr/erk7E39PwutbOEzfQYWR0WzJyA7J4jlr4K5F9Z8GMKx870O3KtU1v1jVquK+8d3zz
+        mn7p5xAIFQeKaLRYMjVJ0h2yKkvSZ54mPMnOyf6Q5odi+yriBzDzg1X/4x/AZ//55rzW2CofnLAV
+        ONJS2+WWhYh/OAGMV2TYRWniEpzyyzTgHIzLqqCUQ+9xlX3VCj//AQAA//8DAFWlIc0sAgAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"b96a106eed80f95ce8ecfc1d407e2efd"']
+      etag: ['"d895dd23bbd821e41a4876e870fb55d3"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '<payment_method><customer_id>80040809</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
+    body: !!python/unicode '<payment_method><customer_id>29331648</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods
   response:
     body:
       string: !!binary |
-        H4sIAI7ak1UAA6xVu3LbMBDs9RUa9hBJPWzaQ8GTJmWa2CnSeEDgSGEEAgwAyma+PgeKelimnGSS
-        Tre3uMdyAeUPr7Wa7sA6afQ6SmdJNAXNjZC6WkdPj59JFj3QSc4tCOkJZ1bQyXSaF1IppBAmhAXn
-        AoaoFPRnlcdSDDFvnTc1WIJIliTLJEvu8vgc3fNKaZ0nmtUw1VKtI29biOIhqdj1HDd1w3Q3knHe
-        AvjDfCMEePWgBYgPKMpwpqQfK2+hQsFGEo1xnimCCgK9W6bJbR6fQ4exW+1t10OEqWbD5qPLXbIW
-        v2PpFnWV/APaNSEtMB/E8FPfNbCOBIZe1hDReZKuSHJLkvQxnd+n2f08/Y4f8XhgqNA24u8qnA70
-        jopHLIU203SZpPMsC3ndY8GDJLSg36RjOMkxPmQ3Rgm019iqwTEoEZdM0Se91eZFY4UTNjmTypRE
-        OtcyzYE+ff0UeO8Tk38X78+uyYkVbOnRfTjUGeuIBq6AQvrTgvtwnyhZqw5zFsYoYDqiQaBA65N7
-        YmtRcII+b1WY9azYZWbS36ZG2r4/qY32G5rO8/gdeMHsgFlUaJ68ofbokQnictaSKQfDiaH7Bpjy
-        G/z0cBrzDAsUWbMKSGsV3XjfuPs4Zs6Bd7PCMqnDY1HhMi+sm6Eb4oZ1NWj/XIPfGPGsTGXiHbpt
-        1ujqAfROWqMDYe2YFoV5xTfvWL/vhvYIXi6Y3p5GeoNODk/bkqZZlubxEAQc21ujzhx6APqkhYah
-        J74YxIffAXdt4biVTRDRDaIxa1k3ON+bLWjKFytf2TzeRwFvtfzR9k9H0ZsN15KlBEuXC54t01Jw
-        vuCL8uZmcbMqYZUmCw4ZFByv5NWjk//wIOxA14Y4sb1igGN+YFtsvb8C77bvb9zp/+sXAAAA//8D
-        AElpROD1BgAA
+        H4sIAMxKDlYAA6xVTXPaMBC98ysY34U/cIudMcr00mMvTXroJSNba6xBlhxJJuHfd2UMOATSdtob
+        +/ZpP56fRHH/2sr5DowVWq2DeBEFc1CV5kJt1sHjw1eSBfd0VlQGuHCkYobT2XxelEJKpBDGuQFr
+        PYao4LR8LkLBx7jqrdMtGIJIki+X8ec0K8IpeuDVwlhHFGthroRcB870EIRjUrLbuUq3HVP7Kxnr
+        DIA7zneFAK8OFAf+AUXqiknhrpU3sEHBriQ6bR2TBBUEmqdxtCrCKXQcu1fO7AeIMNk1LLm63CVr
+        +TuW6lFXUX1AuyWkAea8GG7u9h2sA46hEy0ENIniTySOSJQ8RPldvLxLs5/4EU8Hxgp9x/+uwvnA
+        4KjwiqXQZoqmUZxkmc+rAfMeJL4F/SEsw0lO8THbaMnRXtdW9Y5BiSrBJH1UW6VfFFY4Y7OJVLom
+        wtqeqQro4/cvnvc+Mft38f7smpxZ3pYO3YdDTVgn1HM5lMKdFzyEh0TNenmcs9RaAlMB9QJ52pA8
+        EHuDghP0eS/9rJNil5nZcJs6YYb+pNXKNTROivAdeMHcAzOoUBK9oQ7oiQn8ctaaSQvjibF7A0y6
+        Bj89nMecYJ4iWrYB0htJG+c6exeGzFpwdlEaJpR/LDa4zAvbL9ANYcf2LSj31IJrNH+SeqPDHbpt
+        0anNPaidMFp5wtoyxUv9im/eqf7QDe3hvVwytT2P9AadHZ+2lMZZFhfhGHgc2xstJw49AkPSQMfQ
+        E9804uNvj9u+tJURnRfRjqIxY9h+dL7TW1C07hqzeinCQ+TxXonnfng6ysFsuJaoBRhap3kWp6tV
+        uUyTKkurVR7Vq7RkeZ5kaR3neIVvHZ39hwdhB6rVxPLtDQOc8iPbYOvDFXi3/XDjzv9fvwAAAP//
+        AwA0BKl49QYAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"d044f50bbf2604e357a13f4f5463974d"']
+      etag: ['"9caeee25ffa1be6310b6443ff0730074"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>c35tgr</payment_method_token><amount>2062.11</amount><customer_id></customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>fphr7w</payment_method_token><amount>2062.11</amount><customer_id></customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">4</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAI/ak1UAA+RYTY/jNgy9z68Ictc4TjKz2YHHiwWKAntoL7vbQy8DWaJjbWzJleRMMr++lB1/
-        Rs5OL0WB3mzyiZZIinx09OlU5IsjaCOUfF6G96vlAiRTXMj98/L7t1/JbvkpvotoKQhorTTRYEol
-        DcR3i0VUi4x77F4W9lzC85JqTc/LoEYFPSwqqaZFu8JqKg1lFr/dSGrAuQBpSQE2U5xYdQAZs82D
-        3eso8CrblbRQlbTxevW4vg/DKLi8t2pWGasK0ETwhRT589LqCpodNpvBfceG5hAF9WMrV6Xbn2nf
-        UWKqpBCWpOgNA9bm4PYUpzQ3uNavbI0FE2uXXZFUQM6H30A/WcFESfG0gsdbd/aRpLPosYAnGHu2
-        Xn3xe1SAMXQP8Rd5pDk64xs9LT7XvoqCVnfni06Enz1sZZmco6DdQWQstZWJS60YrlX6hQPLhQSO
-        rmhUd/PuxeNrjfl2JsIogmkH8fevv7gzTcV3Pw0xnkuzzHmHMubEzkvGJh8P2w9vb8mPtX58+OFO
-        eI1q1ivNZ7IjYhqoBU6ovaQ3x1crCljiXsIHsvpAVuG3cP0U7p7Wmz/xAN2Ci4Wq5P/MQr+gc1WT
-        v13kceO71Wq72q0+9vFAeSq0sUTSArx5ntNbWqYKzLCzVwcFFblX8wqJEdZvscyU9GtSTLxrXwfj
-        g0aJyDGf9sNjv+3/nQMbqwEwUzjHqmf8PjlZkNzF6QYoVwxvmvV/RMMeb5jfdQqvUN5cgI/bcPUB
-        7/FA1B8B81ifb52xAbhVhOZlRtfvxG1+jpMVxkowXyRHocODppXk/gvW6Tz9o1Ojlwc1yW+or7kk
-        oZZlM6hMlOU4qfwZ+j/IrJsR/s+l1Dhy/vb5zubpb530aCZMZ8ZLNXLgxzE+/g27001Ab2ScDBPY
-        l8bOTczFF8fj9dprYQPeY3N5pWfU/YDmOmHHMr5sibrWTmiFtEuLN1ovmHFLDx9/1zVtDMSMdnat
-        xXvgpSpz2ItfORdul+j7a2C9l8XTwmf29sLG+FEJ5sKZYqIgDtM1Ae1zReW4Bm6soRazOEtPpKEy
-        M0o4QVG2zCFRKgcqly3j7AE9W8EzEEZ13yPHPHpMnBMh4+0qXO92rmTLcXnbxuFuh1Tr8tLdVzRO
-        aiL3hzAU86x77+tXKXSTKYWSNotDDP+V0IM+A9UYofVqBK+lV1ze1b+aoH7/2hOHXjrcbabyOghz
-        FU0USHxJpfM4s7Y0T0FADXYTc59oKqS7fpc7c4+FvZ1EXppJ5CVXexUc0RP3pdx/AnkUWkkHeDZU
-        8kSdkLB09tsvVlL8VcElLbAsIVxgLdLxdsN22zDljG3YJn183Dw+pPAQrjYMdpAwDNPs0q4Eaigp
-        VrrflbspzXOry4DmNkOfINuWB6leZRQMZC2MQyJsj2heO2WlMVXwDuyr3PHUAW6qGfRDR74FzXvw
-        QDYYALXKB5hW0AXKmAo7APZ3eehRI+m0q6iUOD2VzA0Yn913rxW96xSvWN0n+j30shZ2BFkoYvhh
-        5lp2+q7bTK/lZXYimcC81ecR8xkwhRoDx8EY6e4zjg6oKsp3jhMdfjjHvm90a+rpzeHaJbPB7NMq
-        E7akVX7Au15LBjseUDejsDJCTEsxGlVbeTfbXh++k12c1lbanM4RwioxTIvyBmUcIAY1saaupEQi
-        ojhBJkaci72VY4LFDWo7g67/D0y+5noVwe7iZb5cmDpXZ7TQ2FL9xZ+tb/NzGNYk306nxpFPurkc
-        TzqT8Z2+7UM4Z0vw2cbMOLoWmgLMNz73efVKmnh79OiapNKmIfscLA6nPQUcK+ciN5gW5rYxRl39
-        mHj3Ajg5d2AH0HObcSMO5jVyUb/RijHvGICRmvWE80NZWfCnT/s7TUikl1X9WLfwplK9uErV/3Ob
-        gqaMbXDoMbUbUrVZ0Hus1fTuZ9YGHNBm2LQJXkiXl4AHSNXUe5M/ZVjXPD86/wYAAP//AwAdIrU8
-        JRUAAA==
+        H4sIAM1KDlYAA+RYS3PjNgy+51d4fGdsOerGzijK7KGd2UN76G566CVDSZDFjURqScqP/vqCeksm
+        HffS6UxvEvARAkEQ+KDg5VTkiwNIxQR/Xnr36+UCeCwSxvfPy9dvv5Dt8iW8C2jJCEgpJJGgSsEV
+        hHeLRVCLlHnsXxb6XMLzkkpJz8tVjVoNsKCkkhbdCi0pVzTW+O1GUgPOBXBNCtCZSIgW78DDtMzk
+        4zFYWZXdSlqIiutws/60ufe8YNW+d+q4UloUIAlLFpzlz0stK2g8bJxBv0NFcwhW9WMnF6XxT3Xv
+        KFFVVDBNUoyGAq1zMD6FKc0VrrUrO2OrmbXWK5IyyJPxNzBOmsWspLhbloS+2ftE0lu0WMAdTCNb
+        r27jHhSgFN1D+IUfaI7B+EZPi891rIJVp7uznU5gHDnKbYHAzoNAaaorFZZSxLhWyLcE4pxxSDAU
+        jerOHV7cvpSYb2fClCCYdhD+/Pq72dNcfPfhEeO+ZJyZ6NA4NmITpei7BlXv61LXrBIyceREEEug
+        GhJCdZvUCb5qVsASPfB+It6arDff1rsn7+HJ3/2JbvcLWgtVmfwzC8OCPkBN1vbnjY5vdg8P3id/
+        O5wCylMmlSacFmDN7pxe08aiwLw6W3VQUJZbNUeIFNN2i2UmuF2TYrpdxno13WgQsRyzaD/edvTj
+        39mw0hIAMyVJsNYpe0xOGnhizukKKBcx3i9t/4iEPd4re+gEXpy8Sfud760f8faORMMWMI/l+doe
+        G4BZRWheZnRzI+7hYxyv8KxYbDvJydHhRtOKJ/YL1ussXaNXY5RHlchuqK6NGKCh4s7W2D9AK2wj
+        kv11yydGpiOq48yBylhZTvPWfgn+B8l7NYn+c1k7PTl7X76xK9t7Mj2oGYVyRKlGjuI4xYe/Ytu7
+        ChiMTJNhBvvS2LmKaWNxOFyuvRQ24D32ryM9o+47NNcJm6KyZUvQcwbSXURaL3CEZYBPv2vYAB6E
+        Q+tcq/EeWDmQC9vGNUmY8RJjfwmsfVk8LWxmry9sjB8Ei81xppgoiMN0jUDaQlEZOoOONezFidP0
+        RBqO5FDCCYqyIyeREDlQvuyo7AAYCBHugcRUDm14StCnjDxiPPTX3ma7NV2BT8ubH3rbLXK49qW/
+        r2ic1AzxD6Yo5ln/PtSvkskmUwrBdRZ6ePwXQgv6DFTiCW3WE3gtvRgSTP2rme/r14GbDNKxt5nI
+        60NwVTRWIKMmlczDTOtSPa1WVGE3UfeRpIyb69femXss7N2I89aMOG+52IvVASNxX/L9C/ADk4Ib
+        wLOiPInECTlRb78vUxJKitXoN2GyuXnudBnQXGfoN4Sv/J2LIw9WI1kHSyBiekA0r72yknicmKf7
+        Kjd0dYSba0Y9y3BwbNIDeCQbTX9S5CNMJ+iDqVSFVRp7MH8fUBPpvPKLlBg95TFu+etn891LxRA6
+        kVRxXcsHHwZZB6s4+1FBe/FQgQfCsNrLMPV3W89/fIwe/E289ePH3Tp99CO62222furtkOK7lna2
+        D8ALQVTy7riWvb7vNvNr2Q5lJGOYt/I84T4jplBj4DCaT819xukEVUV548TS48cD8m0zYVNPr07t
+        JtQKY9PNcfXLyNkRa1MCiyKEtGST8beT9/Py5b57WRuvrsjm1MUFq0jFkpVX2OIIMSqHNTEmJXIQ
+        kRAkYcRE11o0Zlh0UGoHuv7nMPuaaVMEG4uV9iZM1VfAoYXGlhgy0lna3FMeliObp3PjSCXNrI87
+        dSR7r+9aEE7xHGy2MTMOpnumAO6eZz4vjqQ5b4seQxNVUjU8PwGNo+/A/qZK18mNBgWXG1PUxc+O
+        mxfAyYQDi790OWMGKMxrpKF2o1UcWycAPClnJEwcygrvozV9ul90jCOzrJpRzHTvpki9mSI1/Meb
+        g+ZkbbTpKasbszQn6BZrNbP7yNqI/ukM+zXBC2nyEnADqZhHb/b3DUua5efp3wAAAP//AwBMAhkQ
+        eRUAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
@@ -610,123 +610,123 @@ interactions:
     body: !!python/unicode '<customer><custom_fields><participant_id type="integer">4</participant_id></custom_fields></customer>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/customers
   response:
     body:
       string: !!binary |
-        H4sIAJHak1UAA5SRzVKDMBSF930KJvsItFJpJ9CdT1A37q65F0hLApOktry9BHHqiC5cnnPy3b+I
-        w0230TtZpzpTsPQhYREZ2aEydcFejs88Z4dyJeTF+U6TLVdRJBSW2Waz22zzrYhHEbwxkw0Yz0d9
-        2tVXrE54vg26wdqK+HsaXlfKOs8NaIqMagvm7YVYPEUt/JXITvdghoVPGlS7cPumM8saFdwW3pXe
-        nPK/9LMEnpCDj/zQU8FwlF5pYuU6STOePPEkPabrfZrv19mriO/AxF96/B9/Bz77TzfnlaIWXXDC
-        VmC9kqqfb/ko4h9OAOMFGXZB5bkEi26eBqyFYV4VEC05R4vsq1b4+Q8AAAD//wMAog450ywCAAA=
+        H4sIAM9KDlYAA5SRu1LDMBBF+3yFR73wI04gGdnp+ILQ0C3SJtbEljXSOsR/j2XMhEFQUN57dfYl
+        cbh1bXJF53VvKpY/ZCxBI3ulzbliL8dn/sQO9UrIwVPfoatXSSK0qsvdNs/K4lGkkwjelMkGDPFJ
+        kyVpm7NyW7m+XC9OpN/T8PqknSduoMPE6LZi5AZk6Ry18Fci+86CGSMfO9Bt5NqmN3GNE9wi7x3f
+        vKZf+jkEQsWBEhotVkxNknSHrC6yfMPzjGfFMdvt8/V+k7+K9A7M/GDV//g78Nl/vjk/aWyVD07Y
+        Chxpqe1yy1KkP5wAphEZdlGauASn/DINOAfjsioo5dB7jLKvWuHnPwAAAP//AwAxOSY9LAIAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"7202dfde7d867952fcb266a898f3cb5f"']
+      etag: ['"0de1563ef10033838d8b95fb6a079f9e"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '<payment_method><customer_id>53393686</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
+    body: !!python/unicode '<payment_method><customer_id>49610427</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods
   response:
     body:
       string: !!binary |
-        H4sIAJLak1UAA6xVTXPaMBC98ysY34W/+HAyoEwvPfbSpIdeMrK0Bg2y5EoyCf++K2MwIZC0097Y
-        t0/a3eenZfnwWqvxDqyTRq+idJJEY9DcCKnXq+jp8Sspogc6WnILQnrCmRV0NB4vS6kUUggTwoJz
-        AUNUCuqzZSxFH/PWeVODJYjM8vwunxfzZXyOHniVtM4TzWoYa6lWkbctRHGfVOx2jpu6YXp/JeO8
-        BfDH/q4Q4NWDFiA+oCjDmZL+2vUW1ijYlURjnGeKoIJA76ZpsljG59Cx7VZ7u+8gwlSzYdnV4S5Z
-        +Wcs3aKukn9AuyWkBeaDGH7s9w2sIoGhlzVENEvSGUkWJEkf0+w+Le6z+U/8iKcD/Q1tI/7uhuFA
-        56j4iqXQZppOkzQripDXHRY8SEIJ+kM6hp2c4mN2Y5RAe10bNTgGJeKSKfqkt9q8aLxhwEZnUpmK
-        SOdapjnQp+9fAu99YvTv4v3ZMxlYwZYe3YdNnbFOaOAKKKUfBjyEh0TFWnXsszRGAdMRDQIFWpc8
-        EFuLghP0eatCr2eXXWZG3WtqpO3qk9pov6Ep7oF34AVzD8yiQlnyhtqhJyaIy14rphz0J/rqG2DK
-        b/DTw9DmGRYosmZrIK1VdON94+7jmDkH3k1Ky6QOy2KNw7yw/QTdEDdsX4P2zzX4jRHPyqxNvEO3
-        TRq9fgC9k9boQFg5pkVpXnHnne7vqqE9gpdLprdDS2/Q0XG1TWlaFOky7oOAY3lr1JlDj0CXtNAw
-        9MQ3g3j/O+CuLR23sgkiul40Zi3b9873ZguazhZiUeG3OUQBb7X81Xaro+zMhmPJSoKl05wX07QS
-        nOc8r+bzfD6rYJYmOYcCSo5P8ubR0X9YCDvQtSFObG8Y4JTv2RZLH57Au+m7Fzf8f/0GAAD//wMA
-        BxbVbvUGAAA=
+        H4sIANBKDlYAA6xVu3LbMBDs9RUa9hAfoi3SQ8GTJmWa2CnSZEDiKGIEAgwAytbf50BRD8uUk0zS
+        6fYW91guoOLxtZXzHRgrtFoH8SIK5qAqzYXarIPnp88kCx7prKgMcOFIxQyns/m8KIWUSCGMcwPW
+        egxRweldXYSCj3HVW6dbMASRNL+PozRZFeEleuDVwlhHFGthroRcB870EIRjUrLbuUq3HVP7iYx1
+        BsAd55sgwKsDxYF/QJG6YlK4qfIGNijYRKLT1jFJUEGgeRpHuO8ldBy7V87sB4gw2TUsmVzumrX8
+        HUv1qKuoPqDdEtIAc14MN3f7DtYBx9CJFgKaRPEdiSMSJU9R/hAvH+6S7/gRTwfGCn3H/67C+cDg
+        qHDCUmgzRdMoTrLM59WAeQ8S34J+E5bhJKf4mG205GivqVW9Y1CiSjBJn9VW6ReFFc7Y7EIqXRNh
+        bc9UBfT56yfPe5+Y/bt4f3ZNzixvS4fuw6EuWCfUczmUwp0XPISHRM16eZyz1FoCUwH1AnnakDwQ
+        e4OCE/R5L/2sF8WuM7PhNnXCDP1Jq5VraJwU4TvwirkHZlChJHpDHdATE/j1rDWTFsYTY/cGmHQN
+        fno4j3mBeYpo2QZIbyRtnOvsQxgya8HZRWmYUP6x2OAyL2y/QDeEHdu3oNyPFlyj+Q+pNzrcodsW
+        ndo8gtoJo5UnrC1TvNSv+Oad6g/d0B7eyyVT2/NIb9DZ8WlLaZxlcRGOgcexvdHywqFHYEga6Bh6
+        4otGfPztcduXtjKi8yLaUTRmDNuPznd6C4pWWb7c3BfhIfJ4r8TPfng6ysFsuJaoBRhap3kWp6tV
+        uUyTKkurVR7Vq7RkeZ5kaR3neIVvHZ39hwdhB6rVxPLtDQOc8iPbYOvDFXi3/XDjzv9fvwAAAP//
+        AwCGtuqM9QYAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"e8e563a691f93a21e560098b70f16804"']
+      etag: ['"9fef6c8ca13095d32d46175acffba28b"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '<payment_method><customer_id>53393686</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
+    body: !!python/unicode '<payment_method><customer_id>49610427</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods
   response:
     body:
       string: !!binary |
-        H4sIAJPak1UAA6xVwXKbMBC98xUe7jJgbIdkMJleeuylSQ+9ZIS0YI2FRCXhxH/fFcY2SXDSTnvz
-        vve02l2e1vn9SyNnezBWaLUJk3kczkAxzYWqN+Hjw1eShfdFkDMDXDjCqOFFMJvlpZASJYRybsBa
-        jyEqeLFyeST4ELPOOt2AIZ5I09t0na3zaIwedZUw1hFFG5gpITehMx2E0UBKep1jummpOkww1hkA
-        d6pvQgAvDhQH/oFEakalcFPpDdQ4sAmi1dZRSXCCUNwuk/gmj8bQqexOOXPoIUJlu6WLyebeqtLP
-        VKrDuQr2gezaIA1Q54fhZu7QwibkGDrRQFgs4mRF4hsSJw/J4i7J7hY3P/Ejng8MGbqW/12Gy4He
-        UdGEpdBmqljGySLLPK96zHuQ+CuKH8JSrOQcn9itlhztNdWqdwyOiAkqi0e1U/pZYYYLFoxGpSsi
-        rO2oYlA8fv/ide+J4N+H92fP5KLytnToPixqpDqjXsuhFO7S4DE8EhXt5KnOUmsJVIVFRaUFr+vZ
-        o7IzOHGCRu+kL3aU7S0T9M+pFaYvgDRauW2RLPLoHfhGeQBqcESL+JW0R89K4FeKHdheuQUq3Ra/
-        PVzKHGFeIhpaA+mMLLbOtfYuiqi14Oy8NFQovy1qbOaZHuZoh6ilhwaUe2rAbTV/krrW0R7tNm9V
-        fQ9qL4xWXrCxVPFSv+DSO+fvb0N/eDOXVO0uJb1Cg9NuWxZJliV5NAQex+uNliOLnoCeNNBSNMU3
-        jfjw2+O2Ky0zovVDtMPQqDH0MFjf6R0oXEq72xrtdYw83inxq+t3R9m7DdsSlQBTLFOWLZOKM5ay
-        tFqv0/WqglUSpwwyKBm+yatHg/+wEfagGk0s310xwJkf1AavPr6Bd933T+7yB/YbAAD//wMAXfyn
-        EPYGAAA=
+        H4sIANFKDlYAA6xVTXPaMBS88ysY34U/cIqdAWV66bGXJj30kpGtZ6xBllxJJqG/vk/GgJOYNJ32
+        xttdS++tVmJ999zI+R6MFVptgngRBXNQpeZCbTfBw/0XkgV3dLYuDXDhSMkMp7P5fF0IKVFCGOcG
+        rPUYooJTp9ah4ENddtbpBgxBJM0/xVGarNbhGD3qKmGsI4o1MFdCbgJnOgjCgZTsOlfqpmXqMMFY
+        ZwDcqb8JATw7UBz4OxKpSyaFm1rewBYNmyBabR2TBB0EmqdxhPOOoVPbnXLm0EOEybZmyeRwr1XL
+        P6lUh76K8h3ZNSMNMOfNcHN3aGETcCydaCCgSRTfkDgiUXIf5bfx8vZm+QMP8fzBsELX8r9b4fJB
+        n6hwIlIYM0XTKE6yzPOqx3wGid+CfheWYSfn+sTWWnKM19SoPjFoUSmYpA9qp/QT5nWEzUZW6YoI
+        azumSqAP3z573Vti9u/mfeyaXFQ+lg7Th02NVGfUazkUwl0GPJZHomKdPPVZaC2BqYBWTFrwup49
+        KjuDjhMMeid9s6PVXjOz/jq1wvQNkEYrV9M4WYdvwFfKAzCDFiXRC2mPnpXArzQ7sL2yBiZdjWcP
+        lzZHmJeIhm2BdEbS2rnW3oYhsxacXRSGCeVfiy0O88QOC4xD2LJDA8o9NuBqzR+l3upwj3FbtGp7
+        B2ovjFZesLFM8UI/46N3Xr/fDfPhw1wwtbu09AKdnd62lMZZFq/DofA4bm+0HEX0BPSkgZZhKL5q
+        xIffHrddYUsjWm+iHUxjxrDDEH2nd6Doqlz+qvBsjpXHOyV+dv3bUfRpw7FEJcDQKs2zOF2timWa
+        lFlarvKoWqUFy/MkS6s4xzt87dPZf3gR9qAaTSzfXQnAmR/UBrc+3oE30/dX7vIH9hsAAP//AwDo
+        xZW/9gYAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"39ce8334ff7259d6db321318e946d9ff"']
+      etag: ['"5be4a257a4bf1efac6c4b90b38dd6cb3"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>94k9g6</payment_method_token><amount>103.3</amount><customer_id></customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>7c3zf2</payment_method_token><amount>103.3</amount><customer_id></customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">4</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAJXak1UAA9xXTW/jNhC9768IfGck2Y7XCRQFCxSL9tBedlMUvSwoamxxLZEqSTl2fn2HoiRL
-        FpVNDwWK3qSZR3K+OPMYP53K4uYISnMpHhfRbbi4AcFkxsX+cfH89TPZLp6SD7FRVGjKDKKSDzc3
-        Mc+S9Wmf7rM4wE8r0YaaWie0NrlU/BVQ04qs1pwrSDQtIA6aTytjtVJ41plwLQkeCcnzl5/iYCq2
-        YFrKWpgkCle3qzAO2l+rKUGxnApDKGNWSNAgbdL7w/rj62v6fak2d9/jwIeyq6XKQOHPjeDF48Ko
-        GhaBs04BNZARam6sxY+LDH8NL2GRLMPojoQfSRh9jZYP0fZhef8n2t0vaNbXVfbP1l8WtNHRRqLV
-        9scF/G61ul9ttpsu5CjdcaUNEbSEa/tRWdB5HZNlRcXZo4GS8sIjf4FUc+Pbq8ql8Ml39DSJajB0
-        K055UWChDVw0/65z2igArIEsU6C1z/uTAZHZLMxCCslowY1vewV7vCC+EEm8C4Wr5vt1FH6Mg6Go
-        MxvrUp3nvXJqu4LQosrp8l2o1Y9QosZ8cDbN1SA96NquFpnvovQa3RY6VYqeR0qM56CB+DbRYEwB
-        JeDFTKlhuReT86oalouv5v6XNfNGBv8zxTLMTtu8yI5DkenOH6oMZ7yirvmu8QqMJYP+MFgZ06Mm
-        oJRUBINbSaHBG5MGN4jZGJ38ijPjTUC3xTjdV6Bf3C5vYhr/j8fpyqnQQvfY9F/oGTXfwV0PnCN6
-        WhFxpSTD0zAO3YylDbzZabv5/Ef4M4b0LdB4l7EpURiGw+VTQz06g6WffKpQc7Tzfg7RhDbLuLUE
-        gz+FTXw9Ss5sgnaYeFyBRZeCmkaktjMdT3FDfAZl6Ik4uuBVwQnKqpvRqZQFULFIdrTQlqv0gI4T
-        oBeEUdXNKCMPILClH+73OJfdn9OkXCTrMFput7aRimELWifRdhvFQfvT3jLclDTc6HeuKVZL/991
-        mYorl8xSCpMn0TIOJsIJ9gxUIeFYhiNwI23PbQcysT2q4XfPXy5j+iK9WJnLogm3v/Pwku6B1KpI
-        cmMq/RAEVGN317epolzYi9NW/C22XGwBZ9v0v5WA1Zp9K+ReBkf0/7YS+ycQR66ksIBHTUWWyhPS
-        g35/d14t+F81tMnHNoJgjt1DJesV266jXcbYiq12m81qc7eDOySQDLaQMkzL7NK2YSmoKPal36Qt
-        bfftNDnQwuQYC6Ss4iDki4iDgcyBMki5uejdb6uqFZYE1ve+LiznG6CuNf10sgSW0+ICHci6BntW
-        shggOkGbGK1r7M84X8XhghlJx/1e7ojVUsEsM/9kT5wqulDJrGZNF7+cfpE50BFEKYnODjOXrde3
-        k2B82doHBsk5VqY6j7hGP6kbBOBGbaTtDUXKjYqyeicN7/H9Dm++bBrE7OPEVajGklIy56aidXHA
-        a9tIegMHzEhLbGmQ0IqjIVO5czO49rOXtLFxzbGgfqZVp5opXs0ysYG+b2UNDyQVTn6ZESQ7xEbR
-        c/mvkGiWMl4smnx1jp0QBIeBh0RmXDel59WB20V2t3amLc09UrCRTG0bb4oUzb5J0a+Zwu31bkjg
-        M1PAdFfM+dFOtR3A3Dyyx8oX4rI50WIY0lppx5IzMPhO67jVWOXPzYBi+48fYybP8HfC4WQDgC1a
-        +c2w7wGsVKR3vg1rxjwMGjMy47v1vKoN+EqjnS2EC+RrdfPZzFPXWL7ZxhIHc6Ax4xk4OiZGQ9Iz
-        C/rxXg1N+tFePZcyOU5RgtfL1h2g6Ts5jtioeSQf/gYAAP//AwC4O19p5REAAA==
+        H4sIANNKDlYAA9xXwXKkNhC971dMzV0GxnhnxoVx7SGpJFWbQ9bOIReXgGbQGiQiifHMfn1aCBgw
+        wvYlVancoPup1d1qdT9F96eqXB1BKib43Tq48tcr4KnIGD/crR8ffia79X38KdKSckVTjaj402oV
+        sSzeZzdhpSMPP41EaaobFdNGF0KyH5BFXicyWn2uIVa0hMhrP40sbaTEvc6EKUFwS4h/evwj8uZi
+        A6aVaLiOA//66tqPvO7XaCqQaUG5JjRNjZCgQ8l3DQp9c+nMGiEzkPiz4qy8W2vZwNqzPkmgGjJC
+        9cr4ebfO8FezCtbxxg9uSOATf/Pg72+D69ub8C/0dljQrm/q7OPrb3D9ZUGXE6UFem1+bJrD/efA
+        DzfbPtEozZlUmnBawWv/UVnSZV0qqprys0MDFWWlQ/4CiWLaZasuBHfJc3qaZdUbhxUlrCyxvC4h
+        av7vBqe0BMAayDIJSrmiP2ngmTmFRUgpUloy7TIv4YDXwpUigTegtDW8DwMfz3As6t3GupTn5ais
+        2qwgtKwLuvkQ6vo9FG/wPFg6P6vR8WBoecMz10UZNKordColPU+UmM9R23AZqanUDNOhQOsSKsAL
+        Ol3hMn7pMO+ZH5lNqE4LJ6ZgdT2uRldJ/y9L8o0C+c/U4vh0ut5IcgZlpvp4TAWlrKa2t4d4w6aS
+        UfsZrYzoURGQUkiCya0FV+DMSYsb5WyKjr/iIHoT0JuYHvcr0K/WypuYNv7jcb5yLjTQA86UF3pG
+        zXew1wPHlJpXRFRLkeJumIf+WtEW3loKHr5+/uU3TOlboKmVqSuB7/vj5XNHHTqNpR9/qVFzNCRi
+        CdGmNsuY8QSTP4fNYj0KlpoDyvHgcQUWXQJynpHGUAbcxXKEBZSmJ2I5iFMFJ6jqngIkQpRA+TrO
+        aakMARoAPeXAKEhKZT8CtXgGHm/T6x/5BuHtn9UkjMehH2x2O9On+bgFhXGw2wWR1/10twyNkpZw
+        /ckUxWoZ/vsuUzNpD7MSXBdxgBvOhDPsGahEPrPxJ+BW2u3bzXtielRLGh+/XVjARXrxshBlm253
+        52EVPQBpZBkXWtfq1vOowu6urhJJGTcXp6v4K2y52ALOpuk/VYDVmj2V4iC8I8Z/VfPDPfAjk4Ib
+        wJ2iPEvECdnHYL9rKxJqit3jd2EK0H5bTQG01AV6DPEjf+biBbnLSGZBGSRMX/T2t1M1Eg8Oq/DQ
+        lIb4jVCvNcMMMSwWx+QFOpL1bfAsRTlC9IIufUo12EVxCvLnC2YinXZlkROjpTzFML99MTvOFX2q
+        RNakba+97H6RWVDD2d8NdJcJxZh8ht1Yxnm43wXhdptch5t0F6bbvZ9vw4Tu95tdmAd7JMhLS63l
+        I/BKEJU9L1y2Qd9Ngull614tpGBYmfI8YRvDpG4RgIa6MzQ3FBk9Kqr6gyx/wA8W3nwutYjFF4/N
+        qMIU9M+c9mfwbUSKlMBuBjGtGfowl9sIvdchDpIuLbYvltRNsppEpZLViyRspB+6WMswSY1DX2QE
+        eQ4xCXTc+1dIdEtqJxZdfrWPGQ4E54CDQWZMtfXs1IG1IvoCW+hIS88f7CFz36ZGkZ2ZNy7GtVCz
+        g97OB3zAcphbxTM/moGWAyyNIrOteCH2NGdaTEPSSGUJcgYaX4A9rZqq3GczYtfu7aeY2bP+g3A4
+        mQRgd5ZuN8xLAysVmZ3LYJOmDvKMJ7IQu4m8bvBWOUqjGyuEcaRqjX2tmFFqe8qT6SmRtwSakp1R
+        oFNONOY7i6D3bbUM6T1bA43SBQ5QgtfL1B2g67mYZmzSPOJP/wAAAP//AwAHg26RNRIAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"a9a15e040fcff16f05d20fff7ba91511"']
+      etag: ['"71c043de874806ff364a05b56fb89cfb"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -735,83 +735,83 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/4xgbgd/void
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/9d54mt/void
   response:
     body:
       string: !!binary |
-        H4sIAJbak1UAA9xYTW/jNhC951cEvjOSbMdxAkWLBYpFe2gvu1kUvSwoamxxLZEqSTl2fn2HoiRL
-        EZUNUBRY9GbNPJLzxZlHxx9OZXF9BKW5FI+L6CZcXINgMuNi/7h4+vKJbBcfkqvYKCo0ZQZRydX1
-        dcyzZH3ap/ssDvCnlWhDTa2To+QZoLT9tBpzriDRtIA4aH5aGauVwnPOhGtJ8DhInj7/EgdTsQXT
-        UtbCJFG4ulmFcdB+Wk0JiuVUGEIZs0KCxmiT3h/Wdy8v6fel2tx+jwMfyq6WKgOFH9eCF48Lo2pY
-        BM46BdRARqi5thY/LjL8NLyERbIMo1sS3pEw+hItH6Ltw/L+L7S7X9Csr6vs3etXIa6/LGijo41E
-        q+2HC/btanW/2mw3XbhRuuNKGyJoCa/tR2VB53VMlhUVZ48GSsoLj/wZUs2Nb68ql8In39HTJKrB
-        0K045UWBRTZw0fy3zmmjALAGskyB1j7vTwZEZrMwCykkowU3vu0V7PFy+EIk8S4Urprv11F4FwdD
-        UWc21qU6z3vl1HYFoUWV0+W7UKsfoUSN+eBsmqtBetC1XS0y30XpNbotdKoUPY+UGM9B8/BtosGY
-        AkrAi5lSw3IvJudVNSwXX839L2vmjQz+NMUyzE7bvMiOQ5Hpzh+qDGe8oq75rvEKjCWD/jBYGdOj
-        JqCUVASDW0mhwRuTBjeI2Rid/I4z401At8U43a9Av7ld3sQ0/h+P05VToYXusek/0zNqvoO7HjhH
-        9LQi4kpJhqdhHGhtcqn4C23gzU7bzac/w18xpG+BxruMTYnCMBwunxrq0Rks/eRjhZqjnfdziCa0
-        WcatJRj8KWziKzIIZhO0w8TjCiy6FNQ0IrWd6XiKG+IzKENPxNEFrwpOUFbdjE6lLICKRbKjhbZc
-        pQd0nAC9IIyqbkYZeQCBLf1wv8e57L6cJuUiWYfRcru1jVQMW9A6ibbbKA7aj/aW4aak4UZfuaZY
-        Lf1312UqrlwySylMnkTLOJgIJ9gzUIWEYxmOwI20PbcdyMT2qIbbPX2+jOmL9GJlLosm3P7Ow0u6
-        B1KrIsmNqfRDEFCN3V3fpIpyYS9OW/E32HKxBZxt0/9WAlZr9q2Qexkc0f+bSuw/gDhyJYUFPGoq
-        slSekB70+7vzasH/rqFNPrYRBHPsHipZr9h2He0yxlZstdtsVpvbHdwigWSwhZRhWmaXtg1LQUWx
-        L/0hbWm7306TAy1MjrFAyioOQj6LOBjIHCiDlJuL3n22qlphSWB97+vCcr4B6rWmn06WwHJaXKAD
-        Wddgz0oWA0QnaBOjdY39GeerOFwwI+m438sdsVoqmGXmH+2JU0UXKpnVrOnil9MvMgc6gigl0dlh
-        5rL1+nYSjC9b+7ggOcfKVOcR1+gndYMA3KiNtL2hSLlRUVbvpPE9vt+hfcZ0DXX8smkQs48TV6Ea
-        S0rJnJuK1sUBr20j6Q0cMCMtsaVBQiuOhkzlzs1g6ue/dr15gcy6Pn3Q/Qxu95K2JNxMKKifYNap
-        ZopXswR0oO87eEN/SYWER2YEOR6xEfT0vFdINEsZLxZNfnWOHYwEZ6CHO2dcNzfOqwO3i+ya1Uw3
-        nnubYf+c2jbeFJmpfYqjXzP3tde72YivawHTXTHnRzvMdwBzY9geK5+Jy+ZEi2FIa6Xd4yADg8/T
-        jlKOVf7cDF4W/uPHmMm/D++Ew8kGACeT8pthn0FYqchqfRvWjHkeDpiRGd+t51VtwFca7UglXCBN
-        rZufDY1w/fSb7adxMAcaE72Bo2M+OOR6s6Af79Wwwx/t1VNIkyN5IHi9bN0Bmr6T44iNmkdy9Q8A
-        AAD//wMAQKdJndgSAAA=
+        H4sIANRKDlYAA9xYQW+sNhC+v1+x2rsDbEiyGxGid2jVVno99CU99BIZGBa/gE1ts9l9v75jDCwE
+        k0Sqqla9LTOfxzPj8cznje6PVbk6gFRM8Lt1cOGvV8BTkTG+v1s/PvxItuv7+FOkJeWKphpR8afV
+        KmJZvMuuwkpHHv40EqWpblR8ECyDLPK6T6PRpxpiRUuIvPankaWNlLjPiTAlCG4H8Q+Pv0XeXGzA
+        tBIN13HgX15c+pHXfRpNBTItKNeEpqkREnQm+aZBoV8unVkjZAYSP1aclXdrLRtYe9YnCVRDRqhe
+        GT/v1hl+albBOt74wRUJfOJvHvzdbXB5exX+gd4OC9r1TZ19fP0Vrj8v6HKitECvzYdNcbi7Dvxw
+        c9MnGaU5k0oTTit47T8qS7qsS0VVU35yaKCirHTIXyBRTLts1YXgLnlOj7OseuOwooSVJZbWOUTN
+        /9nglJYAWANZJkEpV/RHDTwzp7AIKUVKS6Zd5iXs8Uq4UiTwBpS2hndh4OMZjkW921iX8rQclVWb
+        FYSWdUE3H0JdvofiDZ4HS+dnNToeDC1veOa6KINGdYVOpaSniRLzOWoZLiM1lZphOhRoXUIFeEGn
+        K1zGaaMLIdn3982PzCZUp4UTU7C6Hlejq6T/lyX5RoH8Z2pxfDpdbyQ5gzJTfTymglJWU9vbQ7xh
+        U8mo/YxWRvSgCEgpJMHk1oIrcOakxY1yNkXHX3AQvQnoTUyP+xXoZ2vlTUwb/+EwXzkXGugeZ8oL
+        PaHmG9jrgWNKzSsiqqVIcTfMQ3+taAtvLQUPX65/+gVT+hZoamXqSuD7/nj53FGHTmPpx59r1BwM
+        iVhCtKnNMmY8weTPYbNYkZak5oByPHhcgUWXgJxnpDGUAXexHGEBpemRWA7iVMERqrqnAIkQJVC+
+        jnNaKkOABkBPOTAKklLZj0AtnoHHN+nl93yD8PbLahLG49APNtut6dN83ILCONhug8jrPrpbhkZJ
+        S7h+Z4pitQzffZepmbSHWQmuizjADWfCGfYEVCKf2fgTcCvt9u3mPTE9qiWMj1/PLOAsPXtZiLJN
+        t7vzsIrugTSyjAuta3XreVRhd1cXiaSMm4vTVfwFtlxsASfT9J8qwGrNnkqxF94B47+o+f4e+IFJ
+        wQ3gTlGeJeKI7GOw37UVCTXF7vGrMAVof1tNAbTUBXoM8SN/5uIFuctIZkEZJEyf9fazUzUSDw6r
+        cN+UhviNUK81wwwxLBbH5Bk6kvVt8CRFOUL0gi59SjXYRXEK8uczZiKddmWRE6OlPMUwv342O84V
+        fapE1qRtrz3vfpZZUMPZnw10lwnFmHyG3VjGebjbBuHNTXIZbtJtmN7s/PwmTOhut9mGebBDgry0
+        1Fo+AK8EUdnzwmUb9N0kmF627sVCCoaVKU8TtjFM6hYBaKg7Q3NDkdGjoqo/yPIH/GChexudycz4
+        udQiFl88NqMKU9A/c9qPwbcRKVICuxnEtGbow1xuI/TmIf79qK/finr+QPyXIx4kXSHYSVBSN61s
+        EpVKVi/SzpF+6NstpyY10hyREWR2xCTP0eleIdEtqZ1YdPnVPmYcEpx8Ds6cMdXeYKcOrBXRX6mF
+        Hrz04MOuOfdtahT5qHnVY1wLt3TQ24mIT3YOc6t45gczwnOApeFrthUvxJ7mTItpSBqp7JMgA41v
+        3p5ITlXusxm9J9zbTzGzPzI+CIejSQDOI+l2w7ytsFKRy7oMNmnqeC7giSzEbiKvG7xVjtLoBilh
+        HMlpY99nhjzYLvpkumjkLYGm9G4U6JQFjhneIuh9Wy0nfM/WQBx1gZSB4PUydQfoei6mGZs0j/jT
+        XwAAAP//AwB/08/SIxMAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"2f0a4c2dce69c11b948ecf8d9a0ef0d8"']
+      etag: ['"fb38258fed784be6fca447b42739cbc2"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>10.0</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>10.0</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAJjak1UAA9xXzW7jNhC+5ykC3xlJtpN4A0XBAkXRHloU2M0W6CWgqLHFWCK1JOXY+/QdipIs
-        RVSSHgoUvUkzH4fzP8P44VgWlwdQmktxv4iuwsUlCCYzLnb3i8evP5PN4iG5iI2iQlNmEJVcXF7G
-        PEs2RmT5cxzgp6VoQ02tE1qbXCr+A7I4aEmWa04VJJoWEAfNp6WxWim860S4lgSvhOTxy09xMCVb
-        MC1lLUwShVdhGAftn2WUoFhOhSGUMUskqI826af9+vbHj/R5qW6uUUkfyp6WKgOFP5eCF/cLo2pY
-        BE45BdRARqi5tArfLzL8NbyERbIMo2sS3pIw+hot76LN3Wr5F6rdH2jO11X2z86fD7TO0Uai1vbH
-        +TuK1uvV9XLdeRypW660IYKW8Fp/ZBZ0nsdkWVFx8nCgpLzw0F8g1dz4ZFW5FD76lh4nXg2GZsUp
-        LwrMs7OJ65d/1zhtFADmQJYp0Npn/dGAyGwUZiGFZLTgxidewQ7rw+ciiaVQuGT+tI7C2zgYkjq1
-        MS/Vad4qx7YnCC2qnC4/hFq9hxI1xoOzaawG4UHTtrXIfIXSc3Sb6FQpehox0Z+D/uETosGYAkrA
-        wkypYbkXk/OqGqaLL+f+lznzRgT/M8kyjE7bvMiWQ5Hpzh6qDGe8oq75LrEExpRBfxicjOlBE1BK
-        KoLOraTQ4PVJgxv4bIxOfsOZ8SagEzEO9yvQr07Km5jG/sNhenJKtNAdNv0XekLOM7jywDmipxkR
-        V0oyvA390I1Y2sAbSas/wj9/uUGXvgUaSxmrEoV2rM5xZ04aTP3kc4Wcgx33c4jGtVnGrSbo/Cls
-        YutBcmYDtMXA4wlMuhTU1CO1nel4ixviMyhDj8StC14WHKGsuhmdSlkAFYtkSwttV5Ue0O0EaAVh
-        VHUzysg9iCTd59X3EuHNn+OkXCTrMFpuNraRimELWifRZhPFQfvTVhkKJc1q9I1ritnS/3ddpuLK
-        BbOUwuRJhBU0IU6wJ6AKF45lOAI31PbediAT26Oa9e7xy3lMn6lnLXNZNO72dx5e0h2QWhVJbkyl
-        74KAauzu+ipVlAtbOG3GX2HLxRZwsk3/qQTM1uypkDsZHND+q0rsHkAcuJLCAu41FVkqj7ge9PLd
-        fbXg32tog49tBMEcu4dK1iu2WUfbjLEVW21vblY311u4jsIVgw2kDMMye7RtWAoqin3pd2lT2307
-        Tg60MDn6AjdWsRfyRcTBgOZAGaTcnPnut2XVClMC83tXF3bnG6Bec/rpZBdYToszdEDrGuxJyWKA
-        6AhtYLSusT/jfBX7M2ZEHfd7uSWWSwWzi/lne+OU0blKZjVruvj59jPNgQ4gSkl0tp8ptp7fToJx
-        sbXvC5JzzEx1Gu0a/aRuEICCWk/bCsWVGxll9cE1vMf3Et582DSIubeJS1CNGaVkzk1F62KPVdtQ
-        ev0Gi5GW2NEgoRVHPaZ0Z2Xw2sye0rrG9caC+hetOtVM8Wp2ERvw+07WrIGkwsEvM4K7DrFO9NT+
-        KySqpYwXiyq/uscOCIKzwLNDZlw3meflgZMiu6Kd6UpzbxTsI1PdxkJxQ7MvUrRrJm97vpsR+MoU
-        MJWKMT/YobYFmBtH9lr5Qlw0J1x0Q1or7ZbkDAw+07rVaszyx2awYfuvH2Mmj/APwuFoHYAdWvnV
-        sM8BzFTc7nwCa8Y8CzRGZMZ2a3lVG/ClRjtaCBe4rtXNZzNOXV95sn0lDuZA44VnYOh4LxruPLOg
-        92U1W9J7svpVyuQ4RAmWl807QNW3cuyxUfNILv4GAAD//wMA/8VwduMRAAA=
+        H4sIANVKDlYAA9xXQXOrNhC+51d4fFcAx6ntDCHzDu1MO/N66EveoZeMgMUoAYlKwrHfr+8KAQYj
+        kvTQmU5vsPtptbta7X4KH45lsTiAVEzw+2Vw7S8XwBORMr6/Xz49/kK2y4foKtSSckUTjajoarEI
+        WRrF5Tb7UYUefhqJ0lTXKqK1zoVkPyANvVZktPpUQaRoAaHXfBpZUkuJe50IU4LglhD9/PRH6E3F
+        BkxLUXMdBf6174de+2cUJcgkp1wTmiRGSIxrLxqUDj2XzqwRMgWJPwvOivulljUsPeuSBKohJVQv
+        jJv3yxR/NSthGa384JYEPvFXj/7uLri5u938ic72C5r1dZX+s/XnBW1KlBbotfmxWd785G9Xt4Hf
+        5RmlGZNKE05LuPQflQWd1yWirCg/OTRQUlY45G8QK6ZdtqpccJc8o8dJVr1hWGHMigKr6xxilf67
+        wSktAbAG0lSCUq7ojxp4ak5hFlKIhBZMu8xL2OOtcKVI4AUobAnv1oG/Cb2hqHMb61Ke5qOyarOC
+        0KLK6epTqJuPULzG82DJ9KwGx4OhZTVPXRel16i20KmU9DRSYj4HXcNlpKJSM0yHAq0LKAEv6HiF
+        y/i5wXxkfmA2pjrJnZicVdWwGl0l/b8syXcK5D9Ti8PTaXsjyRgUqeriMRWUsIra3r7CGzaWDNrP
+        YGVID4qAlEISTG4luAJnThrcIGdjdPQVB9G7gM7E+LgvQL9aK+9imvgPh+nKqdBA9zhT3ugJNS9g
+        rweOKTWtiLCSIsHdMA/dtaINvLH02/r718cdpvQ90NjK2JXAN7N6TjuzUmPpR18q1BwMh5hDNKlN
+        U2Y8weRPYZNYD4Il5oAyPHhcgUUXg5xmpDaUAXexHGEGpemRWA7iVMERyqqjALEQBVC+jDJaKMN/
+        ekBHOTAKklDZjUAtXoFH2c3+5mWP8ObPamLGo7UfrLZb06f5sAWto2C7DUKv/WlvGRolDd/6zhTF
+        aun/uy5TMWkPsxRc51GAN2ginGBPQCXymZU/AjfSdt923hPToxrO+PTtzALO0rOXuSiadLs7Dyvp
+        HkgtiyjXulJ3nkcVdnd1HUvKuLk4bcVfY8vFFnAyTf+5BKzW9LkQe+EdMP7riu8fgB+YFNwA7hXl
+        aSyOyD56+21bkVBR7B6/C1OA9ttqcqCFztFjiJ74KxdvPPQGMgtKIWb6rLe/raqWeHBYhfu6MMRv
+        gLrU9DPEsFgck2foQNa1wZMUxQDRCdr0KVVjF8UpyF/PmJF03JVFRoyW8gTD/PbF7DhVdKkSaZ00
+        vfa8+1lmQTVnf9XQXiYUY/IZdmMZZevdNlhvNvHNepVs18lm52ebdUx3u9V2nQXYfGaXWssH4KUg
+        Kn2duWy9vp0E48vWPlpIzrAy5WnENvpJ3SAADbVnaG4oMnpUlNUnWX6P7y28+1pqEHMPHptQhRno
+        XjnNT+/agBMpgc0MIloxdGEqtwF6lxH2kjYrti0W1M2x6lglklWzHGyg75tYQzBJhTNfpARpDjH5
+        c1z7CyS6JbUTiy5f7GNmA8Ex4CCQKVNNOTt1YK2Irr5mGtLc6wdbyNS3sVEkZ+aFi3HNlGyvt+MB
+        368cplbxzA9mnmUAc5PIbCveiD3NiRbTENdSWX6cgsYHYMeqxir32QzItXv7MWbyqP8kHI4mAdic
+        pdsN89DASkVi5zJYJ4mDO+OJzMRuIq9qvFWO0minCmEcmVptHytmktqW8mxaSujNgcZcZxDomBIN
+        6c4s6GNbDUH6yFbPonSO85Pg9TJ1B+h6JsYZGzWP6OpvAAAA//8DAHT/WpQzEgAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"4642cd8f767f1e2b62ed787208d9fbc1"']
+      etag: ['"0202bace6381fffdbf3a8a3776a54d93"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -820,62 +820,62 @@ interactions:
     body: !!python/unicode '<search><status type="array"><item>authorized</item></status></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search_ids
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search_ids
   response:
     body:
       string: !!binary |
-        H4sIAJnak1UAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
-        sNGHS4KVZqYUQxUlFhUlViqBBEHAJrMkNdfOpCI9KT3FRh/MQZGxKMlLychCyABZKUDLbfTRnQMA
-        AAD//wMAJ2EIFKAAAAA=
+        H4sIANZKDlYAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
+        sNGHS4KVZqYUQxUlFhUlViqBBEHAJrMkNdcuKdcirarARh/MASnXB6q347LRR7cUAAAA//8DACuu
+        kEKGAAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"274ef038831f3de4e761a618f98e7150"']
+      etag: ['"4d2b34c857076cc8f59e8f4786a8839c"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '<search><status type="array"><item>authorized</item></status><ids
-      type="array"><item>4xgbgd</item><item>8tndhj</item></ids></search>'
+      type="array"><item>bm8fzp</item></ids></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search
   response:
     body:
       string: !!binary |
-        H4sIAJvak1UAA9xYTY/bNhC951csfOdasr0bJ/AqCFAU7aFFgWRToJeAosYWY4lUSMpr59d3SOrT
-        ona3hwJFb9bM43BmOJx59O7DuSxuTqA0l+JhEd9GixsQTGZcHB4Wj59/JtvFh+TNjinIuCGMqowY
-        RYWmzOAKfWMuFTwsmCwKcJJF8ubmZsdqpUAYUtEDEFGXKagGyYWBA6hFEu+WAZRb7b41/wHXa+6i
-        3bJTOqiRhhaEGyh1YIOBFmMY+O3W8izZGpHl33ZL/Gkl2lBT64TWJpcKt8h2y0bk9kL7iaYFoGH7
-        sw+UXQjXkmDaIHn89FMb2VBswbSUtTBJHN1GGEjzZRUlKJZTzARlzAoJ+qNN+u64efvjR/ptpe7v
-        0MkQyq6WKgOFHzeCFw8Lo2pYLL1zCqiBjFDT5CbDT8NLWCSrKL4j0VsSxZ/j1ft4+369+gvd7ha4
-        9XWV/bP1/YImOdrI0h+qz3ccbzbru9WmzThK91xpQwQt4dp/VBZ0XsdkWVFxCWigpLwIyJ8g1VgM
-        AU2VSxGS7+l5ktXlMKxdyosC70of4ubp3w1OGwWANZBlCrQORX82IDJ7CrOQQjJacBMyr+CA9yOU
-        IqntZXLF/G4TR2/xKg5ErdtYl+oyH5VX2xWEFlVOV69CrV9CYfMAxdn0rAbHg6Hta5GFLkqnaZsI
-        VYpeRkoY9b2QEQ3GFFDahpZSw/IgJudVNSyXUM39L2vmmRP8zxTL8HSa5kX2HIpMt/FQZTjjFfXN
-        d2Wn0Ugy6A+DlTt60gSUkopgciscmxDMicMNcjZGJ7/hzHgW0JoYH/cV6Fdv5VmMi/90mq6cCi30
-        gE3/iV5Q882TAPxF9bQidpWSDHfDPLQjljq4s7T+I/rzl3tM6XOgsZWxK3Fkx+qcdmalwdJPPlao
-        OdlxP4dwqc2QAqEnmPwpbBLrSXJmD2iPB48rGhI0yUhtZzru4of4DMrQM/F0IaiCM5RVO6NTKQug
-        yMP2tNCWqnSAlhO0RK4paiOPIJL0mFffS0uZ7JfXpFwkmyhebbe2kYphC9ok8XaLDKv5aG6ZY4eW
-        Gn3hmmK1dN9tl6m48odZSmHyJMYbNBFOsBegCgnHKhqBnbTZtxnIxPYoR+8eP/Vjupf2XuaycOkO
-        dx5eWo5ZqyLJjan0++WSauzu+jZVFOklXpym4m+x5WILuNim/7UErNbsayEPcnnC+G8rcfgA4sSV
-        FBbwoKnIUnlGetDZ9/vVgn+vWwaMbQTBHLuHSjZrtt3E+4yxNVvv7+/X93d7uIujNYMtpAyPZXZp
-        07AUVBT70u/Slrb/7TU50MLkmAtkrOIo5JPYLQcyD8og5abX+89GVSssCazvQ11YzjdAXWu66WQJ
-        LKdFDx3I2gZ7UfiU6BGtoDkYrWvszzhfxbHHjKTjfi/3xGqpYJaYf7Q7ThVtqmRWM9fF+917mQed
-        QJSS6Ow4c9k6fTMJxpeteV+QnGNlqsuIa3ST2iEADTWZtjcUKTcqyuqVNLzDdxaefdg4xNzbxBeo
-        xopSMuemonVxxFvrJJ1/A2KkJXY0SGjF0Y+p3Ee5vA6zkzSp8b2xoGGiVaeaKV7NErGBvutkjgaS
-        Cge/zAhyHWKTGLj7V0h0S5kgFl2+2scOCNK/iYccMuPaVV5QB96KbC/tTFeae6NgH5n6NjaKDM2+
-        SDGumbrt9H5G4CtTwNQqnvnJDrU9wNw4stvKJ+JPc6LFNKS10p4kZ2DwmdZSq7EqfDYDhh3efoyZ
-        PMJfCYezTQB2aBV2wz4HsFKR3YUM1owFCDSeyEzsNvKqNhAqjWa0EC6QrtXupxunvq98tX1lt5wD
-        jQnPINAxLxpynlnQy7YcS3rJVkelTI5DlOD1snUH6PpejjM2ah72c+4PqOTN3wAAAP//AwD22yw7
-        wxIAAA==
+        H4sIANdKDlYAA9xYTW/jNhC951cYvjOSHKe2A0WLPbRAC2wP3WQPvSwoaWRxI5EqSTn2/voORX1a
+        VLI9FCh6s2YehzPD4cyjww/nslidQCom+OM6uPXXK+CJSBk/Pq6fn34h+/WH6CZMJKRMk4TKlGhJ
+        uaKJxhVqpS8VPK4TURTQSNbRzWoVJrWUwDWp6BEIr8sYZItkXMMR5DoKQs+BalY334p9h+s1937o
+        9coGqoWmBWEaSuXYYKTFGEZ+N2tZGsXlPvtehR7+NBKlqa5VRGudC4lbpKHXipq90H6kaAFo2Pwc
+        Ak0uhClBMG0Q/fz8RxfZWGzAtBQ111Hg3/oYSPtlFCXIJKeYCZokRkiMa980KB16Lp1ZI2QKEj9W
+        nBWPay1rWHvWJQlUQ0qobjOS4qdmJayjjR/ck8An/ubJPzwEdw/3uz/R2X5Bs76u0n+2fljQpkRp
+        UdqjtFne/eTvN/eB3+UZpRmTShNOS7j2H5UFXdYloqwovzg0UFJWOOSvECssAYemygV3yTN6nmXV
+        G4cVxqwo8IYMIVbpvxuc0hIAayBNJSjliv6sgafmFBYhhUhowbTLvIQj3gpXioQyV6gp4cM28Hd4
+        AUeizm2sS3lZjsqqzQpCiyqnmx9C3b2HwpYBkiXzsxodD4aW1Tx1XZRe07UOKiW9TJQw6XYuIxWV
+        mmE6FGhdQGna2XSFy/jQYN4zPzIbU53kTkzOqmpcja6S/l+W5BsF8p+pxfHptL2RZAyKVHXxmApK
+        WEVtb9+YETeRjNrPaGVIT4qAlEISTG6FsxicOWlwo5xN0dEnHERvAjoT0+O+Av1qrbyJaeI/neYr
+        50IDPeJMeaUX1HyzzAJ/UTWviLCSIsHdMA/dtaINvLH02/bLp6cDpvQt0NTK1JXAN7N6SbuwUmPp
+        Rx8r1JwMh1hCNKlNkVehJ5j8OWwW60mwxBxQhgePK1pmNctIbSgD7mI5wgJK0zOxHMSpgjOUVUcB
+        YiEKoEjuMloow396QEc5OnbYFrUWL8Cj7O549+1oeJj5spqY8WjrB5v93vRpPm5B2yjY75G2tR/t
+        LWsop+FbX5iiWC39d9dlKibtYZaC6zwK8AbNhDPsBahEPrPxJ+BG2u7bzntielTDGZ8/DyxgkA5e
+        5qJo0u3uPKw0xLWWRZRrXakHz6MKu7u6jSVFzooXp634W2y52AIupul/LQGrNf1aiKPwThj/bcWP
+        H4CfmBTcAB4V5Wkszsg+evttW5FQUewevwtTgPa31eRAC52jxxA98xcuXnnojWQWlELM9KC3n62q
+        lnhwWIXHujDEb4S61vQzxLBYHJMDdCTr2uBF4itiQHSCNn1K1dhFcQrylwEzkU67ssiI0VKeYJif
+        P5od54ouVSKtk6bXDrsPMguqOfur7p4pKMbkM+zGMsq2h32w3e3iu+0m2W+T3cHPdtuYHg6b/TYL
+        sPksLrWWT8BLQVT6snDZen07CaaXrX20kJxhZcrLhG30k7pBABpqz9DcUGT0qCirH2T5Pb638OZr
+        qUEsPXhsQhVmoHvlNB+9ayNOpAQ2M4hoxdCFudwG6F1H2EvarNi2WFA3x6pjlUhWLXKwkb5vYg3B
+        JBXOfJESpDnE5M9x7a+Q6JbUTiy6fLWPmQ1keGOPCWTKVFPOTh1YK6Krr4WGtPT6wRYy921qFMmZ
+        eeFiXAsl2+vteMD3K4e5VTzzk5lnGcDSJDLbildiT3OmxTTEtVSWH6eg8QHYsaqpyn02I3Lt3n6K
+        mT3qfxAOZ5MAbM7S7YZ5aGClIrFzGayTxMGd8UQWYjeRVzXeKkdptFOFMI5MrbaPFTNJbUv5alpK
+        6C2BplxnFOiUEo3pziLofVsNQXrPVs+idI7zk+D1MnUH6HomphmbNA/zufSHVnTzNwAAAP//AwDR
+        tZbaExMAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"885a801ea3c1cab8e5cbdda81fc45053"']
+      etag: ['"5af63d8a612c7940cca2a6500c58211e"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -884,40 +884,40 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/8tndhj/void
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/bm8fzp/void
   response:
     body:
       string: !!binary |
-        H4sIAJzak1UAA9xY3W/bNhB/z19h+J2RZDuOWygKCgzD9rBhQNsN2EtBkWeLsUSqJOXY/et31Jel
-        iEoDDAOKvVl3Px7v+46OH89FvjiBNkLJh2V0Gy4XIJniQh4elp8//Ux2y8fkJraaSkOZRVRys1jE
-        gic7K3n2FAf401GMpbYyyUkJDjwO2k/HsZcSEkNziIP6p6OxSmu850KEUQSvg+Tzx5/iYEp2YFqo
-        StokCm/DMA7aL8coQLOMSksoY45IUBdj03fHzf23b+nTSm/vUEEfyp1WmoPGj4UU+cPS6gqWQaOc
-        BmqBE2oXTuGHJcdPKwpYJqswuiPhPQmjT9HqfbR7v179jWr3B+rzVcnffn6L568HWucYq1Br99H4
-        Ooo2m/XdatN5G6l7oY0lkhbwUn9k5nSex1RRUnnxcKCgIvfQnyE1wvpklZmSPvqenideDYZmxanI
-        c8yxq4mb5//WOGM1AOYA5xqM8Vl/tiC5i8IsJFeM5sL6xGs4YG34XKSwFPImmd9tovA+DoakTm3M
-        S32Zt6phuxOE5mVGV29Crb+HkhXGQ7BprAbhQdP2leS+Quk5pk10qjW9jJjoz0Hv8AkxYG0OBWBh
-        ptSyzIvJRFkO08WXc//LnHklgj9Msgyj0zYvsheQc9PZQ7UVTJS0ab4rLIExZdAfBidjejIEtFaa
-        oHNLJQ14fVLjBj4bo5PfcGa8CuhEjMP9AvRrI+VVTG3/6TQ9OSU66AGb/jO9IOcJmvLAOWKmGRGX
-        WjG8Df1AK5spLb7RGl5LWv8R/vXLFl36GmgsZaxKFLqxOsedOWkx9ZMPJXJObtzPIWrXci6cJuj8
-        KWxiKy4QzAVoj4HHE5h0KeipRyo30/GWZojPoCw9k2Zd8LLgDEXZzehUqRyoXCZ7mhu3qvSAbidA
-        KwijuptRVh1BJukxK78WCK+/Gk4qZLIJo9Vu5xqpHLagTRLtdlEctB9tlaFQUq9GfwpDMVv6767L
-        lEI3wSyUtFkSYQVNiBPsBajGhWMVjsA1tb23HcjE9ah6tfv88Tqmr9SrlpnKa3f7O48o6AFIpfMk
-        s7Y074OAGuzu5jbVVEhXOG3G32LLxRZwcU3/SwGYrfxLrg4qOKH9t6U8PII8Ca2kAzwYKnmqzrge
-        9PKb+yopvlbQBh/bCIIFdg+dbNZst4n2nLE1W++32/X2bg93UbhmsIOUYVhmj7YNS0NJsS/9rlxq
-        N78bTgY0txn6AjdWeZTqWcbBgNaAOKTCXvnNZ8uqNKYE5vehyt3ON0C95PTTyS2wguZX6IDWNdiL
-        VvkA0RHawBhTYX/G+SqPV8yIOu73ak8cl0rmFvMP7sYpo3OV4hWru/j19iutAZ1AFooYfpwptp7f
-        ToJxsbVvC5IJzEx9Ge0a/aSuEYCCWk+7CsWVGxlF+cY1vsf3EtpXTNdQxw+bGjH3NmkS1GBGaZUJ
-        W9IqP2LV1pRev8FiZBR2NEhoKVCPKb2xMpia+e8t375m+fQ59wNY3VPahGgmQk7962WVGqZFObt+
-        Dvh9/66XX1LiuqM4wQ2POAd6Ot4LJKqlrReLKr+4x41FghPQszlzYep68/KgkaK6VjXTi+deZtg9
-        p7qNheJe6t7haNdMtfb8ZjLi21rCVCrG/ORG+R5gbgi7a9UzaaI54aIb0kqb5mnAweLjtFsoxyx/
-        bAbvCv/1Y8zkr4c3wuHsHIBzSfvVcI8gzFTcaX0CK8Y8zwaMyIztzvKysuBLjXagEiFxSa3qn/US
-        0XTTL66bxsEcaLzmDQwdb4PDTW8W9H1Z9W74PVn9AmkzXB0IlpfLO0DV92rssVHzSG7+AQAA//8D
-        AH0z8TzVEgAA
+        H4sIANlKDlYAA9xYTW/jNhC9768IfGckOd7aDhQFe2iBFtgeups99LKgxJHFRCJVknLs/fUdipIs
+        RVSyRVG06M2aeRxyhvPx6Pj+VJVXR1CaS3G3iq7D1RWITDIuDnerh88/kd3qPnkXG0WFpplBVPLu
+        6irmLEmrXf6tjgP8aSXaUNPo5Cg5AxYH3afVmHMNiaYlxEH708qyRinc50y4lgS3g+THh9/iYC62
+        YFrJRpgkCq/DMA66L6uoQGUFFYbQLLNCYo/1aECbOPDp7BqpGCj8uBK8vFsZ1cAqcEdSQA0wQs2V
+        PebdiuGn4RWsknUYvSdRSML153B/G93cvt/+jocdFrTrm5r9tfWXBV1ItJF4avvhIrz9Idyt30dh
+        H2OU5lxpQwSt4OX5UVnSZV0mq5qKs0cDFeWlR/4MqebGZ6supPDJc3qaRTUYuxWnvCwxsy4u1uyf
+        dU4bBYA5wJgCrX3enwwIZm9hEVLKjJbc+MwrOGBF+EIksQBKl8L7TRRu42As6o+NeanOy145tV1B
+        aFkXdP1dqJu3UKLB++DZ/K5G14Ou5Y1gvkIZNLpLdKoUPU+UGM9Rx/AZqakyHMOhwZgSKsACna7w
+        GaeNKaTi3942PzKbUpMVXkzB63qcjb6U/l+m5CsJ8p/JxfHtdL2R5BxKpnt/bAZlvKaut6+xwqaS
+        UfsZrYzpURNQSiqCwa2l0OCNSYsbxWyKTj7iIHoV0JuYXvcL0M/OyquY1v/jcb5yLrTQA86UZ3pG
+        zSO48sAxpecZEddKZrgbxqEvK9rCW0u/bL58/LzHkL4GmlqZHiUK7axe0i6sNJj6yYcaNUfLIZYQ
+        bWgZ4/YkGPw5bOYrspLMXlCOF48rMOlSUPOINJYy4C6OIyygDD0Rx0G8KjhBVfcUIJWyBCpWSU5L
+        bfnPAOgpB3pBMqr6EWjkE4gkvzncPB4Q3n45TcpFsgmj9W5n+7QYt6BNEu12URx0H12VoVHS8q0v
+        XFPMluG77zI1V+4yKylMkURYQTPhDHsGqpDPrMMJuJV2+3bzntge1fLFh08XFnCRXk5ZyLINt7/z
+        8IoegDSqTApjan0bBFRjd9fXqaJc2MLpMv4aWy62gLNt+l8rwGxlX0t5kMER/b+uxeEexJErKSzg
+        TlPBUnlC9jHY79qKgppi9/hV2gR0v52mAFqaAk8MyYN4EvJZxMFI5kAMUm4uevfZqRqFF4dZeGhK
+        S/xGqJeaYYZYFotj8gIdyfo2eFayHCF6QRc+rRvsojgFxdMFM5FOu7LMidVSkaGbnz7YHeeKPlSS
+        NVnbay+7X2QO1Aj+RwNdMaEYg8+xG6sk3+x30Wa7TW8262y3ybb7MN9uUrrfr3ebPMLms7jUWT6C
+        qCTR7Gmh2AZ9NwmmxdY9WEjBMTPVecI2hkndIgANdXdoKxQZPSqq+jtZ/oAfLHRPowuZGb+WWsTS
+        g8cFVGME+ldO+zEcbcSJtMRmBgmtOR5hLncOBnMP/6bTm9swfM3p+fPw33V4kHRp4OZASf2kskl1
+        pni9SDpH+qFrt4ya1EhyJCPI64iNnafPvUDisZTxYvHIL/axw5Dg3PMwZsZ1W79eHTgrsi+ohQ68
+        9NzDnjk/29QoslH7pEe/Fmp00Lt5iA92AXOreOdHO8BzgKXRa7eVz8Td5kyLYUgbpd2DgIHBF29P
+        I6cq/92MXhP+7aeY2b8Y3wmHkw0ATiPlP4Z9WWGmIpP1GWyyzPNYwBtZ8N16XjdYVZ7U6MYo4QKp
+        aeNeZ5Y6uB761fbQOFgCTcndyNEpBxzzu0XQ27ZaRviWrYE2mgIJA8HysnkHePRcTiM2aR7Juz8B
+        AAD//wMA+nTSmiATAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"12313a8ebd959c719e331fe5e9bc8de9"']
+      etag: ['"079aea8d904799ee8a5989078d10dc60"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]

--- a/tests/py/fixtures/TestHistory.yml
+++ b/tests/py/fixtures/TestHistory.yml
@@ -1,189 +1,276 @@
 interactions:
 - request:
-    body: !!python/unicode <transaction><payment_method_token>bkhpqm</payment_method_token><amount>10.0</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>10.61</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
-      type="integer">2</participant_id></custom_fields></transaction>
+      type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAOzHp1UAA9xXS2/jNhC+51cEvjOy/Io3UBQsUBQo0Pay2T30ElDU2GIskVqScuz8+g5FSZYi
-        KkkPBYrepJmPw3nPMHo4Ffn1EZTmUtzPwpv57BoEkykX+/vZ98dfyXb2EF9FRlGhKTOIiq+uryOe
-        xhtzPKhzFOCnpWhDTaVjWplMKv4KaRQ0JMs15xJiTXOIgvrT0lilFN51JlxLgldC/P3bL1EwJlsw
-        LWQlTBzOb+bzKGj+LKMAxTIqDKGMWSJBfbRJvhxWt6+vyfNCbdbPUeBD2dNSpaDw51rw/H5mVAWz
-        wCmngBpICTXXVuH7WYq/hhcwixfzcE3mtyTcPIbru/nqLlz8hWp3B+rzVZn+s/OXA41ztJGotf1x
-        /g7D1Wq5XqxajyN1x5U2RNAC3uqPzJxO85gsSirOHg4UlOce+gskmhufrDKTwkff0dPIq0HfrCjh
-        eY55djFx9fLvGqeNAsAcSFMFWvusPxkQqY3CJCSXjObc+MQr2GN9+FwksRRyl8xfVuH8Ngr6pFZt
-        zEt1nrbKse0JQvMyo4tPoZYfoUSF8eBsHKteeNC0XSVSX6F0HN0kOlWKngdM9Gevf/iEaDAmhwKw
-        MBNqWObFZLws++niy7n/Zc68E8H/TLL0o9M0L7LjkKe6tYcqwxkvqWu+CyyBIaXXH3onI3rUBJSS
-        iqBzSyk0eH1S43o+G6LjP3BmvAtoRQzD/Qb0m5PyLqa2/3gcnxwTLXSPTf+FnpHzDK48cI7ocUZE
-        pZIMb0M/tCOW1vBa0uL3xx+3S3Tpe6ChlKEq4dyO1SnuxEmDqR9/LZFztON+ClG7Nk251QSdP4aN
-        bD1KzmyAdhh4PIFJl4Aae6SyMx1vcUN8AmXoibh1wcuCExRlO6MTKXOgYhbvaK7tqtIB2p0ArSCM
-        qnZGGXkAESeHrPxZILz+c5yEi3g1DxfbrW2kot+CVnG43YZR0Pw0VYZCSb0a/eCaYrZ0/22XKbly
-        wSykMFkcYgWNiCPsGajChWMxH4BranNvM5CJ7VH1evf922VMX6gXLTOZ1+72dx5e0D2QSuVxZkyp
-        74KAauzu+iZRlAtbOE3G32DLxRZwtk3/qQDM1vQpl3sZHNH+m1LsH0AcuZLCAu41FWkiT7gedPKb
-        tqKgpNg9/pQ2Ad2342RAc5OhxrhXioOQLyIKejQHSiHh5sJ3vw2rUhg4zMJ9ldvNrId6y+lmiF0z
-        Oc0v0B6tbYNnJfMeoiU07tO6wi6KU1AcLpgBddiV5Y5YLhXMrs9f7Y1jRusqmVas7rWX2y80B6oE
-        /1lBU0xIRudz7MYqXi3ZdhXuUsaWbLnbbJab9Q7W4XzJYAsJwzSfPOokH0EUkuj0MFFsHb+ZBMNi
-        a94XJOOYmeo82DW6SV0jAAU1MbQViis3Moryk2t4h+8kvPuwqRFTbxPnUI0eUDLjpqRVfsCqrSmd
-        fr3FSEvsaBDTkqMeY7qzMnhrZkdpXON6Y079i1aVaKZ4ObmI9fhdJ6vXQFLi4JcpwV2HWCd6av8N
-        EtVSxotFld/cYwcEwVng2SFTruuc9vLASZFtkk10pak3CvaRsW5Dobih2Rcp2jWRtx3fzQh8ZQoY
-        S8WYH+1Q2wFMjSN7rXwhLpojLrohqZR2S3IKBp9p7Wo1ZPlj09uw/dcPMaNH+CfhcLIOwA6t/GrY
-        5wBmKm53PoEVY54FGiMyYbu1vKwM+FKjGS2EC1zXqvqzHqeurzzZvhIFU6DhwtMzdLgX9XeeSdDH
-        suot6SNZ3SplMhyiBMvL5h2g6js59NigecRXfwMAAP//AwAbB/T04xEAAA==
+        H4sIAL5MDlYAA9xXQXOrNhC+51d4fFcAx4ntDCHzDu20h/bw3ss79JIRsBglIFFJOHZ/fVcIMBiR
+        pIfOdHqD3U+r3dVq91P4eCyLxQGkYoI/LINrf7kAnoiU8f3D8un7z2S7fIyuQi0pVzTRiIquFouQ
+        pdEuL2+TNPTw00iUprpWEa11LiT7C1DTioxWnyqIFC0g9JpPI0tqKXGvE2FKENwSop+evobeVGzA
+        tBQ111HgX98Fodf+GUUJMskp14QmiRES9Cd+0aB06Ll0Zo2QKUj8WXBWPCy1rGHpWZckUA0poXph
+        3HxYpvirWQnLaOUHtyTwib/67u/uV6t7/+4PdLZf0Kyvq/SfrT8vaFOitECvzY/N8ubO365uA7/L
+        M0ozJpUmnJZw6T8qCzqvS0RZUX5yaKCkrHDI3yBWTLtsVbngLnlGj5OsesOwwpgVBVbXOcQq/XeD
+        U1oCYA2kqQSlXNEfNfDUnMIspBAJLZh2mZewx1vhSpHAC1DYEt6tA38TekNR5zbWpTzNR2XVZgWh
+        RZXT1adQNx+heI3nwZLpWQ2OB0PLap66LkqvUW2hUynpaaTEfA66hstIRaVmmA4FWhdQAl7Q8QqX
+        8XOD+cj8wGxMdZI7MTmrqmE1ukr6f1mS7xTIf6YWh6fT9kaSMShS1cVjKihhFbW9fYU3bCwZtJ/B
+        ypAeFAEphSSY3EpwBc6cNLhBzsbo6DccRO8COhPj474A/WqtvItp4j8cpiunQgPd40x5oyfUvIC9
+        Hjim1LQiwkqKBHfDPHTXijbwxtLXu9239S+Y0vdAYytjVwLf94fLp446dBpLP/pSoeZgOMQcoklt
+        mjLjCSZ/CpvEehAsMQeU4cHjCiy6GOQ0I7WhDLiL5QgzKE2PxHIQpwqOUFYdBYiFKIDyZZTRQhn+
+        0wM6yoFRkITKbgRq8Qo8ym72Ny97hDd/VhMzHq39YLXdmj7Nhy1oHQXbLTKj9qe9ZWiUNHzrB1MU
+        q6X/77pMxaQ9zFJwnUcB3qCJcII9AZXIZ1b+CNxI233beU9Mj2o449O3Mws4S89e5qJo0u3uPKyk
+        eyC1LKJc60rdex5V2N3VdSwp4+bitBV/jS0XW8DJNP3nErBa0+dC7IV3wPivK75/BH5gUnADeFCU
+        p7E4Ivvo7bdtRUJFsXv8LkwB2m+ryYEWOkePIXrir1y88dAbyCwohZjps97+tqpa4sFhFe7rwhC/
+        AepS088Qw2JxTJ6hA1nXBk9SFANEJ2jTp1SNXRSnIH89Y0bScVcWGTFayhMM89sXs+NU0aVKpHXS
+        9Nrz7meZBdWc/VlDe5lQjMln2I1llK1322C92cQ361WyXSebnZ9t1jHd7VbbdRbskCDPLbWWD8BL
+        QVT6OnPZen07CcaXrX20kJxhZcrTiG30k7pBABpqz9DcUGT0qCirT7L8Ht9bePe11CDmHjw2oQoz
+        0L1ymp/etQEnUgKbGUS0YujCVG4D9C4j7CVtVmxbLKibY9WxSiSrZjnYQN83sYZgkgpnvkgJ0hxi
+        8ue49hdIdEtqJxZdvtjHzAaCY8BBIFOmmnJ26sBaEV19zTSkudcPtpCpb2OjSM7MCxfjminZXm/H
+        A75fOUyt4pkfzDzLAOYmkdlWvBF7mhMtpiGupbL8OAWND8COVY1V7rMZkGv39mPM5FH/STgcTQKw
+        OUu3G+ahgZWKxM5lsE4SB3fGE5mJ3URe1XirHKXRThXCODK12j5WzCS1LeXZtJTQmwONuc4g0DEl
+        GtKdWdDHthqC9JGtnkXpHOcnwetl6g7Q9UyMMzZqHtHV3wAAAP//AwDnkX6aMxIAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"f684026941b631b7266f1cb59fee3918"']
+      etag: ['"0588a5a2321cbccfaa4c5124f0262dfb"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: <transaction><amount>10.0</amount></transaction>
+    body: <transaction><amount>10.61</amount></transaction>
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/6tvkry/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/9hm5cd/submit_for_settlement
   response:
     body:
       string: !!binary |
-        H4sIAO3Hp1UAA9xYX2+jOBB/76eo8u4SkrTNrijVSqeTTrq7l233YV8qY4bgBmzWNmnST39jDASK
-        6VY6nbS6tzDz83j+zzjR/bEsLg+gNJfibhFeLReXIJhMudjdLR4ffifbxX18ERlFhabMICq+uLyM
-        eBrfmMNenaIAf1qKNtTUOtZ1UnJjIH3KpHrSYEwBJQgTBS3AYs2pgljTAqKg+WlprFYKbz4RriVB
-        BSB+/PpbFEzJFkxLWQsTh8ur5TIK2i/LKEGxnApDKGOWSFA7bZJP+83t62vyvFI3189R4EPZ01Kl
-        oPDjUvDibmFUDYvAKaeAok2Emkur8N0ixU/DS1jEq2V4TZa3JLx5CK8/Lzefw9V3VLs/0Jyvq/Tj
-        59d4/nygdY42ErW2H877YbjZrK9Xm87/SM240oYIWsJb/ZFZ0Hkek2VFxcnDgZLywkN/gURz45NV
-        5VL46Bk9TrwaDM2KEl4UmHVnEzcv/61x2igAzIE0VaC1z/qjAZHaKMxCCslowY1PvIIdVovPRRJL
-        oXDJ/GkTLm+jYEjq1Ma8VKd5qxzbniC0qHK6+hBq/TOUqDEenE1jNQgPmpbVIvUVSs/RbaJTpehp
-        xER/DrqJT8i5a5CEGpZ7MTmvqmG6+HLuf5kz70Twl0mWYXTa5kUyDkWqO3uoMpzxirrmu8ISGFMG
-        /WFwMqIHTUApqQg6t5JCg9cnDW7gszE6/gtnxruATsQ43G9Afzgp72Ia+w+H6ckp0UJ32PRf6Ak5
-        z+DKA+eInmZEVCnJ8Db0A61NLhV/pQ28kbT68+Hb7Rpd+h5oLGWsSri0Y3WOO3PSYOrHXyrkHCD1
-        nm4QjWvTlFtN0PlT2MTWg+TMBijDwOMJTLoE1NQjtZ3peIsb4jMoQ4/ErQteFhyhrLoZnUhZABWL
-        OKOFtqtKD+h2ArSCMKq6GWXkHkSc7PPqR4nw5stxEi7izTJcbbe2kYphC9rE4XYbRkH70VYZCiXN
-        avSNa4rZ0n93XabiygWzlMLkcYgVNCFOsCegCheO1XIEbqjtve1AJrZHNcve49fzmD5Tz1rmsmjc
-        7e88vKQ7ILUq4tyYSn8OAqqxu+urRFEubOG0GX+FLRdbwMk2/acSMFvTp0LuZHBA+68qsbsHceBK
-        Cgu401SkiTzietDLb9uKgopi9/hb2gR0vx0nB1qYHDXGvVLshXwRUTCgOVAKCTdnvvtsWbXCwGEW
-        7urCbmYD1FtOP0PsmslpcYYOaF0bPClZDBAdoXWf1jV2UZyCYn/GjKjjriwzYrlUMLs+f7E3Thmd
-        q2Ras6bXnm8/0xyoFvxHDW0xIRmdz7Ebq3izZttNmKWMrdk6u7lZ31xncB0u1wy2kDBM89mjTvIB
-        RCmJTvczxdbz20kwLrb2tUFyjpmpTqNdo5/UDQJQUBtDW6G4ciOjrD64xvf4XkL7iukaqu1054dN
-        g5h7mziHavSAkjk3Fa2LPVZtQ+n1GyxGWmJHg5hWHPWY0p2VwdTMf2/5+j3LP/LA+wX80FPaFHEz
-        oqD+hbNONFO8ml1IB/y+ozfrMKlwAZIpwZ2PWJd6euAbJKqljBeLKr+5xw5KgjPRs0unXDe17eWB
-        kyK7YpvpznNvNeynU93GQnFTtS9ztGumfnu+m5X42hYwlYoxP9jhngHMjWV7rXwhLpoTLrohqZV2
-        j4UUDD5XuxVzzPLHZvDS8F8/xkz+jPggHI7WATiplF8N+yzCTMUt1yewZszzkMCIzNhuLa9qA77U
-        aEcs4QLX1rr52awVrr8+2f4aBXOg8eI3MHS8Hw53v1nQz2U12+LPZPUrpclxmSBYXjbvAFXP5Nhj
-        o+YRX/wDAAD//wMAU3i6cfkSAAA=
+        H4sIAL9MDlYAA9xYQXOrNhC+51d4fFcAx4ntDCHzDu20h/bw3ksPvWQELEYJSFQSjt1f3xUCDEYk
+        mel02unN7H5a7a5Wu58cPh7LYnEAqZjgD8vg2l8ugCciZXz/sHz6/iPZLh+jq1BLyhVNNKKiq8Ui
+        ZGm0y8vbJA09/GkkSlNdq0jVccm0hvQ5E/JZgdYFlMB16LUAg9WnCiJFCwi95qeRJbWUuPOJMCUI
+        OgDRD09fQ28qNmBaiprrKPCv74LQa7+MogSZ5JRrQpPECAl6F79oUOiAS2fWCJmCxI8FZ8XDUssa
+        lp51SQLFSAjVC+PmwzLFT81KWEYrP7glgU/81Xd/d79a3ft3v6Oz/YJmfV2ln1+/wfXnBW1KlBbo
+        tfmwOd/c+dvVbeB3WUdpxqTShNMSLv1HZUHndYkoK8pPDg2UlBUO+RvEimmXrSoX3CXP6HGSVW8Y
+        VhizosBaO4dYpf9scEpLAKyBNJWglCv6owaemlOYhRQioQXTLvMS9nhHXCkSeAEKW8K7deBvQm8o
+        6tzGupSn+ais2qwgtKhyuvoU6uYjFK/xPFgyPavB8WBoWc1T10XpNaotdColPY2UmM9BD3EZqajU
+        DNNx7hkXK1zGaa1zIdmfH5sfmI2pTnInJmdVNaxGV0n/L0vynQL5z9Ti8HTa3kgyBkWqunhMBSWs
+        ora3r/CGjSWD9jNYGdKDIiClkASTWwmuwJmTBjfI2Rgd/YKD6F1AZ2J83Begn62VdzFN/IfDdOVU
+        aKB7nClv9ISaF7DXA8eUmlZEWEmR4G6Yh+5a0QbeWPp6t/u2/glT+h5obGXsSuD7/nD51FGHTmPp
+        R18q1Bwgda5uEE1q05QZTzD5U9gk1oNgiTmgDA8eV2DRxSCnGakNZcBdLEeYQWl6JJaDOFVwhLLq
+        KEAsRAGUL6OMFsrwnx7QUQ6MgiRUdiNQi1fgUXazv3nZI7z5spqY8WjtB6vt1vRpPmxB6yjYbpEZ
+        tR/tLUOjpOFbvzFFsVr6767LVEzawywF13kU4A2aCCfYE1CJfGblj8CNtN23nffE9KiGQT59O7OA
+        s/TsZS6KJt3uzsNKugdSyyLKta7UvedRhd1dXceSMm4uTlvx19hysQWcTNN/LgGrNX0uxF54B4z/
+        uuL7R+AHJgU3gAdFeRqLI7KP3n7bViRUFLvHr8IUoP1tNTnQQufoMURP/JWLNx56A5kFpRAzfdbb
+        z1ZVSzw4rMJ9XRjiN0BdavoZYlgsjskzdCDr2uBJimKA6ARt+pSqsYviFOSvZ8xIOu7KIiNGS3mC
+        YX77YnacKrpUibROml573v0ss6Casz9qaC8TijH5DLuxjLL1bhusN5v4Zr1Ktutks/OzzTqmu91q
+        u86CHRLkuaXW8gF4KYhKX2cuW69vJ8H4srVPGJIzrEx5GrGNflI3CEBD7RmaG4qMHhVl9clXQo/v
+        LbRPozOZGb6WGsTcg8cmVGEGuldO89G7NuBESmAzg4hWDF2Yym2A3jTCvx/05r2gP/Ng/HdT0Eva
+        wrCToaBumlnHKpGsmqWhA33fxxuOTSqkPSIlyPSIyaaj810g0S2pnVh0+WIfMx4JTkIHh06Zam60
+        UwfWiuiu2ExPnnsAYhed+jY2ivzUPPIxrplb2+vthMQnPIepVTzzgxnpGcDcMDbbijdiT3OixTTE
+        tVT2iZCCxjdwRyzHKvfZDN4X7u3HmMn/Gp+Ew9EkAOeTdLth3lpYqchtXQbrJHE8H/BEZmI3kVc1
+        3ipHabSDlTCOZLW27zVDJmxXfTZdNfTmQGO6Nwh0zAqHjG8W9LGthiN+ZKsnkjpHCkHwepm6A3Q9
+        E+OMjZpHdPUXAAAA//8DAPA/WN9EEwAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"3d3089c82f24547228a5ede3cd243d4b"']
+      etag: ['"7b281152e13086e46b5de14157d1b511"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode <transaction><payment_method_token>bkhpqm</payment_method_token><amount>10.0</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>10.61</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
-      type="integer">2</participant_id></custom_fields></transaction>
+      type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAO7Hp1UAA9xXS4/bNhC+51csfOfKsuWNE2i1CFAU7aFFgWRbIJcFRY0txhKpkJQf+fUdipIs
-        rajd7aFA0Zs083E47xnGD+eyuDmC0lyK+0V4u1zcgGAy42J/v3j88jPZLh6Sd7FRVGjKDKKSdzc3
-        Mc+S6PRhpbI4wE9L0YaaWie0NrlU/AcgpyVZrrlUkGhaQBw0n5bGaqXwrgvhWhK8EpLHzz/FwZRs
-        wbSUtTBJuLxdLuOg/bOMEhTLqTCEMmaJBPXRJv1wiN7/+JF+W6m7zbc48KHsaakyUPhzI3hxvzCq
-        hkXglFNADWSEmhur8P0iw1/DS1gkq2W4Icv3JLz7Em4+LqOPYfQV1e4PNOfrKvtn568HWudoI1Fr
-        ++P8HYZRtN6sos7jSN1xpQ0RtITn+iOzoPM8JsuKiouHAyXlhYd+glRz45NV5VL46Dt6nng1GJoV
-        p7woMM+uJkanf9c4bRQA5kCWKdDaZ/3ZgMhsFGYhhWS04MYnXsEe68PnIomlULhk/hCFy/dxMCR1
-        amNeqsu8VY5tTxBaVDldvQm1fg0laowHZ9NYDcKDpu1qkfkKpefoNtGpUvQyYqI/B/3DJ0SDMQWU
-        gIWZUsNyLybnVTVMF1/O/S9z5oUI/meSZRidtnmRHYci0509VBnOeEVd811hCYwpg/4wOBnToyag
-        lFQEnVtJocHrkwY38NkYnfyGM+NFQCdiHO5noF+dlBcxjf3H4/TklGihe2z6J3pBzjdw5YFzRE8z
-        Iq6UZHgb+qEbsbSBN5L++uPL18+/oEtfAo2ljFUJl3asznFnThpM/eRThZyjHfdziMa1WcatJuj8
-        KWxi61FyZgO0w8DjCUy6FNTUI7Wd6XiLG+IzKEPPxK0LXhacoay6GZ1KWQAVi2RHC21XlR7Q7QRo
-        BWFUdTPKyAOIJD3k1fcS4c2f46RcJNEyXG23tpGKYQuKknC7DeOg/WmrDIWSZjX6k2uK2dL/d12m
-        4soFs5TC5EmIFTQhTrAXoAoXjtVyBG6o7b3tQCa2RzXr3ePn65i+Uq9a5rJo3O3vPLykeyC1KpLc
-        mEp/DAKqsbvr21RRLmzhtBl/iy0XW8DFNv2nEjBbs6dC7mVwRPtvK7F/AHHkSgoLuNdUZKk843rQ
-        y2/bioKKYvf4XdoEdN+OkwMtTI4a414pDkKeRBwMaA6UQcrNle9+W1atMHCYhfu6sJvZAPWc088Q
-        u2ZyWlyhA1rXBi9KFgNER2jdp3WNXRSnoDhcMSPquCvLHbFcKphdnz/ZG6eMzlUyq1nTa6+3X2kO
-        VAv+vYa2mJCMzufYjVUSrdk2CncZY2u23t3dre82O9iEyzWDLaQM03z2qJN8BFFKorPDTLH1/HYS
-        jIutfV+QnGNmqsto1+gndYMAFNTG0FYortzIKKs3ruE9vpfw4sOmQcy9TZxDNXpAyZybitbFAau2
-        ofT6DRYjLbGjQUIrjnpM6c7K4LmZPaV1jeuNBfUvWnWqmeLV7CI24PedrFkDSYWDX2YEdx1ineip
-        /WdIVEsZLxZVfnaPHRAEZ4Fnh8y4bnLaywMnRXZJNtOV5t4o2Eemuo2F4oZmX6Ro10ze9nw3I/CV
-        KWAqFWN+tENtBzA3juy18kRcNCdcdENaK+2W5AwMPtO61WrM8sdmsGH7rx9jJo/wN8LhbB2AHVr5
-        1bDPAcxU3O58AmvGPAs0RmTGdmt5VRvwpUY7WggXuK7VzWczTl1febJ9JQ7mQOOFZ2DoeC8a7jyz
-        oNdlNVvSa7L6VcrkOEQJlpfNO0DVd3LssVHzSN79DQAA//8DAJifv8TjEQAA
+        H4sIAMFMDlYAA9xXQXOrNhC+51d4fFcAx+/ZzhAy79DOdKbtoS9pO++SEbAYJSBRSTh2f/1bIcBg
+        RJIeOtPpDXY/rXZXq91P4f2xLBYHkIoJfrcMrv3lAngiUsb3d8vHhx/JdnkfXYVaUq5oohEVXS0W
+        IUuj55f8Rp1CDz+NRGmqaxXRWudCsr8hDb1WZLT6VEGkaAGh13waWVJLiXudCFOC4JYQ/fD4W+hN
+        xQZMS1FzHQX+9ecg9No/oyhBJjnlmtAkMUKC/sTPGpQOPZfOrBEyBYk/C86Ku6WWNSw965IEqiEl
+        VC+Mm3fLFH81K2EZrfzgEwl84q8e/N3tanXr776hs/2CZn1dpf9s/XlBmxKlBXptfmyWN5/97epT
+        4Hd5RmnGpNKE0xIu/UdlQed1iSgryk8ODZSUFQ75K8SKaZetKhfcJc/ocZJVbxhWGLOiwOo6h1il
+        /25wSksArIE0laCUK/qjBp6aU5iFFCKhBdMu8xL2eCtcKRJ4AQpbwrt14G9Cbyjq3Ma6lKf5qKza
+        rCC0qHK6+hDq5j0Ur/E8WDI9q8HxYGhZzVPXRek1qi10KiU9jZSYz0HXcBmpqNQM06FA6wJKwAs6
+        XuEyfm4w75kfmI2pTnInJmdVNaxGV0n/L0vyjQL5z9Ti8HTa3kgyBkWqunhMBSWsora3r/CGjSWD
+        9jNYGdKDIiClkASTWwmuwJmTBjfI2Rgd/YKD6E1AZ2J83Begn6yVNzFN/IfDdOVUaKB7nCmv9ISa
+        Z7DXA8eUmlZEWEmR4G6Yh+5a0QbeWHr449vmz58xpW+BxlbGrgS+7w+XTx116DSWfvSlQs3BcIg5
+        RJPaNGXGE0z+FDaJ9SBYYg4ow4PHFVh0MchpRmpDGXAXyxFmUJoeieUgThUcoaw6ChALUQDlyyij
+        hTL8pwd0lAOjIAmV3QjU4gV4lN3sb573CG/+rCZmPFr7wWq7NX2aD1vQOgq2W2RG7U97y9AoafjW
+        70xRrJb+v+syFZP2MEvBdR4FeIMmwgn2BFQin1n5I3Ajbfdt5z0xParhjI9fzyzgLD17mYuiSbe7
+        87CS7oHUsohyrSt163lUYXdX17GkjJuL01b8NbZcbAEn0/SfSsBqTZ8KsRfeAeO/rvj+HviBScEN
+        4E5RnsbiiOyjt9+2FQkVxe7xqzAFaL+tJgda6Bw9huiRv3DxykNvILOgFGKmz3r726pqiQeHVbiv
+        C0P8BqhLTT9DDIvFMXmGDmRdGzxJUQwQnaBNn1I1dlGcgvzljBlJx11ZZMRoKU8wzK9fzI5TRZcq
+        kdZJ02vPu59lFlRz9lcN7WVCMSafYTeWUbbebYP1ZhPfrFfJdp1sdn62Wcd0t1tt11mwQ4I8t9Ra
+        PgAvBVHpy8xl6/XtJBhftvbRQnKGlSlPI7bRT+oGAWioPUNzQ5HRo6KsPsjye3xv4c3XUoOYe/DY
+        hCrMQPfKaX561wacSAlsZhDRiqELU7kN0LuMsJe0WbFtsaBujlXHKpGsmuVgA33fxBqCSSqc+SIl
+        SHOIyZ/j2l8g0S2pnVh0+WIfMxsIjgEHgUyZasrZqQNrRXT1NdOQ5l4/2EKmvo2NIjkzL1yMa6Zk
+        e70dD/h+5TC1imd+MPMsA5ibRGZb8UrsaU60mIa4lsry4xQ0PgA7VjVWuc9mQK7d248xk0f9B+Fw
+        NAnA5izdbpiHBlYqEjuXwTpJHNwZT2QmdhN5VeOtcpRGO1UI48jUavtYMZPUtpQn01JCbw405jqD
+        QMeUaEh3ZkHv22oI0nu2ehalc5yfBK+XqTtA1zMxztioeURX3wEAAP//AwCd3zd4MxIAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"c741f4a44072087103a273a432bbe779"']
+      etag: ['"fcb59f1a8f50b30c92a08dc39218c7a4"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: <transaction><amount>10.0</amount></transaction>
+    body: <transaction><amount>10.61</amount></transaction>
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/4w92rd/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/jkh3sy/submit_for_settlement
   response:
     body:
       string: !!binary |
-        H4sIAO/Hp1UAA9xYS4/bNhC+51csfOfKsuWNE2gVBCiK9tCiQB4FcllQ1MhiLJEKSXnt/PoORUmW
-        VtRmgaJA0Js183E47xk6fneuypsTKM2luF+Ft+vVDQgmMy4O96tPH38l+9W75FVsFBWaMoOo5NXN
-        TcyzJHp8s1FZHOBPS9GGmkYnukkrbgxkD7lUDxqMKaECYeKgA1isudSQaFpCHLQ/LY01SuHNF8K1
-        JKgAJJ8+/BIHc7IF00o2wiTh+na9joPuyzIqUKygwhDKmCUS1E6b9M0xev39e/p1o+52X+PAh7Kn
-        pcpA4ceN4OX9yqgGVoFTTgFFmwg1N1bh+1WGn4ZXsEo263BH1q9JePcx3L1dR2/D6AuqPRxozzd1
-        9vLzOzx/PdA5RxuJWtsP5/0wjKLtbhP1/kdqzpU2RNAKnuqPzJIu85isaiouHg5UlJce+iOkmhuf
-        rLqQwkfP6Xnm1WBsVpzyssSsu5oYPf63xmmjADAHskyB1j7rzwZEZqOwCCkloyU3PvEKDlgtPhdJ
-        LIXSJfObKFy/joMxqVcb81Jdlq1ybHuC0LIu6OZFqO2PUKLBeHA2j9UoPGha3ojMVygDR3eJTpWi
-        lwkT/TnqJj4h165BUmpY4cUUvK7H6eLLuf9lzjwTwZ8mWcbR6ZoXyTmUme7tocpwxmvqmu8GS2BK
-        GfWH0cmYnjQBpaQi6NxaCg1en7S4kc+m6OQPnBnPAnoR03A/Af3upDyLae0/neYn50QLPWDTf6QX
-        5HwFVx44R/Q8I+JaSYa3oR9oYwqp+HfawltJf//18cuH39Clz4GmUqaqhGs7Vpe4CycNpn7yvkbO
-        CTLv6RbRujbLuNUEnT+HzWw9Sc5sgHIMPJ7ApEtBzT3S2JmOt7ghvoAy9EzcuuBlwRmqup/RqZQl
-        ULFKclpqu6oMgH4nQCsIo6qfUUYeQSTpsai/VQhvvxwn5SKJ1uFmv7eNVIxbUJSE+30YB91HV2Uo
-        lLSr0WeuKWbL8N13mZorF8xKClMkIVbQjDjDXoAqXDg26wm4pXb3dgOZ2B7VLnufPlzH9JV61bKQ
-        Zetuf+fhFT0AaVSZFMbU+m0QUI3dXd+minJhC6fL+FtsudgCLrbpP1SA2Zo9lPIggxPaf1uLwzsQ
-        J66ksIB7TUWWyjOuB4P8rq0oqCl2jz+lTUD323EKoKUpUGPcK8VRyEcRByOaA2WQcnPlu8+O1SgM
-        HGbhoSntZjZCPeUMM8SumZyWV+iI1rfBi5LlCNETOvdp3WAXxSkojlfMhDrtyjInlksFs+vze3vj
-        nNG7SmYNa3vt9fYrzYEawb810BUTktH5HLuxSqIt20dhnjG2Zdv87m57t8thF663DPaQMkzzxaNO
-        8glEJYnOjgvFNvC7STAttu61QQqOmakuk11jmNQtAlBQF0NbobhyI6OqX7jGD/hBQveK6Ruq7XTX
-        h02LWHqbOIdq9ICSBTc1bcojVm1LGfQbLUZaYkeDhNYc9ZjTnZXB3Mx/b/nuOctf8sD7CfwwULoU
-        cTOipP6Fs0k1U7xeXEhH/KGjt+swqXEBkhnBnY9Yl3p64BMkqqWMF4sqP7nHDkqCM9GzS2dct7Xt
-        5YGTIvtiW+jOS2817Kdz3aZCcVO1L3O0a6F+B76blfjaFjCXijE/2eGeAyyNZXutfCQumjMuuiFt
-        lHaPhQwMPlf7FXPK8sdm9NLwXz/FzP6MeCEcztYBOKmUXw37LMJMxS3XJ7BhzPOQwIgs2G4trxsD
-        vtToRizhAtfWpv3ZrhWuvz7Y/hoHS6Dp4jcydLofjne/RdCPZbXb4o9kDSulKXCZIFheNu8AVc/l
-        1GOT5pG8+gcAAP//AwB7cVc2+RIAAA==
+        H4sIAMJMDlYAA9xYQW/rNgy+91cEuau207yXpHBdvMMGDNh22Gu34V0K2aZjtbbkSXKa7NePsmzH
+        juW2wDBs2C0mP1EkRZGfEt4fy2JxAKmY4HfL4NpfLoAnImV8f7d8fPiebJf30VWoJeWKJhpR0dVi
+        EbI0en7Jb9Qp9PCnkShNda0iVccl0xrSp0zIJwVaF1AC16HXAgxWnyqIFC0g9JqfRpbUUuLOJ8KU
+        IOgARN89/hJ6U7EB01LUXEeBf/05CL32yyhKkElOuSY0SYyQoHfxswaFDrh0Zo2QKUj8WHBW3C21
+        rGHpWZckUIyEUL0wbt4tU/zUrIRltPKDTyTwib968He3q9Wtv/uGzvYLmvV1lX54feDj+vOCNiVK
+        C/TafNicbz7729WnwO+yjtKMSaUJpyVc+o/Kgs7rElFWlJ8cGigpKxzyV4gV0y5bVS64S57R4ySr
+        3jCsMGZFgbV2DrFK/9nglJYAWANpKkEpV/RHDTw1pzALKURCC6Zd5iXs8Y64UiTwAhS2hHfrwN+E
+        3lDUuY11KU/zUVm1WUFoUeV09SHUzXsoXuN5sGR6VoPjwdCymqeui9JrVFvoVEp6Gikxn4Me4jJS
+        UakZpuPcMy5WuIzTWudCsj/fNz8wG1Od5E5MzqpqWI2ukv5fluQbBfKfqcXh6bS9kWQMilR18ZgK
+        SlhFbW9f4Q0bSwbtZ7AypAdFQEohCSa3ElyBMycNbpCzMTr6CQfRm4DOxPi4L0A/WCtvYpr4D4fp
+        yqnQQPc4U17pCTXPYK8Hjik1rYiwkiLB3TAP3bWiDbyx9PDbt83vP2JK3wKNrYxdCXzfHy6fOurQ
+        aSz96EuFmgOkztUNokltmjLjCSZ/CpvEehAsMQeU4cHjCiy6GOQ0I7WhDLiL5QgzKE2PxHIQpwqO
+        UFYdBYiFKIDyZZTRQhn+0wM6yoFRkITKbgRq8QI8ym72N897hDdfVhMzHq39YLXdmj7Nhy1oHQXb
+        LTKj9qO9ZWiUNHzrV6YoVkv/3XWZikl7mKXgOo8CvEET4QR7AiqRz6z8EbiRtvu2856YHtUwyMev
+        ZxZwlp69zEXRpNvdeVhJ90BqWUS51pW69TyqsLur61hSxs3FaSv+GlsutoCTafpPJWC1pk+F2Avv
+        gPFfV3x/D/zApOAGcKcoT2NxRPbR22/bioSKYvf4WZgCtL+tJgda6Bw9huiRv3DxykNvILOgFGKm
+        z3r72apqiQeHVbivC0P8BqhLTT9DDIvFMXmGDmRdGzxJUQwQnaBNn1I1dlGcgvzljBlJx11ZZMRo
+        KU8wzK9fzI5TRZcqkdZJ02vPu59lFlRz9kcN7WVCMSafYTeWUbbebYP1ZhPfrFfJdp1sdn62Wcd0
+        t1tt11mwQ4I8t9RaPgAvBVHpy8xl6/XtJBhftvYJQ3KGlSlPI7bRT+oGAWioPUNzQ5HRo6KsPvhK
+        6PG9hfZpdCYzw9dSg5h78NiEKsxA98ppPnrXBpxICWxmENGKoQtTuQ3Qm0b4t4NunjazQX/kwfjv
+        pqCXtIVhJ0NB3TSzjlUiWTVLQwf6vo83HJtUSHtESpDpEZNNR+e7QKJbUjux6PLFPmY8EpyEDg6d
+        MtXcaKcOrBXRXbGZnjz3AMQuOvVtbBT5qXnkY1wzt7bX2wmJT3gOU6t45gcz0jOAuWFsthWvxJ7m
+        RItpiGup7BMhBY1v4I5YjlXusxm8L9zbjzGT/zU+CIejSQDOJ+l2w7y1sFKR27oM1knieD7giczE
+        biKvarxVjtJoBythHMlqbd9rhkzYrvpkumrozYHGdG8Q6JgVDhnfLOh9Ww1HfM9WTyR1jhSC4PUy
+        dQfoeibGGRs1j+jqLwAAAP//AwBl97FgRBMAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"0cbff3b23a5d40f7c2d5e5cb81d5fc11"']
+      etag: ['"6c4b2064827cd71fcd94e635cf7be047"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode <search><status type="array"><item>authorized</item></status></search>
+    body: !!python/unicode '<search><status type="array"><item>authorized</item></status></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search_ids
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search_ids
   response:
     body:
       string: !!binary |
-        H4sIAPLHp1UAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
-        sNGHS4KVZqYUQxUlFhUlViqBBfWBonZcNvroRgMAAAD//wMA9crnoGwAAAA=
+        H4sIAMRMDlYAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
+        sNGHS4KVZqYUQxUlFhUlViqBBEHAJrMkNdcuKzvDuLjSRh/MASnXB6q347LRR7cUAAAA//8DABCr
+        qaaGAAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"4e86fc9a6fb27a9aa51bcb00737fddd8"']
+      etag: ['"e99563fb9843c64159822362a1983031"']
+      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<search><status type="array"><item>authorized</item></status><ids
+      type="array"><item>jkh3sy</item></ids></search>'
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search
+  response:
+    body:
+      string: !!binary |
+        H4sIAMVMDlYAA9xYTW/jNhC951cEvjOWHGdtLxwt9tACBdoeupu22EtASSOLiUSqJOXY/fUdkvq0
+        qCRAUbTozZp5HM4Mh8M33n86lcX1EaRigt8vwptgcQ08ESnjh/vFw9fvyXbxKbraJxJSpklCZUq0
+        pFzRROMKda3PFdwvElEUYCWL6Or6ep/UUgLXpKIHILwuY5ANknENB5CLKNwvPSi72n4r9idcrrkL
+        9stOaaFaaFoQpqFUng0GWoxh4Lddy9Lo6Tm/Vef9En8aidJU1ypSdVwyrSF9zIR8VKB1ASU6ul82
+        ALsz7hYpWgBuY372YSdnwpQgmESIvnv4pY1zKDZgWoqa6ygMbj6gq82XUZQgk5xiXmiSGCFB7+In
+        DQod8OnMGiFTkPhxzVlxv9CyhsXSuSSBYiSE6iY/KX5qVsIiWgXhHQkDEqy+BruPq9XHYPcNne0W
+        2PV1lb57fRjg+n5BkxKlRekO1uV88yHYru7CoM06SjMmlSaclnDpPyoLOq9LRFlRfvZooKSs8Mhf
+        IFZYEB5NlQvuk2f0NMnqchjWPmZFgfelD7FK/9nglJYAWANpKkEpX/QnDTw1pzALKURCC6Z95iUc
+        8I74UiSUuVC2hHfrMNjgdRyIWrexLuV5PiqnNisILaqcrt6Fun0LhQ0EJEumZzU4Hgwtq3nquyid
+        pm0kVEp6Hilh1Pt8RioqNcN09D3jYoXPOK11LiR2tDfND8zGVCe5F5OzqhpWo6+k/5cl+UqB/Gdq
+        cXg6TW8kGYMiVW08poISVlHX21fmwRtJBu1nsHJPj4qAlEISTG6FLzN4c2Jxg5yN0dFP+BC9CmhN
+        jI/7AvSDs/IqxsZ/PE5XToUGesA35YWeUfPkeAb+ompaEftKigR3wzy014pauLX09bdvm99/xJS+
+        BhpbGbsSBkEwXD511KPTWPrR5wo1R0i9qy3CpjZFloWeYPKnsEmsR8ESc0AZHjyuaHjWJCO1oQy4
+        i+MIMyhNT8RxEK8KTlBWLQWIhSiAItXLaKEM/+kALeVouWJT1Fo8A4+y28Pt08GwMvPlNDHj0ToI
+        V9ut6dN82ILWUbjdIjNqPppbZgmo4Vu/MkWxWrrvtstUTLrDLAXXeRTiDZoIJ9gzUIl8ZhWMwFba
+        7Nu898T0KMsgH770LKCX9l7morDp9nceVhoaW8siyrWu1Mflkirs7uomlhQZLF6cpuJvsOViCzib
+        pv9YAlZr+liIg1geMf6bih8+AT8yKbgB3CvK01ickH109pu2IqGi2D1+FqYA3W+nyYEWOkePIXrg
+        z1y88P1yIHOgFGKme737bFS1xIPDKjzUhSF+A9SlpntDDIvFZ7KHDmRtGzxLnCl6RCto0qdUjV0U
+        X0H+3GNG0nFXFhkxWsoTDPPLZ7PjVNGmSqR1Ynttv3svc6Casz/qdmhBMSafYTeWUbbebcP1ZhPf
+        rlfJdp1sdkG2Wcd0t1tt11m4Q4I8t9RZPgIvBVHp88xl6/TNSzC+bM0IQ3KGlSnPI7bRvdQWAWio
+        OUNzQ5HRo6Ks3jkldPjOQjMa9WRmOC1ZxNzA4xKqMAPtlGM/OtcGnEgJbGYQ0YqhC1O5C3A5jfBv
+        B21Hm9mg3zMw/rsp6CRNYbiXoaB+mlnHKpGsmqWhA33Xxy3HJhXSHpESZHrEZNPT+S6Q6JbUXiy6
+        fLGPeR5J/6fDkEOnTNkb7dWBsyLaKzbTk+cGQOyiU9/GRpGfmiEf45q5tZ3evZA4wnOYWsUzP5on
+        PQOYe4zNtuKFuNOcaDENcS2VGxFS0DgDt8RyrPKfzWC+8G8/xkz+13gnHE4mAfg+Sb8bZtbCSkVu
+        6zNYJ4lnfMATmYndRF7VeKs8pdE8rIRxJKu1m9cMmXBd9dF01f1yDjSme4NAx6xwyPhmQW/bshzx
+        LVsdkdQ5UgiC18vUHaDrmRhnbNQ8zOfcP3zR1V8AAAD//wMAJBk5uCQUAAA=
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: ['"d93ec85608e4e98bc8e2fbef17e544ed"']
+      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: PUT
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/jkh3sy/void
+  response:
+    body:
+      string: !!binary |
+        H4sIAMZMDlYAA9xYTW/jNhC951cEvjOSHO/aDhQFe2iBAm0P3U1b7CWgpJHFRCJVknLs/vodivqM
+        qCRAUbTYmzXzOJwZDmceHd6dyuLyCFIxwW9XwZW/ugSeiJTxw+3q/suPZLe6iy5CLSlXNNGIii4u
+        L0OWRo9P+bU6hx7+NBKlqa5VdBQshTT02k+j0ecKIkULCL3mp5EltZS4z5kwJQhuB9EP97+F3lxs
+        wLQUNddR4F99DEKv/TKKEmSSU64JTRIjJOhL/KhB6dBz6cwaIVOQ+HHJWXG70rKGlWddkkA1pITq
+        S+Pm7SrFT81KWEVrP/hAAp/46y/+/ma9vvH3X9HZfkGzvq7Sd68PfFw/LGhTorRAr82HzfD2o79b
+        fwj8LscozZhUmnBawkv/UVnQZV0iyorys0MDJWWFQ/4MsWLaZavKBXfJM3qaZdUbhxXGrCiwsoYQ
+        q/TfDU5pCYA1kKYSlHJFf9LAU3MKi5BCJLRg2mVewgFvhCtFAi9AYUt4vwn8beiNRZ3bWJfyvByV
+        VZsVhBZVTtfvQl2/heI1ngdL5mc1Oh4MLat56roovUa1hU6lpOeJEvM56hguIxWVmmE6FGhdQAl4
+        QacrXMZprXMh2d9vmx+ZjalOcicmZ1U1rkZXSX+XJflKgfxvanF8Om1vJBmDIlVdPKaCElZR29vX
+        eMOmklH7Ga0M6VERkFJIgsmtBFfgzEmDG+Vsio5+wUH0KqAzMT3uF6CfrJVXMU38x+N85VxooAec
+        Kc/0jJpHsNcDx5SaV0RYSZHgbpiH7lrRBt5Y+vLH1+2fP2NKXwNNrUxdCXzfHy+fO+rQaSz96FOF
+        mqPhEEuIJrVpyownmPw5bBYrspLEHFCGB48rsOhikPOM1IYy4C6WIyygND0Ry0GcKjhBWXUUIBai
+        AMpXUUYLZfhPD+goB0ZBEiq7EajFE/Aouz5cPx4Q3nxZTcx4tPGD9W5n+jQft6BNFOx2yIzaj/aW
+        oVHS8K3fmaJYLf1312UqJu1hloLrPArwBs2EM+wZqEQ+s/Yn4Eba7tvOe2J6VMMX7z8PLGCQDl7m
+        omjS7e48rKQHILUsolzrSt14HlXY3dVVLCnj5uK0FX+FLRdbwNk0/YcSsFrTh0IchHfE+K8qfrgD
+        fmRScAO4VZSnsTgh++jtt21FQkWxe/wqTAHa31aTAy10jh5DdM+fuHjmoTeSWVAKMdOD3n62qlri
+        wWEVHurCEL8R6qWmnyGGxeKYHKAjWdcGz1IUI0QnaNOnVI1dFKcgfxowE+m0K4uMGC3lCYb5+ZPZ
+        ca7oUiXSOml67bD7ILOgmrO/amgvE4ox+Qy7sYyyzX4XbLbb+HqzTnabZLv3s+0mpvv9erfJgj0S
+        5KWl1vIReCmISp8WLluvbyfB9LK1DxaSM6xMeZ6wjX5SNwhAQ+0ZmhuKjB4VZfXOV0KP7y20T6OB
+        zIxfSw1i6cFjE6owA90rp/noXRtxIiWwmUFEK4YuzOU2QG8e4T8OunnaLAat6rhkGkv8IRPyYWBp
+        31cKNq+lYP5C/m8D7iXtTbCjsKBuXl3HKpGsWuTdI30/uJpHBamQ54mUILUlJneOVv8CiW5J7cSi
+        yy/2MXyA4Oh3PBpSppoW5tSBtSK6nrIwhJZevDg25r5NjSIhN/9qYFwLbarXW0qQU85hbhXP/Gg4
+        TAawxD7MtuKZ2NOcaTENcS2VfROloPHR3zHpqcp9NqMHlXv7KWb2R8474XAyCcCBLN1umMclViqS
+        eZfBOkkc7yU8kYXYTeRVjbfKURotkyCMIzuv7QPVsCc7Rh7MGAm9JdCU344CndLgMcVdBL1tqyHF
+        b9nqmbPOkTMRvF6m7gBdz8Q0Y5PmEV18AwAA//8DAL6AUbEjFAAA
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: ['"47bc812ada144cffea83cb59317bdf1f"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]

--- a/tests/py/fixtures/TestPayday.yml
+++ b/tests/py/fixtures/TestPayday.yml
@@ -1,43 +1,43 @@
 interactions:
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>10.0</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>10.0</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAEFl11UAA9xXS2/bOBC+51cEvjOy/EidQlFQoFhggd29tOmhl4KiRhZjiVRJyrH763coSrJk
-        UWn3sMBib9LMx+G8Zxg9ncri9ghKcykeF+HdcnELgsmUi/3j4vnzb2S3eIpvIqOo0JQZRMU3t7cR
-        T2P2cMq/b6IAPy1FG2pqHdPa5FLxH5BGQUuyXHOuINa0gChoPi2N1UrhXWfCtSR4JcTPnz5GwZRs
-        wbSUtTBxuLxbLqOg/bOMEhTLqTCEMmaJBPXRJnk4bN79+JG8rNT99iUKfCh7WqoUFP7cCl48Loyq
-        YRE45RRQAymh5tYq/LhI8dfwEhbxahluyXJHVuHn8N377er9MvyKavcHmvN1lf6z85cDrXO0kai1
-        /XH+DsPNZr1d9R5HasaVNkTQEq71R2ZB53lMlhUVZw8HSsoLD/0VEs2NT1aVS+GjZ/Q08WowNCtK
-        eFFgnl1M3Lz+u8ZpowAwB9JUgdY+608GRGqjMAspJKMFNz7xCvZYHz4XSSyFwiXzwyZcvouCIalT
-        G/NSneetcmx7gtCiyunql1Drn6FEjfHgbBqrQXjQtKwWqa9Qeo5uE50qRc8jJvpz0D98QjQYU0AJ
-        WJgJNSz3YnJeVcN08eXc/zJn3ojgfyZZhtFpmxfJOBSp7uyhynDGK+qa7wpLYEwZ9IfByYgeNQGl
-        pCLo3EoKDV6fNLiBz8bo+E+cGW8COhHjcF+BfndS3sQ09h+P05NTooXusem/0jNyXsCVB84RPc2I
-        qFKS4W3oh27E0gbeSPq4/ePrJ+vSt0BjKWNVwqUdq3PcmZMGUz/+UCHnaMf9HKJxbZpyqwk6fwqb
-        2HqUnNkAZRh4PIFJl4CaeqS2Mx1vcUN8BmXoibh1wcuCE5RVN6MTKQugYhFntNB2VekB3U6AVhBG
-        VTejjDyAiJNDXn0vEd78OU7CRbxZhqvdzjZSMWxBmzjc7cIoaH/aKkOhpFmNvnBNMVv6/67LVFy5
-        YJZSmDwOMdwT4gR7Bqpw4VgtR+CG2t7bDmRie1Sz3j1/uozpC/WiZS6Lxt3+zsNLugdSqyLOjan0
-        +yCgGru7vksU5cIWTpvxd9hysQWcbdP/VgJma/qtkHsZHNH+u0rsn0AcuZLCAh41FWkiT7ge9PLb
-        tqKgotg9/pI2Ad234+RAC5OjxrhXioOQryIKBjQHSiHh5sJ3vy2rVhg4zMJ9XdjNbIC65vQzxK6Z
-        nBYX6IDWtcGzksUA0RFa92ldYxfFKSgOF8yIOu7KMiOWSwWz6/MHe+OU0blKpjVreu3l9gvNgWrB
-        v9fQFhOS0fkcu7GKN2u224RZytiarbP7+/X9NoNtuFwz2EHCMM1njzrJRxClJDo9zBRbz28nwbjY
-        2vcFyTlmpjqPdo1+UjcIQEFtDG2F4sqNjLL6xTW8x/cS3nzYNIi5t4lzqEYPKJlzU9G6OGDVNpRe
-        v8FipCV2NIhpxVGPKd1ZGVyb2VNa17jeWFD/olUnmilezS5iA37fyZo1kFQ4+GVKcNch1ome2r9C
-        olrKeLGo8tU9dkAQnAWeHTLluslpLw+cFNkl2UxXmnujYB+Z6jYWihuafZGiXTN52/PdjMBXpoCp
-        VIz50Q61DGBuHNlr5Stx0Zxw0Q1JrbRbklMw+EzrVqsxyx+bwYbtv36MmTzCfxEOJ+sA7NDKr4Z9
-        DmCm4nbnE1gz5lmgMSIztlvLq9qALzXa0UK4wHWtbj6bcer6yjfbV6JgDjReeAaGjvei4c4zC/q5
-        rGZL+pmsfpUyOQ5RguVl8w5Q9UyOPTZqHvHN3wAAAP//AwB/dUO/4xEAAA==
+        H4sIAD9KDlYAA9xXQW+sNhC+51es9u4AG97LbkSIntRW6qE99L20Ui+RgWFxAjbPNpvd/vqOMbCw
+        mCQ9VKp6g5nP45nxeOZz9HCsytUBpGKC36+Da3+9Ap6KjPH9/frx209ku36IryItKVc01YiKr1ar
+        iGVxWO/D72Hk4aeRKE11o2La6EJI9hdkkdeJjFafaogVLSHy2k8jSxspca8TYUoQ3BLiHx9/i7y5
+        2IBpJRqu48C/9v3I6/6MogKZFpRrQtPUCAn6kzxrUDryXDqzRsgMJP6sOCvv11o2sPasSxKohoxQ
+        vTJu3q8z/NWsgnW88YNPJPCJv/nm7+6C4G7z+U90dljQrm/q7J+tPy/oUqK0QK/Nj83y7Wd/u/kU
+        +H2eUZozqTThtIJL/1FZ0mVdKqqa8pNDAxVlpUP+Coli2mWrLgR3yXN6nGXVG4cVJawssbrOIdbZ
+        vxuc0hIAayDLJCjliv6ogWfmFBYhpUhpybTLvIQ93gpXigRegNKW8C4M/NvIG4t6t7Eu5Wk5Kqs2
+        Kwgt64JuPoS6eQ/FGzwPls7PanQ8GFre8Mx1UQaN6gqdSklPEyXmc9Q1XEZqKjXDdCjQuoQK8IJO
+        V7iMnxvMe+ZHZhOq08KJKVhdj6vRVdL/y5J8o0D+M7U4Pp2uN5KcQZmpPh5TQSmrqe3tG7xhU8mo
+        /YxWRvSgCEgpJMHk1oIrcOakxY1yNkXHv+AgehPQm5ge9wXoZ2vlTUwb/+EwXzkXGugeZ8orPaHm
+        Gez1wDGl5hUR1VKkuBvmob9WtIW3ljb+D39sv2JK3wJNrUxdCXwzq5e0Cys1ln78pUbNwXCIJUSb
+        2ixjxhNM/hw2i/UgWGoOKMeDxxVYdAnIeUYaQxlwF8sRFlCaHonlIE4VHKGqewqQCFEC5es4p6Uy
+        /GcA9JQDoyAplf0I1OIFeJzf7G+e9whv/6wmYTwO/WCz3Zo+zcctKIyD7TaIvO6nu2VolLR863em
+        KFbL8N93mZpJe5iV4LqIA7xBM+EMewIqsTo2/gTcSrt9u3lPTI9qOePj1zMLOEvPXhaibNPt7jys
+        onsgjSzjQuta3XkeVdjd1XUiKePm4nQVf40tF1vAyTT9pwqwWrOnUuyFd8D4r2u+fwB+YFJwA7hX
+        lGeJOCL7GOx3bUVCTbF7/CpMAdpvqymAlrpAjyF+5C9cvPLIG8ksKIOE6bPe/naqRuLBYRXum9IQ
+        vxHqUjPMEMNicUyeoSNZ3wZPUpQjRC/o0qdUg10UpyB/OWMm0mlXFjkxWspTDPPrF7PjXNGnSmRN
+        2vba8+5nmQU1nH1voLtMKMbkM+zGMs7D3TYIb2+Tm3CTbsP0dufnt2FCd7vNNsyDHRLkpaXW8gF4
+        JYjKXhYu26DvJsH0snWPFlIwrEx5mrCNYVK3CEBD3RmaG4qMHhVV/UGWP+AHC2++llrE0oPHJlRh
+        BvpXTvszuDbiREpgM4OY1gxdmMttgN5lhIOky4ptiyV1c6wmUalk9SIHG+mHJtYSTFLjzBcZQZpD
+        TP4c1/4CiW5J7cSiyxf7mNlAcAw4CGTGVFvOTh1YK6Kvr4WGtPT6wRYy921qFMmZeeFiXAslO+jt
+        eMD3K4e5VTzzg5lnOcDSJDLbildiT3OmxTQkjVSWH2eg8QHYs6qpyn02I3Lt3n6KmT3qPwiHo0kA
+        NmfpdsM8NLBSkdi5DDZp6uDOeCILsZvI6wZvlaM0uqlCGEem1tjHipmktqU8mZYSeUugKdcZBTql
+        RGO6swh631ZLkN6zNbAoXeD8JHi9TN0Bup6LacYmzSO++hsAAP//AwCmQ92TMxIAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"4e915be350b75c10e38db3c0270e5465"']
+      etag: ['"ded5751f2605a0dbdd83104d09f8e9f1"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -46,83 +46,83 @@ interactions:
     body: <transaction><amount>10.0</amount></transaction>
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/c9xhq4/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/4pg4q4/submit_for_settlement
   response:
     body:
       string: !!binary |
-        H4sIAENl11UAA9xYS2/bOBC+91cEvjOy/EidQFFRoFhggd29pN1DLwFFjSzWEqmSlGPn1+9QlGQp
-        opIAiwWKvVkzH4fznqGjT6eyuDqC0lyK+0V4vVxcgWAy5WJ/v/j29TeyW3yKP0RGUaEpM4iKP1xd
-        RTyN2e0p/7mJAvxpKdpQU+tY10nJjYH0MZPqUYMxBZQgTBS0AIs15wpiTQuIguanpbFaKbz5TLiW
-        BBWA+NvDlyiYki2YlrIWJg6X18tlFLRfllGCYjkVhlDGLJGgdtokt4fNx+fn5MdK3Wx/RIEPZU9L
-        lYLCjyvBi/uFUTUsAqecAoo2EWqurML3ixQ/DS9hEa+W4ZYsd2QVfg0/3m1Xd8vwO6rdH2jO11X6
-        /vNrPH850DpHG4la2w/n/TDcbNbbVe9/pGZcaUMELeGl/sgs6DyPybKi4uzhQEl54aE/QaK58cmq
-        cil89IyeJl4NhmZFCS8KzLqLiZun/9Y4bRQA5kCaKtDaZ/3JgEhtFGYhhWS04MYnXsEeq8XnIoml
-        ULhkvt2Ey49RMCR1amNeqvO8VY5tTxBaVDldvQu1fgslaowHZ9NYDcKDpmW1SH2F0nN0m+hUKXoe
-        MdGfg27iE3LpGiShhuVeTM6rapguvpz7X+bMKxH8ZZJlGJ22eZGMQ5Hqzh6qDGe8oq75rrAExpRB
-        fxicjOhRE1BKKoLOraTQ4PVJgxv4bIyO/8SZ8SqgEzEO9wvQ707Kq5jG/uNxenJKtNA9Nv0nekbO
-        D3DlgXNETzMiqpRkeBv6gdYml4o/0wbeSPqy/eP7g3Xpa6CxlLEq4dKO1TnuzEmDqR9/rpBzhNR7
-        ukE0rk1TbjVB509hE1uPkjMboAwDjycw6RJQU4/UdqbjLW6Iz6AMPRG3LnhZcIKy6mZ0ImUBVCzi
-        jBbario9oNsJ0ArCqOpmlJEHEHFyyKufJcKbL8dJuIg3y3C129lGKoYtaBOHu10YBe1HW2UolDSr
-        0d9cU8yW/rvrMhVXLpilFCaPQwz3hDjBnoEqXDhWyxG4obb3tgOZ2B7VLHvfHi5j+kK9aJnLonG3
-        v/Pwku6B1KqIc2MqfRcEVGN319eJolzYwmkz/hpbLraAs236jyVgtqaPhdzL4Ij2X1di/wnEkSsp
-        LOBeU5Em8oTrQS+/bSsKKord4y9pE9D9dpwcaGFy1Bj3SnEQ8klEwYDmQCkk3Fz47rNl1QoDh1m4
-        rwu7mQ1QLzn9DLFrJqfFBTqgdW3wrGQxQHSE1n1a19hFcQqKwwUzoo67ssyI5VLB7Pr82d44ZXSu
-        kmnNml57uf1Cc6Ba8J81tMWEZHQ+x26s4s2a7TZhljK2Zuvs5mZ9s81gGy7XDHaQMEzz2aNO8hFE
-        KYlODzPF1vPbSTAutva1QXKOmanOo12jn9QNAlBQG0NbobhyI6Os3rnG9/heQvuK6Rqq7XSXh02D
-        mHubOIdq9ICSOTcVrYsDVm1D6fUbLEZaYkeDmFYc9ZjSnZXB1Mx/b/n6Ncvf88D7BfzQU9oUcTOi
-        oP6Fs040U7yaXUgH/L6jN+swqXABkinBnY9Yl3p64AskqqWMF4sqv7jHDkqCM9GzS6dcN7Xt5YGT
-        Irtim+nOc2817KdT3cZCcVO1L3O0a6Z+e76blfjaFjCVijE/2uGeAcyNZXutfCIumhMuuiGplXaP
-        hRQMPle7FXPM8sdm8NLwXz/GTP6MeCccTtYBOKmUXw37LMJMxS3XJ7BmzPOQwIjM2G4tr2oDvtRo
-        RyzhAtfWuvnZrBWuvz7a/hoFc6Dx4jcwdLwfDne/WdDbsppt8S1Z/UppclwmCJaXzTtA1TM59tio
-        ecQf/gEAAP//AwAk7QPi+RIAAA==
+        H4sIAEBKDlYAA9xYzW7jNhC+5ykM3xlJjndtB4qCBdoCPbSHZrMFegkoaWQxkUgtSTl2n75DUZIl
+        i0oCFEWL3qyZj8OZ4fw6vD+WxeIAUjHB75bBtb9cAE9Eyvj+bvn49SeyXd5HV6GWlCuaaERFV4tF
+        yNJoXe3X39ehhz8NRWmqaxWpOi6Z1pA+ZUI+KdC6gBK4Dr0WYLD6VEGkaAGh1/w0tKSWEm8+EaYE
+        QQUg+vHxt9Cbkg2YlqLmOgr8a98PvfbLMEqQSU65JjRJDJGgdvGzBoUKuHjmjJApSPxYcFbcLbWs
+        YelZlSRQtIRQvTBq3i1T/NSshGW08oNPJPCJv/rq726D4Hb1+Q9Utj/QnK+r9OPnt3j+fKB1idIC
+        tTYf1uebz/529SnwO68jNWNSacJpCZf6I7Og87xElBXlJwcHSsoKB/0VYsW0S1aVC+6iZ/Q48ao3
+        NCuMWVFgrJ1NrNJ/1jilJQDGQJpKUMpl/VEDT80rzEIKkdCCaZd4CXvMEZeLBCZAYUN4tw78TegN
+        SZ3aGJfyNG+VZZsThBZVTlcfQt28h+I1vgdLpm81eB40Lat56kqUnqPaQKdS0tOIif4c1BCXkIpK
+        zdAd55pxccIlnNY6F5L9+b74gdiY6iR3YnJWVcNodIX0/zIk3wiQ/0wsDl+nrY0kY1CkqrPHRFDC
+        Kmpr+wozbEwZlJ/ByZAeFAEphSTo3EpwBU6fNLiBz8bo6BdsRG8COhHj574A/WylvIlp7D8cpien
+        RAPdY095pSfkPINND2xTahoRYSVFgrehH7q0og28kbTyf/h9+4AufQs0ljJWJfBNr57jzpzUGPrR
+        lwo5B0idpxtE49o0ZUYTdP4UNrH1IFhiHijDh8cTGHQxyKlHajMy4C12RphBaXokdgZxsuAIZdWN
+        ALEQBVC+jDJaKDP/9IBu5EArSEJl1wK1eAEeZTf7m+c9wpsvy4kZj9Z+sNpuTZ3mwxK0joLtNgi9
+        9qPNMhRKmnnrG1MUo6X/7qpMxaR9zFJwnUcBZtCEOMGegEqMjpU/AjfU9t623xNTo5oJ8vHhPAWc
+        qWctc1E07nZXHlbSPZBaFlGudaVuPY8qrO7qOpaUcZM4bcRfY8nFEnAyRf+pBIzW9KkQe+Ed0P7r
+        iu/vgR+YFNwA7hTlaSyOOH308tuyIqGiWD1+FSYA7W/LyYEWOkeNIXrkL1y88tAb0CwohZjpM99+
+        tqxa4sNhFO7rwgx+A9Qlp+8hZorFNnmGDmhdGTxJUQwQHaF1n1I1VlHsgvzljBlRx1VZZMRwKU/Q
+        zIcv5sYpo3OVSOukqbXn2880C6o5+15Dm0xIRuczrMYyyta7bbDebOKb9SrZrpPNzs8265judqvt
+        Ogt2OCDPHbWSD8BLQVT6MpNsPb/tBONka1cYkjOMTHkaTRt9p24QgILaNzQZihM9Msrqg1tCj+8l
+        tKvReZgZbksNYm7hsQ5V6IFuy2k+etUGM5ESWMwgohVDFaZ0a6A3tfDvG719y+iPLIz/rgt6ShsY
+        tjMU1D1m1rFKJKtmx9ABv6/jzYxNKhx7REpw0iPGm47Kd4FEtaR2YlHli3tMeyTYCR0zdMpUk9FO
+        HlgpokuxmZo8twBiFZ3qNhaK86lZ8tGumazt+bZD4grPYSoV3/xgWnoGMNeMzbXildjXnHDRDXEt
+        lV0RUtC4A3eD5ZjlfpvBfuG+foyZ/K/xQTgcjQOwP0m3GmbXwkjF2dYlsE4Sx/qALzJju7G8qjGr
+        HKHRNlbCOA6rtd3XzDBhq+qTqaqhNwcaj3sDQ8dT4XDimwW9L6uZEd+T1Q+SOscRgmB6mbgDVD0T
+        Y4+Nikd09RcAAAD//wMAWrAa3EQTAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"921b3efc34f3fdba32afee3246beb849"']
+      etag: ['"47fbb3874835e3e22e44b2f347bcaaa9"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>10.61</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>10.61</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAEVl11UAA9xXTW/kNgy9768I5q54PB/JbOA42KIo0ALdyyZ76CWQZc5YGVtyJHkyk19fyrI9
-        diwn6aFA0ZtNPlEkRZFP0d2xyC8OoDSX4nYWXs5nFyCYTLnY3c4e7n8jm9ld/CUyigpNmUFU/OXi
-        IuJpvF8/r5SJAvy0Em2oqXRMK5NJxV8hjYJGZLXmVEKsaQ5RUH9aGauUwr1OhGtJcEuIH378GgVj
-        sQXTQlbCxOH88iqMgubPKgpQLKPCEMqYFRL0R5vk6351/fqaPC3U1fopCnwou1qqFBT+XAie386M
-        qmAWOOcUUAMpoebCOnw7S/HX8AJm8WIersl8QxbhfXh9s17czFd/odvdgnp9Vab/bP15QZMcbSR6
-        bX9cvsNwtVquF6s24yjdcqUNEbSAt/6jMqfTOiaLkoqTRwMF5blH/gKJ5sZnq8yk8Mm39DjKatAP
-        K0p4nmOdnUNcvfy7wWmjALAG0lSB1r7ojwZEak9hEpJLRnNufOYV7PB++FIk8Srkrpi/rsL5dRT0
-        Ra3bWJfqNB2VU9sVhOZlRhefQi0/QokKz4Oz8Vn1jgdD21Yi9V2UTqObQqdK0dNAifns9Q+fEQ3G
-        5FAAXsyEGpZ5MRkvy365+Gruf1kz75zgf6ZY+qfTNC+y5ZCnuo2HKsMZL6lrvgu8AkNJrz/0Vkb0
-        oAkoJRXB5JZSaPDmpMb1cjZEx3/izHgX0JoYHvcb0O/OyruYOv7DYbxyLLTQHTb9F3pCzRO464Fz
-        RI8rIiqVZLgb5qEdsbSG15Z++ePq+z0OkXdBQytDV8L5fN5fPnbUozNY+vG3EjUHO+6nEHVq05Rb
-        TzD5Y9go1oPkzB7QFg8eV2DRJaDGGansTMdd3BCfQBl6JI4ueFVwhKJsZ3QiZQ5UzOItzbWlKh2g
-        5QQYBWFUtTPKyD2IONln5XOB8PrPaRIu4tU8XGw2tpGKfgtaxeFmgySm+WluGRolNTX6yTXFaun+
-        2y5TcuUOs5DCZHGIN2gkHGFPQBUSjsV8AK6lzb7NQCa2R9X07uHHeUyfpWcvM5nX6fZ3Hl7QHZBK
-        5XFmTKlvgoBq7O76MlGUC3txmoq/xJaLLeBkm/5jAVit6WMudzI4YPyXpdjdgThwJYUF3Goq0kQe
-        kR509pu2oqCk2D2+S1uA7ttpMqC5ydBj5JViL+SLiIKezIFSSLg5691vo6oUHhxW4a7KLTProd5q
-        uhliaSan+Rnak7Vt8KRk3kO0giZ9WlfYRXEKiv0ZM5AOu7LcEqulgln6/M3uOFa0qZJpxepee979
-        LHOgSvDnCprLhGJMPsdurOLVkm1W4TZlbMmW26ur5dV6C+twvmSwgYRhmU8udZYPIApJdLqfuGyd
-        vpkEw8vWvC9IxrEy1WnANbpJXSMADTVnaG8oUm5UFOUnaXiH7yy8+7CpEVNvE5dQjRlQMuOmpFW+
-        x1tbSzr/esRIS+xoENOSox9juYsyeBtmJ2lS43pjTv1Eq0o0U7ycJGI9fdfJahpIShz8MiXIdYhN
-        oufuv0GiW8p4sejym33sgCA4CzwcMuW6rmmvDpwV2RbZRFeaeqNgHxn7NjSKDM2+SDGuibrt9G5G
-        4CtTwNgqnvnBDrUtwNQ4stvKF+JOc6TFNCSV0o4kp2DwmdZSq6HKfzY9hu3ffogZPcI/CYejTQB2
-        aOV3wz4HsFKR3fkMVox5CDSeyETsNvKyMuArjWa0EC6QrlX1Zz1OXV95tH0lCqZAQ8LTC3TIi/qc
-        ZxL0sa2aJX1kq6NSJsMhSvB62boDdH0rhxkbNI/4y98AAAD//wMANf2w7uMRAAA=
+        H4sIAEJKDlYAA9xXwXKkNhC9+ytcc5eB8ex6xoVxbVWyqRySw+46h724BDSDbJAUSYxn8vVpIWDA
+        CHtzSFUqN+h+anW3Wt1P8f2xri4PoDQT/G4VXYWrS+CZyBnf360evn0m29V9chEbRbmmmUFUcnF5
+        GbM8WZ8kf97EAX5aiTbUNDqhjSmFYn9BHgedyGrNSUKiaQVx0H5aWdYohXudCNOC4JaQ/PzwJQ7m
+        YgumtWi4SaLw6mMUB92fVdSgspJyQ2iWWSFBf9InA9rEgU9n1wiVg8KfS86qu5VRDawC55ICaiAn
+        1FxaN+9WOf4aVsMqWYfRBxKFJFx/C3e3UXS73n1HZ4cF7fpG5v9s/XlBlxJtBHptf1yWbz6G2/WH
+        KOzzjNKCKW0IpzW89h+VFV3WZaKWlJ88GqgpqzzyF0g1Mz5bshTcJy/ocZbVYBxWnLKqwuo6hyjz
+        fzc4bRQA1kCeK9DaF/3RAM/tKSxCKpHRihmfeQV7vBW+FAm8AJUr4d0mCm/iYCzq3ca6VKflqJza
+        riC0kiVd/xDq+j0Ub/A8WDY/q9HxYGhFw3PfRRk0uit0qhQ9TZSYz1HX8BmRVBmG6dBgTAU14AWd
+        rvAZPzeY98yPzKbUZKUXUzIpx9XoK+n/ZUm+USD/mVocn07XG0nBoMp1H4+toIxJ6nr7Gm/YVDJq
+        P6OVMT1oAkoJRTC5UnAN3py0uFHOpujkNxxEbwJ6E9PjfgX61Vl5E9PGfzjMV86FFrrHmfJCT6h5
+        Anc9cEzpeUXEUokMd8M89NeKtvDW0ufvP335xab0LdDUytSVKAzD8fK5ox6dwdJPPknUHCyHWEK0
+        qc1zZj3B5M9hs1gPgmX2gAo8eFyBRZeCmmeksZQBd3EcYQFl6JE4DuJVwRFq2VOAVIgKKF8lBa20
+        5T8DoKccGAXJqOpHoBHPwJPien/9tEd4++c0KePJJozW263t03zcgjZJtN0iM+p+uluGRknLt/5g
+        mmK1DP99l5FMucOsBTdlEuFxz4Qz7AmoQj6zDifgVtrt2817YntUyxkfvp5ZwFl69rIUVZtuf+dh
+        Nd0DaVSVlMZIfRsEVGN311epoozbi9NV/BW2XGwBJ9v0H2vAas0fK7EXwQHjv5J8fw/8wJTgFnCn
+        Kc9TcUT2Mdjv2ooCSbF7/C5sAbpvpymBVqZEjyF54M9cvPA4GMkcKIeUmbPe/XaqRuHBYRXum8oS
+        vxHqtWaYIZbF4pg8Q0eyvg2elKhGiF7QpU/rBrsoTkH+fMZMpNOuLApitZRnGObXT3bHuaJPlcib
+        rO21593PMgdqOPuzge4yoRiTz7Abq6TY7LbR5uYmvd6ss+0mu9mFxc0mpbvderspoh0S5KWlzvIB
+        eC2Izp8XLtug7ybB9LJ1jxZSMqxMdZqwjWFStwhAQ90Z2huKjB4VtXyf5V+HyPIH/GDhzddSi1h6
+        8LiEasxA/8ppfwbXRpxIC2xmkFDJ0IW53AUYvI5wkHRZcW2xon6O1aQ6U0wucrCRfmhiLcEkEme+
+        yAnSHGLz57n2r5DoljJeLLr8ah87GwiOAQ+BzJluy9mrA2dF9PW10JCWXj/YQua+TY0iObMvXIxr
+        oWQHvRsP+H7lMLeKZ36w86wAWJpEdlvxQtxpzrSYhrRR2vHjHAw+AHtWNVX5z2ZErv3bTzGzR/0P
+        wuFoE4DNWfndsA8NrFQkdj6DTZZ5uDOeyELsNnLZ4K3ylEY3VQjjyNQa91ixk9S1lEfbUuJgCTTl
+        OqNAp5RoTHcWQe/bagnSe7YGFmVKnJ8Er5etO0DXCzHN2KR5JBd/AwAA//8DAOzP5aczEgAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"4fe130aca1c632e3673daf450217b4a8"']
+      etag: ['"d7e00a34d5d6022186c51639c6e70a2c"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -131,83 +131,83 @@ interactions:
     body: <transaction><amount>10.61</amount></transaction>
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/k5q4rt/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/2ypnk4/submit_for_settlement
   response:
     body:
       string: !!binary |
-        H4sIAEZl11UAA9xYS4/bNhC+51csfOfK8itOoNUiRVGgBZpLsj30sqCokcW1RCok5bXz6zsUJVla
-        UZsFigJBb9bMx+G8Z+jo/lwWNydQmktxtwhvl4sbEEymXBzuFg9ffyP7xX38LjKKCk2ZQVT87uYm
-        4ml83H7bKBMF+NNStKGm1rGuk5IbA+ljJtWjBmMKKEEgrgVYrLlUEGtaQBQ0Py2N1UrhzRfCtSSo
-        AMQPX36NginZgmkpa2HicHm7C6Og/bKMEhTLqTCEMmaJBLXTJvlw3Lz//j15Wqnd9ikKfCh7WqoU
-        FH7cCF7cLYyqYRE45RRQtIlQc2MVvluk+Gl4CYt4tQy3ZLknq/Br+P7jdvVxufkb1e4PNOfrKn37
-        +R2evx5onaONRK3th/N+GG426+1q0/kfqRlX2hBBS3ipPzILOs9jsqyouHg4UFJeeOjPkGhufLKq
-        XAofPaPniVeDoVlRwosCs+5q4ub5vzVOGwWAOZCmCrT2WX82IFIbhVlIIRktuPGJV3DAavG5SGIp
-        FC6ZP2zC5fsoGJI6tTEv1WXeKse2Jwgtqpyu3oRa/wglaowHZ9NYDcKDpmW1SH2F0nN0m+hUKXoZ
-        MdGfg27iE3LtGiShhuVeTM6rapguvpz7X+bMKxH8aZJlGJ22eZGMQ5Hqzh6qDGe8oq75rrAExpRB
-        fxicjOhJE1BKKoLOraTQ4PVJgxv4bIyO/8SZ8SqgEzEO9wvQ707Kq5jG/tNpenJKtNADNv1nekHO
-        E7jywDmipxkRVUoyvA39QGuTS8W/0wbeSPrlj93nrzhEXgWNpYxVCZfL5fD4VFEPz2Dqx58q5Jwg
-        9Z5uEI1r05RbTdD5U9jE1pPkzAYow8DjCUy6BNTUI7Wd6XiLG+IzKEPPxK0LXhacoay6GZ1IWQAV
-        izijhbarSg/odgK0gjCquhll5BFEnBzz6luJ8ObLcRIu4s0yXO33tpGKYQvaxOF+j0tM+9FWGQol
-        zWr0F9cUs6X/7rpMxZULZimFyeMQK2hCnGAvQBUuHKvlCNxQ23vbgUxsj2qWvYcv1zF9pV61zGXR
-        uNvfeXhJD0BqVcS5MZX+GARUY3fXt4miXNjCaTP+FlsutoCLbfqPJWC2po+FPMjghPbfVuJwD+LE
-        lRQWcKepSBN5xvWgl9+2FQUVxe7xWdoEdL8dJwdamBw1xr1SHIV8FlEwoDlQCgk3V777bFm1wsBh
-        Fh7qwm5mA9RLTj9D7JrJaXGFDmhdG7woWQwQHaF1n9Y1dlGcguJ4xYyo464sM2K5VDC7Pn+yN04Z
-        natkWrOm115vv9IcqBb8Ww1tMSEZnc+xG6t4s2b7TZiljK3ZOtvt1rttBttwuWawh4Rhms8edZJP
-        IEpJdHqcKbae306CcbG1rw2Sc8xMdRntGv2kbhCAgtoY2grFlRsZZfXGNb7H9xLaV0zXUG2nuz5s
-        GsTc28Q5VKMHlMy5qWhdHLFqG0qv32Ax0hI7GsS04qjHlO6sDKZm/nvLd69Z/pYH3k/gh57Spoib
-        EQX1L5x1opni1exCOuD3Hb1Zh0mFC5BMCe58xLrU0wNfIFEtZbxYVPnFPXZQEpyJnl065bqpbS8P
-        nBTZFdtMd557q2E/neo2Foqbqn2Zo10z9dvz3azE17aAqVSM+ckO9wxgbizba+UzcdGccNENSa20
-        eyykYPC52q2YY5Y/NoOXhv/6MWbyZ8Qb4XC2DsBJpfxq2GcRZipuuT6BNWOehwRGZMZ2a3lVG/Cl
-        RjtiCRe4ttbNz2atcP310fbXKJgDjRe/gaHj/XC4+82Cfiyr2RZ/JKtfKU2OywTB8rJ5B6h6Jsce
-        GzWP+N0/AAAA//8DAJrR5wn5EgAA
+        H4sIAENKDlYAA9xYwW7jNhC95ysM3xlJjndtB4qCBdotemgPu5s97CWgpJHFRCJVknLsfn2HoiRL
+        FpUEKIoWvVkzj8OZ4XDm0eH9sSwWB5CKCX63DK795QJ4IlLG93fLh2+fyXZ5H12FWlKuaKIRFV0t
+        FiFLo9Wp4s/r0MOfRqI01bWKVB2XTGtIHzMhHxVoXUAJXIdeCzBYfaogUrSA0Gt+GllSS4k7nwhT
+        gqADEP388CX0pmIDpqWouY4C//pjEHrtl1GUIJOcck1okhghQe/iJw0KHXDpzBohU5D4seCsuFtq
+        WcPSsy5JoBgJoXph3LxbpvipWQnLaOUHH0jgE3/1zd/dBsHtavcDne0XNOvrKn33+psA158XtClR
+        WqDX5sPmfPPR364+BH6XdZRmTCpNOC3h0n9UFnRel4iyovzk0EBJWeGQv0CsmHbZqnLBXfKMHidZ
+        9YZhhTErCqy1c4hV+s8Gp7QEwBpIUwlKuaI/auCpOYVZSCESWjDtMi9hj3fElSKBF6CwJbxbB/4m
+        9Iaizm2sS3maj8qqzQpCiyqnq3ehbt5C8RrPgyXTsxocD4aW1Tx1XZReo9pCp1LS00iJ+Rz0EJeR
+        ikrNMB3nnnGxwmWc1joXkv35tvmB2ZjqJHdiclZVw2p0lfT/siRfKZD/TC0OT6ftjSRjUKSqi8dU
+        UMIqanv7Cm/YWDJoP4OVIT0oAlIKSTC5leAKnDlpcIOcjdHRbziIXgV0JsbHfQH61Vp5FdPEfzhM
+        V06FBrrHmfJCT6h5Ans9cEypaUWElRQJ7oZ56K4VbeCNpc8/fvryi0npa6CxlbErge/7w+VTRx06
+        jaUffapQc4DUubpBNKlNU2Y8weRPYZNYD4Il5oAyPHhcgUUXg5xmpDaUAXexHGEGpemRWA7iVMER
+        yqqjALEQBVC+jDJaKMN/ekBHOTAKklDZjUAtnoFH2c3+5mmP8ObLamLGo7UfrLZb06f5sAWto2C7
+        RWbUfrS3DI2Shm99Z4pitfTfXZepmLSHWQqu8yjA454IJ9gTUIl8ZuWPwI203bed98T0qIZBPnw9
+        s4Cz9OxlLoom3e7Ow0q6B1LLIsq1rtSt51GF3V1dx5Iybi5OW/HX2HKxBZxM038sAas1fSzEXngH
+        jP+64vt74AcmBTeAO0V5Gosjso/efttWJFQUu8fvwhSg/W01OdBC5+gxRA/8mYsXHnoDmQWlEDN9
+        1tvPVlVLPDiswn1dGOI3QF1q+hliWCyOyTN0IOva4EmKYoDoBG36lKqxi+IU5M9nzEg67soiI0ZL
+        eYJhfv1kdpwqulSJtE6aXnve/SyzoJqzP2poLxOKMfkMu7GMsvVuG6w3m/hmvUq262Sz87PNOqa7
+        3Wq7zoIdEuS5pdbyAXgpiEqfZy5br28nwfiytU8YkjOsTHkasY1+UjcIQEPtGZobioweFWX1Dpbv
+        I8vv8b2F9ml0JjPD11KDmHvw2IQqzED3ymk+etcGnEgJbGYQ0YqhC1O5DdCbRvj3gw5eC/o9D8Z/
+        NwW9pC0MOxkK6qaZdawSyapZGjrQ93284dikQtojUoJMj5hsOjrfBRLdktqJRZcv9jHjkeAkdHDo
+        lKnmRjt1YK2I7orN9OS5ByB20alvY6PIT80jH+OaubW93k5IfMJzmFrFMz+YkZ4BzA1js614IfY0
+        J1pMQ1xLZZ8IKWh8A3fEcqxyn83gfeHefoyZ/K/xTjgcTQJwPkm3G+athZWK3NZlsE4Sx/MBT2Qm
+        dhN5VeOtcpRGO1gJ40hWa/teM2TCdtVH01VDbw40pnuDQMescMj4ZkFv22o44lu2eiKpc6QQBK+X
+        qTtA1zMxztioeURXfwEAAP//AwCYUK+qRBMAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"1696567c11946b3cedf1f1aa7a6ef90a"']
+      etag: ['"084099e18312de227ab2199961fc8050"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>12.67</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>12.67</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAEll11UAA9xXwXLbNhC9+ys8usMUJdlWMjQzaTud6SG5OO6hlwwIrEREJMAAoCz567sgSIo0
-        QSc9dKbTG7n7sNhdLHYfkg+nsrg+gjZCyYdFfLNcXINkigu5f1g8ffmdbBcf0qvEaioNZRZR6dX1
-        dSJ4ylf8e2aTCD+dxFhqa5PS2uZKixfgSdSKnNaeK0gNLSCJmk8nY7XWuNeZCKMIbgnp0+NvSTQV
-        OzAtVS1tGq9u7u6TqP1zihI0y6m0hDLmhAT9MTZ7d9jcv7xk31b67vZbEoVQbrXSHDT+XEtRPCys
-        rmEReec0UAucUHvtHH5YcPy1ooRFulrGt2S5Jav4S3z//nb1fvnuL3S7X9Csryv+z9ZfFrTJMVah
-        1+7H5zuON5v17WrTZRylO6GNJZKW8Np/VBZ0XsdUWVF5DmigpKIIyJ8hM8KGbFW5kiH5jp4mWY2G
-        YSWZKAqss0uIm+d/NzhjNQDWAOcajAlFf7IguTuFWUihGC2EDZnXsMf7EUqRwqtQ+GJ+t4mXWMFD
-        Uec21qU+z0fl1W4FoUWV09VPodY/Qskaz0Ow6VkNjgdD29WShy5KrzFtoVOt6XmkxHwO+kfIiAFr
-        CygBL2ZGLcuDmFxU1bBcQjX3v6yZN07wP1Msw9NpmxfZCSi46eKh2gomKuqb7wqvwFgy6A+DlQk9
-        GgJaK00wuZWSBoI5aXCDnI3R6SecGW8COhPj434F+sNbeRPTxH88TldOhQ66x6b/TM+o+Qb+euAc
-        MdOKSCqtGO6GeehGLG3gjaVfPn/69XGLKX0LNLYydiVeLpfD5VNHAzqLpZ9+rFBzdON+DtGklnPh
-        PMHkT2GTWI9KMHdAOzx4XIFFl4GeZqR2Mx138UN8BmXpiXi6EFTBCcqqm9GZUgVQuUh3tDCOqvSA
-        jhNgFIRR3c0oqw4g0+yQV99LhDd/XpMJmW6W8Wq7dY1UDlvQJo232ziJ2p/2lqFR0lCjP4WhWC39
-        f9dlKqH9YZZK2hyZUBJNhBPsGahGwrFajsCNtN23HcjE9aiG3j09Xsb0RXrxMldFk+5w5xEl3QOp
-        dZHm1lbmfRRRg93d3GSaCukuTlvxN9hysQWcXdP/WgJWK/9aqL2Kjhj/TSX3H0AehVbSAR4MlTxT
-        J6QHvf22rWioKHaPz8oVoP/2mhxoYXP0GHmlPEj1LJNoIPMgDpmwF73/bVW1xoPDKtzXhWNmA9Rr
-        TT9DHM0UtLhAB7KuDZ61KgaITtCmz5gauyhOQXm4YEbScVdWO+K0VDJHnz+6HaeKLlWK16zptZfd
-        LzIPqqX4XkN7mVCMyRfYjXW6WbPtJt5xxtZsvbu7W9/d7uA2Xq4ZbCFjWOazS73lI8hSEcMPM5et
-        17eTYHzZ2vcFyQVWpj6PuEY/qRsEoKH2DN0NRcqNirL6SRre43sLbz5sGsTc28Qn1GAGtMqFrWhd
-        HPDWNpLevwExMgo7GqS0EujHVO6jjF6H2Uva1PjeWNAw0aozw7SoZonYQN93soYGkgoHv+IEuQ5x
-        SQzc/VdIdEvbIBZdfrWPGxAEZ0GAQ3JhmpoO6sBbUV2RzXSluTcK9pGpb2OjyNDcixTjmqnbXu9n
-        BL4yJUyt4pkf3VDbAcyNI7eteib+NCdaTENWa+NJMgeLz7SOWo1V4bMZMOzw9mPM5BH+k3A4uQRg
-        h9ZhN9xzACsV2V3IYM1YgEDjiczE7iKvaguh0mhHCxES6VrdfDbj1PeVr66vJNEcaEx4BoGOedGQ
-        88yCfmyrYUk/stVTKZvjECV4vVzdAbq+U+OMjZpHevU3AAAA//8DAJJzbEXjEQAA
+        H4sIAEdKDlYAA9xXQXOrNhC+v1/h8V0BbCexM4TMO7QzPbSHl5fO9F0yAhajBCQqCcfur+8KAQYj
+        kvTQmU5vsPtptbta7X4KH45lsTiAVEzw+2Vw5S8XwBORMr6/Xz59/5lslw/Rl1BLyhVNNKKiL4tF
+        yNLo5qZK1mno4aeRKE11rSJa61xI9hegphUZrT5VEClaQOg1n0aW1FLiXifClCC4JUQ/PX0LvanY
+        gGkpaq6jYHV1cxt67Z9RlCCTnHJNaJIYIUF/4hcNSoeeS2fWCJmCxJ8FZ8X9Ussalp51SQLVkBKq
+        F8bN+2WKv5qVsIxWfnBNAp/4q+/+7i4I7tbXP9DZfkGzvq7Sf7b+vKBNidICvTY/Nsu3N/52dR34
+        XZ5RmjGpNOG0hEv/UVnQeV0iyoryk0MDJWWFQ/4GsWLaZavKBXfJM3qcZNUbhhXGrCiwus4hVum/
+        G5zSEgBrIE0lKOWK/qiBp+YUZiGFSGjBtMu8hD3eCleKBF6AwpbwbhP4WLdDUec21qU8zUdl1WYF
+        oUWV09WnUOuPULzG82DJ9KwGx4OhZTVPXRel16i20KmU9DRSYj4HXcNlpKJSM0yHAq0LKAEv6HiF
+        y/i5wXxkfmA2pjrJnZicVdWwGl0l/b8syXcK5D9Ti8PTaXsjyRgUqeriMRWUsIra3r7CGzaWDNrP
+        YGVID4qAlEISTG4luAJnThrcIGdjdPQrDqJ3AZ2J8XFfgH6xVt7FNPEfDtOVU6GB7nGmvNETal7A
+        Xg8cU2paEWElRYK7YR66a0UbeGPpx+rm2+MfmNL3QGMrY1cC3/eHy6eOOnQaSz/6WqHmYDjEHKJJ
+        bZoy4wkmfwqbxHoQLDEHlOHB4wosuhjkNCO1oQy4i+UIMyhNj8RyEKcKjlBWHQWIhSiA8mWU0UIZ
+        /tMDOsqBUZCEym4EavEKPMrW+/XLHuHNn9XEjEcbP1htt6ZP82EL2kTBdhuEXvvT3jI0Shq+9TtT
+        FKul/++6TMWkPcxScJ0jvQq9iXCCPQGVyGdW/gjcSNt923lPTI9qOOPT45kFnKVnL3NRNOl2dx5W
+        0j2QWhZRrnWl7jyPKuzu6iqWlHFzcdqKv8KWiy3gZJr+cwlYrelzIfbCO2D8VxXfPwA/MCm4Adwr
+        ytNYHJF99PbbtiKhotg9fhOmAO231eRAC52jxxA98Vcu3njoDWQWlELM9Flvf1tVLfHgsAr3dWGI
+        3wB1qelniGGxOCbP0IGsa4MnKYoBohO06VOqxi6KU5C/njEj6bgri4wYLeUJhvn41ew4VXSpEmmd
+        NL32vPtZZkE1Z3/W0F4mFGPyGXZjGWWb3TbY3N7G680q2W6S252f3W5iututtpss2CFBnltqLR+A
+        l4Ko9HXmsvX6dhKML1v7aCE5w8qUpxHb6Cd1gwA01J6huaHI6FFRVp9k+T2+t/Dua6lBzD14bEIV
+        ZqB75TQ/vWsDTqQENjOIaMXQhancBuhdRthL2qzYtlhQN8eqY5VIVs1ysIG+b2INwSQVznyREqQ5
+        xOTPce0vkOiW1E4sunyxj5kNBMeAg0CmTDXl7NSBtSK6+pppSHOvH2whU9/GRpGcmRcuxjVTsr3e
+        jgd8v3KYWsUzP5h5lgHMTSKzrXgj9jQnWkxDXEtl+XEKGh+AHasaq9xnMyDX7u3HmMmj/pNwOJoE
+        YHOWbjfMQwMrFYmdy2CdJA7ujCcyE7uJvKrxVjlKo50qhHFkarV9rJhJalvKs2kpoTcHGnOdQaBj
+        SjSkO7Ogj201BOkjWz2L0jnOT4LXy9QdoOuZGGds1DyiL38DAAD//wMAvzP9xTMSAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"b7ad6f02284b9610452d6e76b6a7f3ab"']
+      etag: ['"87091376f6e5e3c3cfdb3619c16ea830"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -216,144 +216,100 @@ interactions:
     body: <transaction><amount>12.67</amount></transaction>
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/d2dqbt/submit_for_settlement
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/66pc3d/submit_for_settlement
   response:
     body:
       string: !!binary |
-        H4sIAEtl11UAA9xYwW7bOBC99ysC3xlZtpM4haKgu4sF9tBe2vSwl4CiRhZjiVRJyrHz9TsUJVmK
-        qDTAYoFib9bM43BmOJx5dHR/LIuLAyjNpbhbhJfLxQUIJlMudneLh29/ku3iPv4QGUWFpswgKv5w
-        cRHxNE5X6Y/ERAH+tBJtqKl1rOuk5MZA+phJ9ajBmAJKEIhrARZrThXEmhYQBc1PK2O1UrjziXAt
-        CToA8cPXP6JgKrZgWspamDhcXV7fREH7ZRUlKJZTYQhlzAoJeqdNcrvf3Ly8JE8rdX31FAU+lF0t
-        VQoKPy4EL+4WRtWwCJxzCijGRKi5sA7fLVL8NLyERbxahldkuSWr8Ft48/Fq9XF5+ze63S9o1tdV
-        +u714RLXnxe0ydFGotf2w2U/DDeb9dVq0+UfpRlX2hBBS3jtPyoLOq9jsqyoOHk0UFJeeOTPkGhu
-        fLaqXAqfPKPHSVaDYVhRwosCq+4c4ub5vw1OGwWANZCmCrT2RX80IFJ7CrOQQjJacOMzr2CHt8WX
-        IolXoXDFfLsJl1jBQ1HnNtalOs1H5dR2BaFFldPVu1Drn6FEjefB2fSsBseDoWW1SH0XpdfottCp
-        UvQ0UmI+B93EZ+TcNUhCDcu9mJxX1bBcfDX3v6yZN07wlymW4em0zYtkHIpUd/FQZTjjFXXNd4VX
-        YCwZ9IfByogeNAGlpCKY3EoKDd6cNLhBzsbo+DPOjDcBnYnxcb8C/eWsvIlp4j8cpiunQgvdYdN/
-        pifUPIG7HjhH9LQiokpJhrthHmhtcqn4C23gjaXfvnz+/esWU/oWaGxl7Eq4XC6Hy6eOenQGSz/+
-        VKHmAKl3dYNoUpum3HqCyZ/CJrEeJGf2gDI8eFyBRZeAmmaktjMdd3FDfAZl6JE4uuBVwRHKqpvR
-        iZQFULGIM1poS1V6QMcJMArCqOpmlJF7EHGyz6sfJcKbL6dJuIg3y3C13dpGKoYtaBOH220YBe1H
-        e8vQKGmo0XeuKVZL/911mYord5ilFCZHJhQFE+EEewKqkHCsliNwI233bQcysT2qIXsPX89j+iw9
-        e5nLokm3v/Pwku6A1KqIc2Mq/TEIqMburi8TRbmwF6et+EtsudgCTrbpP5aA1Zo+FnIngwPGf1mJ
-        3T2IA1dSWMCdpiJN5BHpQW+/bSsKKord44u0Beh+O00OtDA5eoy8UuyFfBZRMJA5UAoJN2e9+2xV
-        tcKDwyrc1YVlZgPUa00/QyzN5LQ4Qweyrg2elCwGiE7Qpk/rGrsoTkGxP2NG0nFXlhmxWiqYpc+f
-        7I5TRZcqmdas6bXn3c8yB6oF/1FDe5lQjMnn2I1VvFmz7SbMUsbWbJ1dX6+vrzK4CpdrBltIGJb5
-        7FJn+QCilESn+5nL1uvbSTC+bO1rg+QcK1OdRlyjn9QNAtBQe4b2hiLlRkVZvZPG9/jeQvuK6Rqq
-        7XTnh02DmHubuIRqzICSOTcVrYs93tpG0vs3IEZaYkeDmFYc/ZjKXZTBNMx/HXnzAJmN/D0PvF8g
-        D72kLRE3IwrqJ5x1opni1SwhHej7jt7QYVIhAZIpQc5HbEo9PfAVEt1SxotFl1/tYwclwZno4dIp
-        183d9urAWZHdZZvpznNvNeynU9/GRpGp2pc5xjVzf3u9m5X42hYwtYpnfrDDPQOYG8t2W/lM3GlO
-        tJiGpFbaPRZSMPhc7SjmWOU/m8FLw7/9GDP5M+KdcDjaBOCkUn437LMIKxVZrs9gzZjnIYEnMhO7
-        jbyqDfhKox2xhAukrXXzs6EVrr8+2v4aBXOgMfEbBDrmh0PuNwv6ua2GLf7MVk8pTY5kguD1snUH
-        6HomxxkbNY/4wz8AAAD//wMA3daZuvkSAAA=
+        H4sIAEhKDlYAA9xYQW/rNgy+91cUuau20zRNCtfFO2zADtvh9fUBe5dCtulYrS15kpwm+/WjLNux
+        Y7ktMAwbdovJTxRJUeSnhA+Hsrjcg1RM8PtFcOUvLoEnImV8d794+vYz2SweootQS8oVTTSioovL
+        y5Cl0XpdJddp6OFPI1Ga6lpFqo5LpjWkz5mQzwq0LqAErkOvBRisPlYQKVpA6DU/jSyppcSdj4Qp
+        QdABiH56+hp6U7EB01LUXEfB8mp9G3rtl1GUIJOcck1okhghQe/iFw0KHXDpzBohU5D4cclZcb/Q
+        soaFZ12SQDESQvWlcfN+keKnZiUsoqUf3JDAJ/7ym7+9C4K765sf6Gy/oFlfV+nn169x/WlBmxKl
+        BXptPmzOb9f+ZnkT+F3WUZoxqTThtIRz/1FZ0HldIsqK8qNDAyVlhUP+BrFi2mWrygV3yTN6mGTV
+        G4YVxqwosNZOIVbpPxuc0hIAayBNJSjliv6ggafmFGYhhUhowbTLvIQd3hFXigRegMKW8HYV+Fi3
+        Q1HnNtalPM5HZdVmBaFFldPlp1DXH6F4jefBkulZDY4HQ8tqnrouSq9RbaFTKelxpMR8DnqIy0hF
+        pWaYjlPPOFvhMk5rnQvJ/vzY/MBsTHWSOzE5q6phNbpK+n9Zku8UyH+mFoen0/ZGkjEoUtXFYyoo
+        YRW1vX2JN2wsGbSfwcqQ7hUBKYUkmNxKcAXOnDS4Qc7G6OhXHETvAjoT4+M+A/1irbyLaeLf76cr
+        p0ID3eFMeaNH1LyAvR44ptS0IsJKigR3wzx014o28MbSj+X66+PvmNL3QGMrY1cC3/eHy6eOOnQa
+        Sz/6UqFmD6lzdYNoUpumzHiCyZ/CJrHuBUvMAWV48LgCiy4GOc1IbSgD7mI5wgxK0wOxHMSpggOU
+        VUcBYiEKoHwRZbRQhv/0gI5yYBQkobIbgVq8Ao+y6931yw7hzZfVxIxHKz9YbjamT/NhC1pFwWYT
+        hF770d4yNEoavvWdKYrV0n93XaZi0h5mKbjOkV6F3kQ4wR6BSuQzS38EbqTtvu28J6ZHNQzy6fHE
+        Ak7Sk5e5KJp0uzsPK+kOSC2LKNe6UneeRxV2d3UVS8q4uThtxV9hy8UWcDRN/7kErNb0uRA74e0x
+        /quK7x6A75kU3ADuFeVpLA7IPnr7bVuRUFHsHr8JU4D2t9XkQAudo8cQPfFXLt546A1kFpRCzPRJ
+        bz9bVS3x4LAKd3VhiN8Ada7pZ4hhsTgmT9CBrGuDRymKAaITtOlTqsYuilOQv54wI+m4K4uMGC3l
+        CYb5+MXsOFV0qRJpnTS99rT7SWZBNWd/1NBeJhRj8hl2Yxllq+0mWN3exterZbJZJbdbP7tdxXS7
+        XW5WWbBFgjy31FreAy8FUenrzGXr9e0kGF+29glDcoaVKY8jttFP6gYBaKg9Q3NDkdGjoqw++Uro
+        8b2F9ml0IjPD11KDmHvw2IQqzED3ymk+etcGnEgJbGYQ0YqhC1O5DdCbRvj3g16/F/RnHoz/bgp6
+        SVsYdjIU1E0z61glklWzNHSg7/t4w7FJhbRHpASZHjHZdHS+MyS6JbUTiy6f7WPGI8FJ6ODQKVPN
+        jXbqwFoR3RWb6clzD0DsolPfxkaRn5pHPsY1c2t7vZ2Q+ITnMLWKZ743Iz0DmBvGZlvxRuxpTrSY
+        hriWyj4RUtD4Bu6I5VjlPpvB+8K9/Rgz+V/jk3A4mATgfJJuN8xbCysVua3LYJ0kjucDnshM7Cby
+        qsZb5SiNdrASxpGs1va9ZsiE7arPpquG3hxoTPcGgY5Z4ZDxzYI+ttVwxI9s9URS50ghCF4vU3eA
+        rmdinLFR84gu/gIAAP//AwCMiLFcRBMAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"402b7c851b4b54dc0265856b84823af0"']
+      etag: ['"242d49469364afcbb0a82c2fc6b3fa9e"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>15.76</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>15.0</amount><customer_id>76082510</customer_id><type>credit</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAExl11UAA9xXS2/jNhC+51cEvjOy/EicQFGwQFGgBbqH7qZAewkoamwxlkgtSTl2fn2HoiRL
-        EZWkhwJFb9LMx+G8Zxg9HIv88gBKcynuZ+HVfHYJgsmUi9397PH7z2Qze4gvIqOo0JQZRMUXl5cR
-        T+PlRt2qTRTgp6VoQ02lY1qZTCr+CmkUNCTLNacSYk1ziIL609JYpRTedSJcS4JXQvz47acoGJMt
-        mBayEiYO11c311HQ/FlGAYplVBhCGbNEgvpok9zuVzevr8nzQl2vn6PAh7KnpUpB4c+l4Pn9zKgK
-        ZoFTTgE1kBJqLq3C97MUfw0vYBYv5uGazDdkEX4Pb+7Wi7tw8Req3R2oz1dl+s/Onw80ztFGotb2
-        x/k7DFer5Xqxaj2O1C1X2hBBC3irPzJzOs1jsiipOHk4UFCee+gvkGhufLLKTAoffUuPI68GfbOi
-        hOc55tnZxNXLv2ucNgoAcyBNFWjts/5oQKQ2CpOQXDKac+MTr2CH9eFzkcRSyF0y367C+U0U9Emt
-        2piX6jRtlWPbE4TmZUYXn0ItP0KJCuPB2ThWvfCgadtKpL5C6Ti6SXSqFD0NmOjPXv/wCdFgTA4F
-        YGEm1LDMi8l4WfbTxZdz/8uceSeC/5lk6UenaV5kyyFPdWsPVYYzXlLXfBdYAkNKrz/0Tkb0oAko
-        JRVB55ZSaPD6pMb1fDZEx7/hzHgX0IoYhvsN6Bcn5V1Mbf/hMD45JlroDpv+Cz0h5xlceeAc0eOM
-        iEolGd6GfmhHLK3htaTl4uuvv/+JLn0PNJQyVCWcz+f942NFPTyDqR9/KZFzsON+ClG7Nk251QSd
-        P4aNbD1IzmyAthh4PIFJl4Aae6SyMx1vcUN8AmXokbh1wcuCIxRlO6MTKXOgYhZvaa7tqtIB2p0A
-        rSCMqnZGGbkHESf7rPxRILz+c5yEi3g1DxebjW2kot+CVnG42YRR0Pw0VYZCSb0a/cE1xWzp/tsu
-        U3LlgllIYbI4xAoaEUfYE1CFC8diPgDX1ObeZiAT26Pq9e7x23lMn6lnLTOZ1+72dx5e0B2QSuVx
-        Zkyp74KAauzu+ipRlAtbOE3GX2HLxRZwsk3/qQDM1vQplzsZHND+q1LsHkAcuJLCAu41FWkij7ge
-        dPKbtqKgpNg9vkqbgO7bcTKguclQY9wrxV7IFxEFPZoDpZBwc+a734ZVKQwcZuGuyu1m1kO95XQz
-        xK6ZnOZnaI/WtsGTknkP0RIa92ldYRfFKSj2Z8yAOuzKcksslwpm1+cv9sYxo3WVTCtW99rz7Wea
-        A1WC/6igKSYko/M5dmMVr5Zsswq3KWNLttxeXy+v11tYh/Mlgw0kDNN88qiTfABRSKLT/USxdfxm
-        EgyLrXlfkIxjZqrTYNfoJnWNABTUxNBWKK7cyCjKT67hHb6T8O7DpkZMvU2cQzV6QMmMm5JW+R6r
-        tqZ0+vUWIy2xo0FMS456jOnOyuCtmR2lcY3rjTn1L1pVopni5eQi1uN3naxeA0mJg1+mBHcdYp3o
-        qf03SFRLGS8WVX5zjx0QBGeBZ4dMua5z2ssDJ0W2STbRlabeKNhHxroNheKGZl+kaNdE3nZ8NyPw
-        lSlgLBVjfrBDbQswNY7stfKFuGiOuOiGpFLaLckpGHymtavVkOWPTW/D9l8/xIwe4Z+Ew9E6ADu0
-        8qthnwOYqbjd+QRWjHkWaIzIhO3W8rIy4EuNZrQQLnBdq+rPepy6vvJk+0oUTIGGC0/P0OFe1N95
-        JkEfy6q3pI9kdauUyXCIEiwvm3eAqm/l0GOD5hFf/A0AAP//AwA1Er+c4xEAAA==
+        H4sIAEpKDlYAA7JJLSrKLyq2C81LLC3JyC/KrEpNsdGHCgIAAAD//wMAtUiw9B0AAAA=
     headers:
-      cache-control: ['max-age=0, private, must-revalidate']
+      cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"88a31c27144fe72295f3982f930dbfa1"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-    status: {code: 201, message: Created}
+    status: {code: 403, message: Forbidden}
 - request:
-    body: <transaction><amount>15.76</amount></transaction>
+    body: !!python/unicode '<search><status type="array"><item>authorized</item></status></search>'
     headers: {}
-    method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/38r9r8/submit_for_settlement
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search_ids
   response:
     body:
       string: !!binary |
-        H4sIAE1l11UAA9xY3W/bNhB/z18R+J2R5Y/ELRQVBYYBG7A+rE2B7SWgqJPFWCJVknLs/vU7ipIs
-        RVQaYBhQ7M26+/F433d09OFUFtdHUJpLcb8Ib5aLaxBMplzs7xcPX34lu8WH+CoyigpNmUFUfHV9
-        HfE0Xu/UO7WLAvxpKdpQU+tY10nJjYH0MZPqUYMxBZQgTBS0AIs15wpiTQuIguanpbFaKbz5TLiW
-        BBWA+OHzL1EwJVswLWUtTBxub+5uo6D9sowSFMupMIQyZokEtdMmeXfY3H3/njyt1O32KQp8KHta
-        qhQUflwLXtwvjKphETjlFFC0iVBzbRW+X6T4aXgJi3i1DLdkuSOr8Et49367eh+u/ka1+wPN+bpK
-        335+jecvB1rnaCNRa/vhvB+Gm816u9p0/kdqxpU2RNASXuqPzILO85gsKyrOHg6UlBce+jMkmhuf
-        rCqXwkfP6Gni1WBoVpTwosCsu5i4ef5vjdNGAWAOpKkCrX3WnwyI1EZhFlJIRgtufOIV7LFafC6S
-        WAqFS+Z3m3B5FwVDUqc25qU6z1vl2PYEoUWV09WbUOsfoUSN8eBsGqtBeNC0rBapr1B6jm4TnSpF
-        zyMm+nPQTXxCLl2DJNSw3IvJeVUN08WXc//LnHklgj9Nsgyj0zYvknEoUt3ZQ5XhjFfUNd8VlsCY
-        MugPg5MRPWoCSklF0LmVFBq8PmlwA5+N0fEfODNeBXQixuF+AfrNSXkV09h/PE5PTokWusem/0zP
-        yHkCVx44R/Q0I6JKSYa3oR9obXKp+HfawBtJ69Wn3//8C136GmgsZaxKuFwuh8eninp4BlM//lgh
-        5wip93SDaFybptxqgs6fwia2HiVnNkAZBh5PYNIloKYeqe1Mx1vcEJ9BGXoibl3wsuAEZdXN6ETK
-        AqhYxBkttF1VekC3E6AVhFHVzSgjDyDi5JBX30qEN1+Ok3ARb5bharezjVQMW9AmDne7MAraj7bK
-        UChpVqOvXFPMlv676zIVVy6YpRQmj0OsoAlxgj0DVbhwrJYjcENt720HMrE9qln2Hj5fxvSFetEy
-        l0Xjbn/n4SXdA6lVEefGVPp9EFCN3V3fJIpyYQunzfgbbLnYAs626T+WgNmaPhZyL4Mj2n9Tif0H
-        EEeupLCAe01FmsgTrge9/LatKKgodo9P0iag++04OdDC5Kgx7pXiIOSziIIBzYFSSLi58N1ny6oV
-        Bg6zcF8XdjMboF5y+hli10xOiwt0QOva4FnJYoDoCK37tK6xi+IUFIcLZkQdd2WZEculgtn1+aO9
-        ccroXCXTmjW99nL7heZAteDfamiLCcnofI7dWMWbNdttwixlbM3W2e3t+nabwTZcrhnsIGGY5rNH
-        neQjiFISnR5miq3nt5NgXGzta4PkHDNTnUe7Rj+pGwSgoDaGtkJx5UZGWb1xje/xvYT2FdM1VNvp
-        Lg+bBjH3NnEO1egBJXNuKloXB6zahtLrN1iMtMSOBjGtOOoxpTsrg6mZ/97y9WuWv+WB9xP4oae0
-        KeJmREH9C2edaKZ4NbuQDvh9R2/WYVLhAiRTgjsfsS719MAXSFRLGS8WVX5xjx2UBGeiZ5dOuW5q
-        28sDJ0V2xTbTnefeathPp7qNheKmal/maNdM/fZ8NyvxtS1gKhVjfrTDPQOYG8v2WvlMXDQnXHRD
-        UivtHgspGHyudivmmOWPzeCl4b9+jJn8GfFGOJysA3BSKb8a9lmEmYpbrk9gzZjnIYERmbHdWl7V
-        Bnyp0Y5YwgWurXXzs1krXH99tP01CuZA48VvYOh4PxzufrOgH8tqtsUfyepXSpPjMkGwvGzeAaqe
-        ybHHRs0jvvoHAAD//wMAI/OhsvkSAAA=
+        H4sIAEtKDlYAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
+        sNGHS4KVZqYUQxUlFhUlViqBBEHAJrMkNdfOzKwg2TjFRh/MASnXB6q347LRR7cUAAAA//8DAIIQ
+        wKiGAAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"664739933d0de13a6dda2c493e4aa259"']
+      etag: ['"51ab30f6ec09b4c0eed1f6c7c9310402"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<search><status type="array"><item>authorized</item></status></search>'
+    body: !!python/unicode '<search><status type="array"><item>authorized</item></status><ids
+      type="array"><item>66pc3d</item></ids></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search_ids
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search
   response:
     body:
       string: !!binary |
-        H4sIAE9l11UAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
-        sNGHS4KVZqYUQxUlFhUlViqBBfWBonZcNvroRgMAAAD//wMA9crnoGwAAAA=
+        H4sIAE1KDlYAA3TOwQrCMAwG4FcZuddtB8FD1918An2A2oVSaNORZkN9essQkaHH5P9+Ej3eU2xW
+        5BIyDdAfOmiQXJ4C+QGul7M6wWi0Y5yCKGd5UsKWinVSC6WRx4wDuBwjbhuodmFGEjVbj4qWdEN+
+        s0CCHhlMr9sfyuhtKOGJ+8Kx0+0nNFqy2KiCYCp7WeFXauqhP6+bFwAAAP//AwCNtt0D+wAAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"bef84d7df48ddc2ffdffbc7459d3f5cc"']
+      etag: ['"9d7d5333691ff073e1c2d9cb4c8fa382"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]

--- a/tests/py/fixtures/TestPayin.yml
+++ b/tests/py/fixtures/TestPayin.yml
@@ -3,60 +3,60 @@ interactions:
     body: !!python/unicode '<search><status type="array"><item>authorized</item></status></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search_ids
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search_ids
   response:
     body:
       string: !!binary |
-        H4sIAKfak1UAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
+        H4sIAJpMDlYAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
         sNGHS4KVZqYUQxUlFhUlViqBBfWBonZcNvroRgMAAAD//wMA9crnoGwAAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"ab5fd74a70d3e9a3686fe93c80986764"']
+      etag: ['"cb20603456880dcae59aa9b63c48fc8d"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>10.61</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>10.61</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIAKrak1UAA9xXS2+kOBC+z6+I+u4A/Ug6I0I00mqlPexopXkc9hIZU904DTZjm073/PotY6Ch
-        MZlcVlrtDao+l+td5fjpVBY3R1CaS/G4iG7DxQ0IJjMu9o+Lb19/J9vFU/IhNooKTZlBVPLh5ibm
-        WZKaXJXnOMBPS9GGmlontDa5VPwnZHHQkizXnCtINC0gDppPS2O1UnjXmXAtCV4Jybcvv8XBlGzB
-        tJS1MEkU3t5FcdD+WUYJiuVUGEIZs0SC+miTPhzW9z9/pi9Ldbd5iQMfyp6WKgOFPzeCF48Lo2pY
-        BE45BdRARqi5sQo/LjL8NbyERbIMow0J70kYfY2WH6Ptx/XD36h2f6A5X1fZu89vQjx/OdA6RxuJ
-        Wtsf5+8oWq9Xm+W68zhSd1xpQwQt4Vp/ZBZ0nsdkWVFx9nCgpLzw0F8h1dz4ZFW5FD76jp4mXg2G
-        ZsUpLwrMs4uJ69d/1zhtFADmQJYp0Npn/cmAyGwUZiGFZLTgxidewR7rw+ciiaVQuGR+WEfhfRwM
-        SZ3amJfqPG+VY9sThBZVTpfvQq1+hRI1xoOzaawG4UHTdrXIfIXSc3Sb6FQpeh4x0Z+D/uETosGY
-        AkrAwkypYbkXk/OqGqaLL+f+lznzRgT/M8kyjE7bvMiOQ5Hpzh6qDGe8oq75LrEExpRBfxicjOlR
-        E1BKKoLOraTQ4PVJgxv4bIxO/sSZ8SagEzEO9xXoDyflTUxj//E4PTklWugem/4rPSPnBVx54BzR
-        04yIKyUZ3oZ+6EYsbeCNpM/f7+82f6FL3wKNpYxVicIwHB6fKurhGUz95FOFnKMd93OIxrVZxq0m
-        6PwpbGLrUXJmA7TDwOMJTLoU1NQjtZ3peIsb4jMoQ0/ErQteFpygrLoZnUpZABWLZEcLbVeVHtDt
-        BGgFYVR1M8rIA4gkPeTVjxLhzZ/jpFwk6zBabre2kYphC1on0XaLS0z701YZCiXNavSda4rZ0v93
-        XabiygWzlMLkSYQVNCFOsGegCheOZTgCN9T23nYgE9ujmvXu25fLmL5QL1rmsmjc7e88vKR7ILUq
-        ktyYSn8MAqqxu+vbVFEubOG0GX+LLRdbwNk2/ecSMFuz50LuZXBE+28rsX8CceRKCgt41FRkqTzh
-        etDLd/fVgv+ooQ0+thEEc+weKlmv2HYd7TLGVmy1u7tb3W12sInCFYMtpAzDMnu0bVgKKop96bO0
-        qe2+HScHWpgcfYEbqzgI+SriYEBzoAxSbi5899uyaoUpgfm9rwu78w1Q15x+OtkFltPiAh3QugZ7
-        VrIYIDpCGxita+zPOF/F4YIZUcf9Xu6I5VLB7GL+yd44ZXSuklnNmi5+uf1Cc6AjiFISnR1miq3n
-        t5NgXGzt+4LkHDNTnUe7Rj+pGwSgoNbTtkJx5UZGWb1zDe/xvYQ3HzYNYu5t4hJUY0YpmXNT0bo4
-        YNU2lF6/wWKkJXY0SGjFUY8p3VkZXJvZU1rXuN5YUP+iVaeaKV7NLmIDft/JmjWQVDj4ZUZw1yHW
-        iZ7av0KiWsp4sajy1T12QBCcBZ4dMuO6yTwvD5wU2RXtTFeae6NgH5nqNhaKG5p9kaJdM3nb892M
-        wFemgKlUjPnRDrUdwNw4stfKV+KiOeGiG9JaabckZ2DwmdatVmOWPzaDDdt//RgzeYS/Ew4n6wDs
-        0Mqvhn0OYKbiducTWDPmWaAxIjO2W8ur2oAvNdrRQrjAda1uPptx6vrKs+0rcTAHGi88A0PHe9Fw
-        55kF/VpWsyX9Sla/SpkchyjB8rJ5B6j6To49NmoeyYd/AAAA//8DADO39v3jEQAA
+        H4sIAJxMDlYAA9xXz2+sNhC+v79itXcH2Ox7uxsRondopapqVfUl79BLZGBYnIBNbbM/+td3jIGF
+        xSTpoVLVG8x8Hs+MxzOfw4dTWSwOIBUT/H4Z3PjLBfBEpIzv75dPjz+S7fIh+hRqSbmiiUZU9Gmx
+        CFkavRwP6rgNPfw0EqWprlVEa50Lyf6CNPRakdHqcwWRogWEXvNpZEktJe51JkwJgltC9MPT76E3
+        FRswLUXNdRT4N1+C0Gv/jKIEmeSUa0KTxAgJ+hO/aFA69Fw6s0bIFCT+LDgr7pda1rD0rEsSqIaU
+        UL0wbt4vU/zVrIRltPKDzyTwib969Hd3q+DudvUHOtsvaNbXVfrP1l8WtClRWqDX5sdmefPF364+
+        B36XZ5RmTCpNOC3h2n9UFnRel4iyovzs0EBJWeGQHyFWTLtsVbngLnlGT5OsesOwwpgVBVbXJcQq
+        /XeDU1oCYA2kqQSlXNGfNPDUnMIspBAJLZh2mZewx1vhSpHAC1DYEt6tA38TekNR5zbWpTzPR2XV
+        ZgWhRZXT1YdQt++heI3nwZLpWQ2OB0PLap66LkqvUW2hUynpeaTEfA66hstIRaVmmA4FWhdQAl7Q
+        8QqX8UuDec/8wGxMdZI7MTmrqmE1ukr6f1mSbxTIf6YWh6fT9kaSMShS1cVjKihhFbW9fYU3bCwZ
+        tJ/BypAeFAEphSSY3EpwBc6cNLhBzsbo6BccRG8COhPj474C/WStvIlp4j8cpiunQgPd40w50jNq
+        XsBeDxxTaloRYSVFgrthHrprRRt4Y8nf/bz97RFT+hZobGXsSuD7/nD51FGHTmPpR18r1BwMh5hD
+        NKlNU2Y8weRPYZNYD4Il5oAyPHhcgUUXg5xmpDaUAXexHGEGpemJWA7iVMEJyqqjALEQBVC+jDJa
+        KMN/ekBHOTAKklDZjUAtXoFH2e3+9mWP8ObPamLGo7UfrLZb06f5sAWto2C7RWbU/rS3DI2Shm99
+        Z4pitfT/XZepmLSHWQqu8yjAGzQRTrBnoBL5zMofgRtpu28774npUQ1nfPp2YQEX6cXLXBRNut2d
+        h5V0D6SWRZRrXak7z6MKu7u6iSVl3FyctuJvsOViCzibpv9cAlZr+lyIvfAOGP9NxfcPwA9MCm4A
+        94ryNBYnZB+9/batSKgodo9fhSlA+201OdBC5+gxRE/8lYsjD72BzIJSiJm+6O1vq6olHhxW4b4u
+        DPEboK41/QwxLBbH5AU6kHVt8CxFMUB0gjZ9StXYRXEK8tcLZiQdd2WREaOlPMEwv301O04VXapE
+        WidNr73sfpFZUM3ZnzW0lwnFmHyG3VhG2Xq3DdabTXy7XiXbdbLZ+dlmHdPdbrVdZ8EOCfLcUmv5
+        ALwURKWvM5et17eTYHzZ2kcLyRlWpjyP2EY/qRsEoKH2DM0NRUaPirL6IMvv8b2FN19LDWLuwWMT
+        qjAD3Sun+eldG3AiJbCZQUQrhi5M5TZA7zrCXtJmxbbFgro5Vh2rRLJqloMN9H0TawgmqXDmi5Qg
+        zSEmf45rf4VEt6R2YtHlq33MbCA4BhwEMmWqKWenDqwV0dXXTEOae/1gC5n6NjaK5My8cDGumZLt
+        9XY84PuVw9QqnvnBzLMMYG4SmW3FkdjTnGgxDXEtleXHKWh8AHasaqxyn82AXLu3H2Mmj/oPwuFk
+        EoDNWbrdMA8NrFQkdi6DdZI4uDOeyEzsJvKqxlvlKI12qhDGkanV9rFiJqltKc+mpYTeHGjMdQaB
+        jinRkO7Mgt631RCk92z1LErnOD8JXi9Td4CuZ2KcsVHziD79DQAA//8DAKTc2l0zEgAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"52b3e339b3b96ed25ad0982cf05930a7"']
+      etag: ['"a933fc48f3395d665977a72f93d60cb3"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -65,40 +65,40 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/bthrmy/void
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/jwvsw8/void
   response:
     body:
       string: !!binary |
-        H4sIAKvak1UAA9xYS2/bOBC+51cEvjOS/EicQFFRYLHAHrZYoE0PewkoamyxlkiVpBy7v36HoiRL
-        EZUGWCxQ7M2a+UjOizMfHX84lcX1EZTmUjwuoptwcQ2CyYyL/ePi6cvvZLv4kFzFRlGhKTOISq6u
-        r2OeJanJVXmOA/xpJdpQU+vkKHkGWRy0n1ZjzhUkmhYQB81PK2O1UnjOmXAtCR4HydPn3+JgKrZg
-        WspamCQKb26jOGi/rKIExXIqDKGMWSFBW7RJ7w/rux8/0m9Ldbv5Fgc+lF0tVQYKP64FLx4XRtWw
-        CJxxCqiBjFBzbQ1+XGT4aXgJi2QZRhsS3pEw+hItH6Ltw/r+bzS7X9Csr6vs3es3Ea6/LGiDo41E
-        q+2Hi3UUrderzXLdRRulO660IYKW8Np+VBZ0XsdkWVFx9migpLzwyF8g1dz49qpyKXzyHT1NohoM
-        3YpTXhRYYxcX1y//rXPaKACsgSxToLXP+5MBkdkszEIKyWjBjW97BXu8G74QSbwKhSvm+3UU3sXB
-        UNSZjXWpzvNeObVdQWhR5XT5LtTqZyhRYz44m+ZqkB50bVeLzHdReo1uC50qRc8jJcZz0Dt8m2gw
-        poAS8GKm1LDci8l5VQ3LxVdz/8uaeSODv0yxDLPTNi+y41BkuvOHKsMZr6hrvku8AmPJoD8MVsb0
-        qAkoJRXB4FZSaPDGpMENYjZGJ3/izHgT0G0xTvcr0B9ulzcxjf/H43TlVGihe2z6L/SMmm/grgfO
-        ET2tiLhSkuFpGAdam1wq/oM28GanT1/vbjd/YUjfAo13GZsShWE4XD411KMzWPrJxwo1Rzvu5xBN
-        aLOMW0sw+FPYxFckEMwmaIeJxxVYdCmoaURqO9PxFDfEZ1CGnoijC14VnKCsuhmdSlkAFYtkRwtt
-        qUoP6DgBekEYVd2MMvIAIkkPefW9RHjz5TQpF8k6jJbbrW2kYtiC1km03SKJaT/aW4abkoYafeWa
-        YrX0312XqbhyySylMHkS4Q2aCCfYM1CFhGMZjsCNtD23HcjE9qiG2j19vozpi/RiZS6LJtz+zsNL
-        ugdSqyLJjan0QxBQjd1d36SKcmEvTlvxN9hysQWcbdN/LgGrNXsu5F4GR/T/phL7DyCOXElhAY+a
-        iiyVJ6QH/f7uvFrw7zW0ycc2gmCO3UMl6xXbrqNdxtiKrXa3t6vbzQ42UbhisIWUYVpml7YNS0FF
-        sS99kra03W+nyYEWJsdYIGMVByFfRBwMZA6UQcrNRe8+W1WtsCSwvvd1YTnfAPVa008nS2A5LS7Q
-        gaxrsGcliwGiE7SJ0brG/ozzVRwumJF03O/ljlgtFcwS84/2xKmiC5XMatZ08cvpF5kDHUGUkujs
-        MHPZen07CcaXrX1bkJxjZarziGv0k7pBAG7URtreUKTcqCird9DwEGl4j+93aF8xXUMdP2waxNzb
-        xBWoxopSMuemonVxwFvbSHr7BsRIS+xokNCKox1TufMymLr57z2P3vJ8+pz7BbzuJW1BuIlQUD+9
-        rFPNFK9m6edA3/fvhvySCumOzAgyPGID6Ol4r5BoljJeLJr86hw7FglOQA9zzrhu7ptXB24X2bWq
-        mV489zLD7jm1bbwp8lL7Dke/Zm5rr3eTEd/WAqa7Ys6PdpTvAOaGsD1WvhCXzYkWw5DWSrunQQYG
-        H6cdoRyr/LkZvCv8x48xk78e3gmHkw0AziXlN8M+grBSkdP6NqwZ8zwbMCMzvlvPq9qArzTagUq4
-        QJJaNz8bEuG66bPtpnEwBxrTvIGjYzY4ZHqzoJ/v1XDDn+3VE0iTI3UgeL1s3QGavpPjiI2aR3L1
-        DwAAAP//AwDvs/2R1RIAAA==
+        H4sIAJ5MDlYAA9xYz2/rNgy+968IcldtJ3mvSeG6eIcNGIYNw177DrsUsk3Ham3Jk+T82F8/yrId
+        u5bbDsOwYbeY/ESRFEl9Snh/KovFAaRigt8tg2t/uQCeiJTx/d3y8eF7sl3eR1ehlpQrmmhERVeL
+        RcjS6Pl4UMdt6OFPI1Ga6lpFB8FSSEOv/TQafa4gUrSA0Gt+GllSS4n7nAlTguB2EH33+GvoTcUG
+        TEtRcx0F/vXnIPTaL6MoQSY55ZrQJDFCgr7EzxqUDj2XzqwRMgWJHwvOirulljUsPeuSBKohJVQv
+        jJt3yxQ/NSthGa384BMJfOKvHvzd7Sq4Xa9+Q2f7Bc36ukr/2vrLgjYlSgv02nzYDN989rerT4Hf
+        5RilGZNKE05LeO0/Kgs6r0tEWVF+dmigpKxwyI8QK6ZdtqpccJc8o6dJVr1hWGHMigIr6xJilf6z
+        wSktAbAG0lSCUq7oTxp4ak5hFlKIhBZMu8xL2GNHuFIksAEKW8K7TeDfhN5Q1LmNdSnP81FZtVlB
+        aFHldPUh1Po9FK/xPFgyPavB8WBoWc1TV6P0GtUWOpWSnkdKzOdgYriMVFRqhulQoHUBJWCDjle4
+        jNNa50KyP943PzAbU53kTkzOqmpYja6S/l+W5BsF8p+pxeHptLORZAyKVHXxmApKWEXtbF9hh40l
+        g/EzWBnSgyIgpZAEk1sJrsCZkwY3yNkYHf2EF9GbgM7E+LhfgX6wVt7ENPEfDtOVU6GB7vFOOdIz
+        ap7BtgdeU2paEWElRYK7YR66tqINvLHk737c/vKAKX0LNLYydiXwfX+4fOqoQ6ex9KMvFWoOhkPM
+        IZrUpikznmDyp7BJrMhKEnNAGR48rsCii0FOM1IbyoC7WI4wg9L0RCwHcargBGXVUYBYiAIoX0YZ
+        LZThPz2goxwYBUmo7K5ALV6AR9l6v37eI7z5spqY8WjjB6vt1sxpPhxBmyjYbpEZtR9tl6FR0vCt
+        b0xRrJb+u5syFZP2MEvBdR4F2EET4QR7BiqRz6z8EbiRtvu29z0xM6rhi49fLyzgIr14mYuiSbd7
+        8rCS7oHUsohyrSt163lU4XRX17GkjJvGaSv+GkcujoCzGfpPJWC1pk+F2AvvgPFfV3x/D/zApOAG
+        cKcoT2NxQvbR22/HioSK4vT4WZgCtL+tJgda6Bw9huiRv3Bx5KE3kFlQCjHTF739bFW1xIPDKtzX
+        hSF+A9RrTX+HGBaL1+QFOpB1Y/AsRTFAdII2fUrVOEXxFuQvF8xIOp7KIiNGS3mCYX79YnacKrpU
+        ibROmll72f0is6Cas99raJsJxZh8htNYRtlmtw02NzfxerNKtpvkZudnN5uY7nar7SYLdkiQ55Za
+        ywfgpSAqfZlptl7f3gTjZmsfLCRnWJnyPGIb/U3dIAANtWdoOhQZPSrK6oMsv8f3Ftqn0YXMDF9L
+        DWLuwWMTqjAD3Sun+ehdG3AiJXCYQUQrhi5M5TZAbxrh3w96/VbQ0+fhvxtwL2nLwN4DBXWTyjpW
+        iWTVLOkc6Pup3TBqUiHJESlBXkdM7hxz7hUS3ZLaiUWXX+1jLkOC956DMadMNf3r1IG1IrqGmpnA
+        c889nJlT38ZGkY2aJz3GNdOjvd7eh/hg5zC1imd+MBd4BjB39ZptxZHY05xoMQ1xLZV9EKSg8cXb
+        0cixyn02g9eEe/sxZvIvxgfhcDIJwNtIut0wLyusVGSyLoN1kjgeC3giM7GbyKsau8pRGu01ShhH
+        alrb15mhDnaGPpkZGnpzoDG5GwQ65oBDfjcLet9Wwwjfs9XTRp0jYSDYXqbuAF3PxDhjo+ERXf0J
+        AAD//wMABdt7zCATAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"56e8565aeda9e621349b3d84528d2645"']
+      etag: ['"1f7116cfb70c124e8e7d98403cb326de"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -107,83 +107,83 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/bthrmy
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/jwvsw8
   response:
     body:
       string: !!binary |
-        H4sIAK3ak1UAA9xYS2/bOBC+51cEvjOS/EicQFFRYLHAHrZYoE0PewkoamyxlkiVpBy7v36HoiRL
-        EZUGWCxQ7M2a+UjOizMfHX84lcX1EZTmUjwuoptwcQ2CyYyL/ePi6cvvZLv4kFzFRlGhKTOISq6u
-        r2OeJanJVXmOA/xpJdpQU+vkKHkGWRy0n1ZjzhUkmhYQB81PK2O1UnjOmXAtCR4HydPn3+JgKrZg
-        WspamCQKb26jOGi/rKIExXIqDKGMWSFBW7RJ7w/rux8/0m9Ldbv5Fgc+lF0tVQYKP64FLx4XRtWw
-        CJxxCqiBjFBzbQ1+XGT4aXgJi2QZRhsS3pEw+hItH6Ltw/r+bzS7X9Csr6vs3es3Ea6/LGiDo41E
-        q+2Hi3UUrderzXLdRRulO660IYKW8Np+VBZ0XsdkWVFx9migpLzwyF8g1dz49qpyKXzyHT1NohoM
-        3YpTXhRYYxcX1y//rXPaKACsgSxToLXP+5MBkdkszEIKyWjBjW97BXu8G74QSbwKhSvm+3UU3sXB
-        UNSZjXWpzvNeObVdQWhR5XT5LtTqZyhRYz44m+ZqkB50bVeLzHdReo1uC50qRc8jJcZz0Dt8m2gw
-        poAS8GKm1LDci8l5VQ3LxVdz/8uaeSODv0yxDLPTNi+y41BkuvOHKsMZr6hrvku8AmPJoD8MVsb0
-        qAkoJRXB4FZSaPDGpMENYjZGJ3/izHgT0G0xTvcr0B9ulzcxjf/H43TlVGihe2z6L/SMmm/grgfO
-        ET2tiLhSkuFpGAdam1wq/oM28GanT1/vbjd/YUjfAo13GZsShWE4XD411KMzWPrJxwo1Rzvu5xBN
-        aLOMW0sw+FPYxFckEMwmaIeJxxVYdCmoaURqO9PxFDfEZ1CGnoijC14VnKCsuhmdSlkAFYtkRwtt
-        qUoP6DgBekEYVd2MMvIAIkkPefW9RHjz5TQpF8k6jJbbrW2kYtiC1km03SKJaT/aW4abkoYafeWa
-        YrX0312XqbhyySylMHkS4Q2aCCfYM1CFhGMZjsCNtD23HcjE9qiG2j19vozpi/RiZS6LJtz+zsNL
-        ugdSqyLJjan0QxBQjd1d36SKcmEvTlvxN9hysQWcbdN/LgGrNXsu5F4GR/T/phL7DyCOXElhAY+a
-        iiyVJ6QH/f7uvFrw7zW0ycc2gmCO3UMl6xXbrqNdxtiKrXa3t6vbzQ42UbhisIWUYVpml7YNS0FF
-        sS99kra03W+nyYEWJsdYIGMVByFfRBwMZA6UQcrNRe8+W1WtsCSwvvd1YTnfAPVa008nS2A5LS7Q
-        gaxrsGcliwGiE7SJ0brG/ozzVRwumJF03O/ljlgtFcwS84/2xKmiC5XMatZ08cvpF5kDHUGUkujs
-        MHPZen07CcaXrX1bkJxjZarziGv0k7pBAG7URtreUKTcqCird9DwEGl4j+93aF8xXUMdP2waxNzb
-        xBWoxopSMuemonVxwFvbSHr7BsRIS+xokNCKox1TufMymLr57z2P3vJ8+pz7BbzuJW1BuIlQUD+9
-        rFPNFK9m6edA3/fvhvySCumOzAgyPGID6Ol4r5BoljJeLJr86hw7FglOQA9zzrhu7ptXB24X2bWq
-        mV489zLD7jm1bbwp8lL7Dke/Zm5rr3eTEd/WAqa7Ys6PdpTvAOaGsD1WvhCXzYkWw5DWSrunQQYG
-        H6cdoRyr/LkZvCv8x48xk78e3gmHkw0AziXlN8M+grBSkdP6NqwZ8zwbMCMzvlvPq9qArzTagUq4
-        QJJaNz8bEuG66bPtpnEwBxrTvIGjYzY4ZHqzoJ/v1XDDn+3VE0iTI3UgeL1s3QGavpPjiI2aR3L1
-        DwAAAP//AwDvs/2R1RIAAA==
+        H4sIAJ9MDlYAA9xYz2/rNgy+968IcldtJ3mvSeG6eIcNGIYNw177DrsUsk3Ham3Jk+T82F8/yrId
+        u5bbDsOwYbeY/ESRFEl9Snh/KovFAaRigt8tg2t/uQCeiJTx/d3y8eF7sl3eR1ehlpQrmmhERVeL
+        RcjS6Pl4UMdt6OFPI1Ga6lpFB8FSSEOv/TQafa4gUrSA0Gt+GllSS4n7nAlTguB2EH33+GvoTcUG
+        TEtRcx0F/vXnIPTaL6MoQSY55ZrQJDFCgr7EzxqUDj2XzqwRMgWJHwvOirulljUsPeuSBKohJVQv
+        jJt3yxQ/NSthGa384BMJfOKvHvzd7Sq4Xa9+Q2f7Bc36ukr/2vrLgjYlSgv02nzYDN989rerT4Hf
+        5RilGZNKE05LeO0/Kgs6r0tEWVF+dmigpKxwyI8QK6ZdtqpccJc8o6dJVr1hWGHMigIr6xJilf6z
+        wSktAbAG0lSCUq7oTxp4ak5hFlKIhBZMu8xL2GNHuFIksAEKW8K7TeDfhN5Q1LmNdSnP81FZtVlB
+        aFHldPUh1Po9FK/xPFgyPavB8WBoWc1TV6P0GtUWOpWSnkdKzOdgYriMVFRqhulQoHUBJWCDjle4
+        jNNa50KyP943PzAbU53kTkzOqmpYja6S/l+W5BsF8p+pxeHptLORZAyKVHXxmApKWEXtbF9hh40l
+        g/EzWBnSgyIgpZAEk1sJrsCZkwY3yNkYHf2EF9GbgM7E+LhfgX6wVt7ENPEfDtOVU6GB7vFOOdIz
+        ap7BtgdeU2paEWElRYK7YR66tqINvLHk737c/vKAKX0LNLYydiXwfX+4fOqoQ6ex9KMvFWoOhkPM
+        IZrUpikznmDyp7BJrMhKEnNAGR48rsCii0FOM1IbyoC7WI4wg9L0RCwHcargBGXVUYBYiAIoX0YZ
+        LZThPz2goxwYBUmo7K5ALV6AR9l6v37eI7z5spqY8WjjB6vt1sxpPhxBmyjYbpEZtR9tl6FR0vCt
+        b0xRrJb+u5syFZP2MEvBdR4F2EET4QR7BiqRz6z8EbiRtvu29z0xM6rhi49fLyzgIr14mYuiSbd7
+        8rCS7oHUsohyrSt163lU4XRX17GkjJvGaSv+GkcujoCzGfpPJWC1pk+F2AvvgPFfV3x/D/zApOAG
+        cKcoT2NxQvbR22/HioSK4vT4WZgCtL+tJgda6Bw9huiRv3Bx5KE3kFlQCjHTF739bFW1xIPDKtzX
+        hSF+A9RrTX+HGBaL1+QFOpB1Y/AsRTFAdII2fUrVOEXxFuQvF8xIOp7KIiNGS3mCYX79YnacKrpU
+        ibROmll72f0is6Cas99raJsJxZh8htNYRtlmtw02NzfxerNKtpvkZudnN5uY7nar7SYLdkiQ55Za
+        ywfgpSAqfZlptl7f3gTjZmsfLCRnWJnyPGIb/U3dIAANtWdoOhQZPSrK6oMsv8f3Ftqn0YXMDF9L
+        DWLuwWMTqjAD3Sun+ehdG3AiJXCYQUQrhi5M5TZAbxrh3w96/VbQ0+fhvxtwL2nLwN4DBXWTyjpW
+        iWTVLOkc6Pup3TBqUiHJESlBXkdM7hxz7hUS3ZLaiUWXX+1jLkOC956DMadMNf3r1IG1IrqGmpnA
+        c889nJlT38ZGkY2aJz3GNdOjvd7eh/hg5zC1imd+MBd4BjB39ZptxZHY05xoMQ1xLZV9EKSg8cXb
+        0cixyn02g9eEe/sxZvIvxgfhcDIJwNtIut0wLyusVGSyLoN1kjgeC3giM7GbyKsau8pRGu01ShhH
+        alrb15mhDnaGPpkZGnpzoDG5GwQ65oBDfjcLet9Wwwjfs9XTRp0jYSDYXqbuAF3PxDhjo+ERXf0J
+        AAD//wMABdt7zCATAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"38e17eab825833ba4667fc4131b0b350"']
+      etag: ['"e57cb7f074903c78057e4e1af877f01f"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<transaction><payment_method_token>bkhpqm</payment_method_token><amount>20.91</amount><customer_id>11443524</customer_id><type>sale</type><options><submit_for_settlement
+    body: !!python/unicode '<transaction><payment_method_token>f3g3jg</payment_method_token><amount>20.91</amount><customer_id>76082510</customer_id><type>sale</type><options><submit_for_settlement
       type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
       type="integer">2</participant_id></custom_fields></transaction>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions
   response:
     body:
       string: !!binary |
-        H4sIALDak1UAA9xXzW7jNhC+5ykC3xlZtpM4gaJggaJAUbSH7mZR9BJQ1NhiLJFaknLsPH2HoiRL
-        FpWkhwJFb9LMx+H8zzB6PBT55R6U5lI8zMKr+ewSBJMpF9uH2dO3n8l69hhfREZRoSkziIovLi8j
-        nsbr/eG2SKMAPy1FG2oqHdPKZFLxN0BOQ7Jccywh1jSHKKg/LY1VSuFdR8K1JHglxE9ff4qCMdmC
-        aSErYeLF/OoujILmzzIKUCyjwhDKmCUS1Eeb5G63un17S14W6ub6JQp8KHtaqhQU/lwKnj/MjKpg
-        FjjlFFADKaHm0ir8MEvx1/ACZqhDeE3mt2QefgsX9+H6/vrmL1S7O1Cfr8r0n50/HWico41Ere2P
-        83cYrlbL68Wq9ThSN1xpQwQt4Fx/ZOZ0msdkUVJx9HCgoDz30F8h0dz4ZJWZFD76hh5GXg36ZkUJ
-        z3PMs5OJq9d/1zhtFADmQJoq0Npn/cGASG0UJiG5ZDTnxidewRbrw+ciiaWQu2S+W4Xz2yjok1q1
-        MS/Vcdoqx7YnCM3LjC4+hVp+hBIVxoOzcax64UHTNpVIfYXScXST6FQpehww0Z+9/uETosGYHArA
-        wkyoYZkXk/Gy7KeLL+f+lznzTgT/M8nSj07TvMiGQ57q1h6qDGe8pK75LrAEhpRef+idjOheE1BK
-        KoLOLaXQ4PVJjev5bIiOf8OZ8S6gFTEM9xnoFyflXUxt/34/PjkmWugWm/4rPSLnBVx54BzR44yI
-        SiUZ3oZ+aEcsreG1pD9v7/74dYkufQ80lDJUJZzP5/3jY0U9PIOpH38pkbO3434KUbs2TbnVBJ0/
-        ho1s3UvObIA2GHg8gUmXgBp7pLIzHW9xQ3wCZeiBuHXBy4IDFGU7oxMpc6BiFm9oru2q0gHanQCt
-        IIyqdkYZuQMRJ7us/FEgvP5znISLeDUPF+u1baSi34JWcbhe4xLT/DRVhkJJvRp955pitnT/bZcp
-        uXLBLKQwWRxiBY2II+wRqMKFYzEfgGtqc28zkIntUfV69/T1NKZP1JOWmcxrd/s7Dy/oFkil8jgz
-        ptT3QUA1dnd9lSjKhS2cJuOvsOViCzjapv9cAGZr+pzLrQz2aP9VKbaPIPZcSWEBD5qKNJEHXA86
-        +e6+SvAfFTTBxzaCYI7dQ8WrJVuvwk3K2JItNzc3y5vrDVyH8yWDNSQMwzJ5tGlYCkqKfel3aVPb
-        fTtOBjQ3GfoCN1axE/JVREGP5kApJNyc+O63YVUKUwLze1vldufroc453XSyCyyn+Qnao7UN9qhk
-        3kO0hCYwWlfYn3G+it0JM6AO+73cEMulgtnF/Iu9ccxoXSXTitVd/HT7ieZAexCFJDrdTRRbx28m
-        wbDYmvcFyThmpjoOdo1uUtcIQEGNp22F4sqNjKL85Bre4TsJ7z5sasTU28QlqMaMUjLjpqRVvsOq
-        rSmdfr3FSEvsaBDTkqMeY7qzMjg3s6M0rnG9Maf+RatKNFO8nFzEevyuk9VrIClx8MuU4K5DrBM9
-        tX+GRLWU8WJR5bN77IAgOAs8O2TKdZ15Xh44KbIt2omuNPVGwT4y1m0oFDc0+yJFuybytuO7GYGv
-        TAFjqRjzvR1qG4CpcWSvla/ERXPERTckldJuSU7B4DOtXa2GLH9sehu2//ohZvQI/yQcDtYB2KGV
-        Xw37HMBMxe3OJ7BizLNAY0QmbLeWl5UBX2o0o4VwgetaVX/W49T1lWfbV6JgCjRceHqGDvei/s4z
-        CfpYVr0lfSSrW6VMhkOUYHnZvANUfSOHHhs0j/jibwAAAP//AwBhE/cr4xEAAA==
+        H4sIAKJMDlYAA9xXUXOjNhB+z6/w+F0BHF9tZwiZ60w77UPvoXdpO/eSEbAYJSBRSTj2/fquEGAw
+        Isk9dKbTN9j9tNpdrXY/hffHslgcQCom+N0yuPaXC+CJSBnf3y0fvvxMtsv76CrUknJFE42o6Gqx
+        CFkaxZvNfvsUevhpJEpTXauI1joXkn2DNPRakdHqUwWRogWEXvNpZEktJe51IkwJgltC9NPD76E3
+        FRswLUXNdbTyr3dB6LV/RlGCTHLKNaFJYoTEuPakQenQc+nMGiFTkPiz4Ky4W2pZw9KzLkmgGlJC
+        9cK4ebdM8VezEpa4c/CBBD7xV1/83e0quL3ZfkVn+wXN+rpKv2/9eUGbEqUFem1+bJY3P/jb1YfA
+        7/KM0oxJpQmnJVz6j8qCzusSUVaUnxwaKCkrHPIXiBXTLltVLrhLntHjJKveMKwwZkWB1XUOsUr/
+        3eCUlgBYA2kqQSlX9EcNPDWnMAspREILpl3mJezxVrhSJPACFLaEd+vA34TeUNS5jXUpT/NRWbVZ
+        QWhR5XT1LtTNWyhe43mwZHpWg+PB0LKap66L0mtUW+hUSnoaKTGfg67hMlJRqRmmQ4HWBZSAF3S8
+        wmX83GDeMj8wG1Od5E5MzqpqWI2ukv5fluQrBfKfqcXh6bS9kWQMilR18ZgKSlhFbW9f4Q0bSwbt
+        Z7AypAdFQEohCSa3ElyBMycNbpCzMTr6DQfRq4DOxPi4L0C/WiuvYpr4D4fpyqnQQPc4U17oCTVP
+        YK8Hjik1rYiwkiLB3TAP3bWiDbyx9Oenv1a//IgpfQ00tjJ2JfB9f7h86qhDp7H0o48Vag6GQ8wh
+        mtSmKTOeYPKnsEmsB8ESc0AZHjyuwKKLQU4zUhvKgLtYjjCD0vRILAdxquAIZdVRgFiIAihfRhkt
+        lOE/PaCjHBgFSajsRqAWz8Cj7GZ/87RHePNnNTHj0doPVtut6dN82ILWUbDdIjNqf9pbhkZJw7f+
+        YIpitfT/XZepmLSHWQqu8yjAGzQRTrAnoBL5zMofgRtpu28774npUQ1nfPh8ZgFn6dnLXBRNut2d
+        h5V0D6SWRZRrXalbz6MKu7u6jiVl3FyctuKvseViCziZpv9YAlZr+liIvfAOGP91xff3wA9MCm4A
+        d4ryNBZHZB+9/batSKgodo9PwhSg/baaHGihc/QYogf+zMULD72BzIJSiJk+6+1vq6olHhxW4b4u
+        DPEboC41/QwxLBbH5Bk6kHVt8CRFMUB0gjZ9StXYRXEK8uczZiQdd2WREaOlPMEwP380O04VXapE
+        WidNrz3vfpZZUM3Z3zW0lwnFmHyG3VhG2Xq3DdabTXyzXiXbdbLZ+dlmHdPdbrVdZ8EOCfLcUmv5
+        ALwURKXPM5et17eTYHzZ2kcLyRlWpjyN2EY/qRsEoKH2DM0NRUaPirJ6J8vv8b2FV19LDWLuwWMT
+        qjAD3Sun+eldG3AiJbCZQUQrhi5M5TZA7zLCXtJmxbbFgro5Vh2rRLJqloMN9H0TawgmqXDmi5Qg
+        zSEmf45rf4FEt6R2YtHli33MbCA4BhwEMmWqKWenDqwV0dXXTEOae/1gC5n6NjaK5My8cDGumZLt
+        9XY84PuVw9QqnvnBzLMMYG4SmW3FC7GnOdFiGuJaKsuPU9D4AOxY1VjlPpsBuXZvP8ZMHvXvhMPR
+        JACbs3S7YR4aWKlI7FwG6yRxcGc8kZnYTeRVjbfKURrtVCGMI1Or7WPFTFLbUh5NSwm9OdCY6wwC
+        HVOiId2ZBb1tqyFIb9nqWZTOcX4SvF6m7gBdz8Q4Y6PmEV39AwAA//8DAGemOw4zEgAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"300546cb1d0cae212a90da738c8babac"']
+      etag: ['"48412e1b3a49cdd5061f37d51d5e81eb"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -192,62 +192,62 @@ interactions:
     body: !!python/unicode '<search><status type="array"><item>authorized</item></status></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search_ids
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search_ids
   response:
     body:
       string: !!binary |
-        H4sIALLak1UAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
-        sNGHS4KVZqYUQxUlFhUlViqBBEHAJrMkNdfOoqzCPDfFRh/MASnXB6q347LRR7cUAAAA//8DAJ2D
-        feiGAAAA
+        H4sIAKNMDlYAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
+        sNGHS4KVZqYUQxUlFhUlViqBBEHAJrMkNdcuydw83SLLRh/MASnXB6q347LRR7cUAAAA//8DADuz
+        f2OGAAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"53a307d642e84d1a38607f2af4085e7c"']
+      etag: ['"cc9ffd0942667c2abeb278de14e58ee4"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '<search><status type="array"><item>authorized</item></status><ids
-      type="array"><item>8vx7md</item></ids></search>'
+      type="array"><item>b77g8j</item></ids></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search
   response:
     body:
       string: !!binary |
-        H4sIALPak1UAA9xYS4/bNhC+51csfOfa8mPXG3gVBCgKFEV7aLJB0UtAUWOLMUUqJOW18+s7pN4W
-        tbs9FCh6s2Y+DmeGw5mP3n045+LmBNpwJR9n0e1idgOSqZTLw+Ps6fPPZDv7EL/bMQ0pt4RRnRKr
-        qTSUWVxhbuylgMcZU0KAl8zidzc3O1ZqDdKSgh6AyDJPQNdILi0cQM/iaDcPoPxq/234D7hes1ns
-        5q3SQ62yVBBuITeBDXpajKHnt1/L03h7Ot/n6W6OP53EWGpLE9PSZkrjFqipRX4vtB8bKgANu59d
-        oOxCuFEE0wbx06efmsj6YgemuSqljZeL2wd0rv5yihw0yyhmgjLmhAT9MTZ5OK7vf/xIvi313ebb
-        bh5CudVKp6Dx40Zy8TizuoTZvHJOA7WQEmrr3KT4aXkOM/Qh2pDFPVlEn6Pl+2j7fnP3F7rdLvDr
-        yyL9Z+u7BXVyjFV5dahVvqNovV5tlusm4yjdc20skTSHa/9RKei0jqm8oPIS0EBOuQjInyExWAwB
-        TZEpGZLv6XmU1Xk/rF3ChcC70oW4fv53gzNWA2ANpKkGY0LRny3I1J3CJEQoRgW3IfMaDng/QilS
-        xl0mX8wP62hxj1exJ2rcxrrUl+moKrVbQagoMrp8E2r1GgqbB2jOxmfVOx4MbV/KNHRRWk3TRKjW
-        9DJQwqDvhYwYsFZA7hpaQi3LgpiMF0W/XEI197+smRdO8D9TLP3TqZsX2XMQqWniodpyxgtaNd+l
-        m0YDSa8/9Fbu6MkQ0FppgsktcGxCMCce18vZEB3/hjPjRUBjYnjcV6BfKisvYnz8p9N45VjooAds
-        +s/0gppvFQnAX9SMK2JXaMVwN8xDM2Kph3tLf94//PHrClP6EmhoZehKtFgs+svHjgZ0Fks//lig
-        5uTG/RTCpzZFCoSeYPLHsFGsJ8WZO6A9HjyuqEnQKCOlm+m4SzXEJ1CWnklFF4IqOENeNDM6UUoA
-        RR62p8I4qtICGk7QELm6qK06goyTY1Z8zx1lcl+VJuEyXi+i5XbrGqnst6B1HG23SGLqj/qWeXbo
-        qNEXbihWS/vddJmC6+owcyVtFkd4g0bCEfYCVCPhWC4GYC+t960HMnE9ytO7p0/dmO6knZeZEj7d
-        4c7Dc8cxSy3izNrCvJ/PqcHubm4TTZFe4sWpK/4WWy62gItr+l9zwGpNvwp1UPMTxn9byMMHkCeu
-        lXSAR0Nlmqgz0oPWfrVfKfn3smHA2EYQzLF76Hi9Ytt1tE8ZW7HV/u5udbfZwyZarBhsIWF4LJNL
-        64aloaDYl35XrrSr35UmAypshrlAxiqPUj3L3bwnq0ApJNx2+uqzVpUaSwLr+1AKx/l6qGtNO50c
-        geVUdNCerGmwF41PiQ7RCOqDMabE/ozzVR47zEA67PdqT5yWSuaI+Ue341jRpEqlJfNdvNu9k1Wg
-        E8hcEZMeJy5bq68nwfCy1e8LknGsTH0ZcI12UnsEoKE60+6GIuVGRV68kYa3+NbCiw8bj5h6m1QF
-        arCitMq4LWgpjnhrvaT1r0eMjMKOBjEtOPoxlldRzq/DbCV1aqreKGiYaJWJYZoXk0Ssp287maeB
-        pMDBr1KCXIe4JAbu/hUS3dI2iEWXr/ZxA4J0b+I+h0y58ZUX1EFlRTWXdqIrTb1RsI+MfRsaRYbm
-        XqQY10TdtvpqRuArU8LYKp75yQ21PcDUOHLbqmdSneZIi2lISm0qkpyCxWdaQ62GqvDZ9Bh2ePsh
-        ZvQIfyMczi4B2KF12A33HMBKRXYXMlgyFiDQeCITsbvIi9JCqDTq0UK4RLpW+p9+nFZ95avrK7v5
-        FGhIeHqBDnlRn/NMgl635VnSa7ZaKmUzHKIEr5erO0DX92qYsUHzcJ9Tf0DF7/4GAAD//wMAGCkn
-        N8MSAAA=
+        H4sIAKRMDlYAA9xYTY/jNgy9768IctfYzmSbZODxYgu0aA/dQ3enLXoZyDYda8aWXEnOJPvrS1n+
+        jOWZ7aFA0VtMPlEkRZFPCT+cy2J1AqmY4Pfr4MZfr4AnImX8eL9++PIj2a8/RO/CRELKNEmoTImW
+        lCuaaFyhVvpSwf06EUUBjWQdvVutwqSWErgmFT0C4XUZg2yRjGs4glxHQeg5UM3q5luxr3C95r0f
+        er2ygWqhaUGYhlI5NhhpMYaR381alkbxbnfcP4Ue/jQSpamuVURrnQuJW6Sh14qavdB+pGgBaNj8
+        HAJNLoQpQTBtEP3w8GsX2VhswLQUNdfRxr85oHPtl1GUIJOcYiZokhghMa49aVA69Fw6s0bIFCR+
+        rDgr7tda1rD2rEsSqIaUUN1mJMVPzUpY487BexL4xN988Q93m+Dudv8nOtsvaNbXVfrP1g8L2pQo
+        LUp7lDbLu+/8/eZ94Hd5RmnGpNKE0xKu/UdlQZd1iSgryi8ODZSUFQ75C8QKS8ChqXLBXfKMnmdZ
+        9cZhhTErCrwhQ4hV+u8Gp7QEwBpIUwlKuaI/a+CpOYVFSCESWjDtMi/hiLfClSKhzBVqSviwDfwd
+        XsCRqHMb61JelqOyarOC0KLK6eabULdvobBlgGTJ/KxGx4OhZTVPXRel13Stg0pJLxMlTLqdy0hF
+        pWaYDgVaF1CadjZd4TI+NJi3zI/MxlQnuROTs6oaV6OrpP+XJflKgfxnanF8Om1vJBmDIlVdPKaC
+        ElZR29s3ZsRNJKP2M1oZ0pMiIKWQBJNb4SwGZ04a3ChnU3T0Cw6iVwGdielxX4F+tlZexTTxn07z
+        lXOhgR5xprzQC2qeLLPAX1TNKyKspEhwN8xDd61oA28s/f7pj81P32NKXwNNrUxdCXzfHy+fO+rQ
+        aSz96GOFmpPhEEuIJrUp8ir0BJM/h81iPQmWmAPK8OBxRcusZhmpDWXAXSxHWEBpeiaWgzhVcIay
+        6ihALEQBFMldRgtl+E8P6ChHxw7botbiGXiU3R5vn46Gh5kvq4kZj7Z+sNnvTZ/m4xa0jYL9HplR
+        +9HesoZyGr71G1MUq6X/7rpMxaQ9zFJwnUcB3qCZcIa9AJXIZzb+BNxI233beU9Mj2o448PngQUM
+        0sHLXBRNut2dh5WGuNayiHKtK3XneVRhd1c3saTIWfHitBV/gy0XW8DFNP3HErBa08dCHIV3wvhv
+        Kn78APzEpOAGcK8oT2NxRvbR22/bioSKYvf4JEwB2t9WkwMtdI4eQ/TAn7l44aE3kllQCjHTg95+
+        tqpa4sFhFR7rwhC/Eepa088Qw2JxTA7QkaxrgxeJr4gB0Qna9ClVYxfFKcifB8xEOu3KIiNGS3mC
+        YX7+aHacK7pUibROml477D7ILKjm7K+6e6agGJPPsBvLKNse9sF2t4tvt5tkv012Bz/bbWN6OGz2
+        2yw4IEFeWmotn4CXgqj0eeGy9fp2EkwvW/toITnDypSXCdvoJ3WDADTUnqG5ocjoUVFW38jye3xv
+        4dXXUoNYevDYhCrMQPfKaT5610acSAlsZhDRiqELc7kN0LuOsJe0WbFtsaBujlXHKpGsWuRgI33f
+        xBqCSSqc+SIlSHOIyZ/j2l8h0S2pnVh0+WofMxvI8MYeE8iUqaacnTqwVkRXXwsNaen1gy1k7tvU
+        KJIz88LFuBZKttfb8YDvVw5zq3jmJzPPMoClSWS2FS/EnuZMi2mIa6ksP05B4wOwY1VTlftsRuTa
+        vf0UM3vUfyMcziYB2Jyl2w3z0MBKRWLnMlgniYM744ksxG4ir2q8VY7SaKcKYRyZWm0fK2aS2pby
+        aFpK6C2BplxnFOiUEo3pziLobVsNQXrLVs+idI7zk+D1MnUH6HomphmbNA/zufSHVvTubwAAAP//
+        AwCffIx2ExMAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"c73a9d691427c8978055947664fcbf10"']
+      etag: ['"220fba5cc776b044e82a07862676db4e"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -256,62 +256,62 @@ interactions:
     body: !!python/unicode '<search><status type="array"><item>authorized</item></status></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search_ids
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search_ids
   response:
     body:
       string: !!binary |
-        H4sIALjak1UAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
-        sNGHS4KVZqYUQxUlFhUlViqBBEHAJrMkNdfOoqzCPDfFRh/MASnXB6q347LRR7cUAAAA//8DAJ2D
-        feiGAAAA
+        H4sIAKdMDlYAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
+        sNGHS4KVZqYUQxUlFhUlViqBBEHAJrMkNdcuydw83SLLRh/MASnXB6q347LRR7cUAAAA//8DADuz
+        f2OGAAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"574ab2f015673d6735b1946dc65ece12"']
+      etag: ['"22507a0bb76d776895789196ae8d6fea"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '<search><status type="array"><item>authorized</item></status><ids
-      type="array"><item>8vx7md</item></ids></search>'
+      type="array"><item>b77g8j</item></ids></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search
   response:
     body:
       string: !!binary |
-        H4sIALnak1UAA9xYS4/bNhC+51csfOfa8mPXG3gVBCgKFEV7aLJB0UtAUWOLMUUqJOW18+s7pN4W
-        tbs9FCh6s2Y+DmeGw5mP3n045+LmBNpwJR9n0e1idgOSqZTLw+Ps6fPPZDv7EL/bMQ0pt4RRnRKr
-        qTSUWVxhbuylgMcZU0KAl8zidzc3O1ZqDdKSgh6AyDJPQNdILi0cQM/iaDcPoPxq/234D7hes1ns
-        5q3SQ62yVBBuITeBDXpajKHnt1/L03h7Ot/n6W6OP53EWGpLE9PSZkrjFqipRX4vtB8bKgANu59d
-        oOxCuFEE0wbx06efmsj6YgemuSqljZeL2wd0rv5yihw0yyhmgjLmhAT9MTZ5OK7vf/xIvi313ebb
-        bh5CudVKp6Dx40Zy8TizuoTZvHJOA7WQEmrr3KT4aXkOM/Qh2pDFPVlEn6Pl+2j7fnP3F7rdLvDr
-        yyL9Z+u7BXVyjFV5dahVvqNovV5tlusm4yjdc20skTSHa/9RKei0jqm8oPIS0EBOuQjInyExWAwB
-        TZEpGZLv6XmU1Xk/rF3ChcC70oW4fv53gzNWA2ANpKkGY0LRny3I1J3CJEQoRgW3IfMaDng/QilS
-        xl0mX8wP62hxj1exJ2rcxrrUl+moKrVbQagoMrp8E2r1GgqbB2jOxmfVOx4MbV/KNHRRWk3TRKjW
-        9DJQwqDvhYwYsFZA7hpaQi3LgpiMF0W/XEI197+smRdO8D9TLP3TqZsX2XMQqWniodpyxgtaNd+l
-        m0YDSa8/9Fbu6MkQ0FppgsktcGxCMCce18vZEB3/hjPjRUBjYnjcV6BfKisvYnz8p9N45VjooAds
-        +s/0gppvFQnAX9SMK2JXaMVwN8xDM2Kph3tLf94//PHrClP6EmhoZehKtFgs+svHjgZ0Fks//lig
-        5uTG/RTCpzZFCoSeYPLHsFGsJ8WZO6A9HjyuqEnQKCOlm+m4SzXEJ1CWnklFF4IqOENeNDM6UUoA
-        RR62p8I4qtICGk7QELm6qK06goyTY1Z8zx1lcl+VJuEyXi+i5XbrGqnst6B1HG23SGLqj/qWeXbo
-        qNEXbihWS/vddJmC6+owcyVtFkd4g0bCEfYCVCPhWC4GYC+t960HMnE9ytO7p0/dmO6knZeZEj7d
-        4c7Dc8cxSy3izNrCvJ/PqcHubm4TTZFe4sWpK/4WWy62gItr+l9zwGpNvwp1UPMTxn9byMMHkCeu
-        lXSAR0Nlmqgz0oPWfrVfKfn3smHA2EYQzLF76Hi9Ytt1tE8ZW7HV/u5udbfZwyZarBhsIWF4LJNL
-        64aloaDYl35XrrSr35UmAypshrlAxiqPUj3L3bwnq0ApJNx2+uqzVpUaSwLr+1AKx/l6qGtNO50c
-        geVUdNCerGmwF41PiQ7RCOqDMabE/ozzVR47zEA67PdqT5yWSuaI+Ue341jRpEqlJfNdvNu9k1Wg
-        E8hcEZMeJy5bq68nwfCy1e8LknGsTH0ZcI12UnsEoKE60+6GIuVGRV68kYa3+NbCiw8bj5h6m1QF
-        arCitMq4LWgpjnhrvaT1r0eMjMKOBjEtOPoxlldRzq/DbCV1aqreKGiYaJWJYZoXk0Ssp287maeB
-        pMDBr1KCXIe4JAbu/hUS3dI2iEWXr/ZxA4J0b+I+h0y58ZUX1EFlRTWXdqIrTb1RsI+MfRsaRYbm
-        XqQY10TdtvpqRuArU8LYKp75yQ21PcDUOHLbqmdSneZIi2lISm0qkpyCxWdaQ62GqvDZ9Bh2ePsh
-        ZvQIfyMczi4B2KF12A33HMBKRXYXMlgyFiDQeCITsbvIi9JCqDTq0UK4RLpW+p9+nFZ95avrK7v5
-        FGhIeHqBDnlRn/NMgl635VnSa7ZaKmUzHKIEr5erO0DX92qYsUHzcJ9Tf0DF7/4GAAD//wMAGCkn
-        N8MSAAA=
+        H4sIAKhMDlYAA9xYTY/jNgy9768IctfYzmSbZODxYgu0aA/dQ3enLXoZyDYda8aWXEnOJPvrS1n+
+        jOWZ7aFA0VtMPlEkRZFPCT+cy2J1AqmY4Pfr4MZfr4AnImX8eL9++PIj2a8/RO/CRELKNEmoTImW
+        lCuaaFyhVvpSwf06EUUBjWQdvVutwqSWErgmFT0C4XUZg2yRjGs4glxHQeg5UM3q5luxr3C95r0f
+        er2ygWqhaUGYhlI5NhhpMYaR381alkbxbnfcP4Ue/jQSpamuVURrnQuJW6Sh14qavdB+pGgBaNj8
+        HAJNLoQpQTBtEP3w8GsX2VhswLQUNdfRxr85oHPtl1GUIJOcYiZokhghMa49aVA69Fw6s0bIFCR+
+        rDgr7tda1rD2rEsSqIaUUN1mJMVPzUpY487BexL4xN988Q93m+Dudv8nOtsvaNbXVfrP1g8L2pQo
+        LUp7lDbLu+/8/eZ94Hd5RmnGpNKE0xKu/UdlQZd1iSgryi8ODZSUFQ75C8QKS8ChqXLBXfKMnmdZ
+        9cZhhTErCrwhQ4hV+u8Gp7QEwBpIUwlKuaI/a+CpOYVFSCESWjDtMi/hiLfClSKhzBVqSviwDfwd
+        XsCRqHMb61JelqOyarOC0KLK6eabULdvobBlgGTJ/KxGx4OhZTVPXRel13Stg0pJLxMlTLqdy0hF
+        pWaYDgVaF1CadjZd4TI+NJi3zI/MxlQnuROTs6oaV6OrpP+XJflKgfxnanF8Om1vJBmDIlVdPKaC
+        ElZR29s3ZsRNJKP2M1oZ0pMiIKWQBJNb4SwGZ04a3ChnU3T0Cw6iVwGdielxX4F+tlZexTTxn07z
+        lXOhgR5xprzQC2qeLLPAX1TNKyKspEhwN8xDd61oA28s/f7pj81P32NKXwNNrUxdCXzfHy+fO+rQ
+        aSz96GOFmpPhEEuIJrUp8ir0BJM/h81iPQmWmAPK8OBxRcusZhmpDWXAXSxHWEBpeiaWgzhVcIay
+        6ihALEQBFMldRgtl+E8P6ChHxw7botbiGXiU3R5vn46Gh5kvq4kZj7Z+sNnvTZ/m4xa0jYL9HplR
+        +9HesoZyGr71G1MUq6X/7rpMxaQ9zFJwnUcB3qCZcIa9AJXIZzb+BNxI233beU9Mj2o448PngQUM
+        0sHLXBRNut2dh5WGuNayiHKtK3XneVRhd1c3saTIWfHitBV/gy0XW8DFNP3HErBa08dCHIV3wvhv
+        Kn78APzEpOAGcK8oT2NxRvbR22/bioSKYvf4JEwB2t9WkwMtdI4eQ/TAn7l44aE3kllQCjHTg95+
+        tqpa4sFhFR7rwhC/Eepa088Qw2JxTA7QkaxrgxeJr4gB0Qna9ClVYxfFKcifB8xEOu3KIiNGS3mC
+        YX7+aHacK7pUibROml477D7ILKjm7K+6e6agGJPPsBvLKNse9sF2t4tvt5tkv012Bz/bbWN6OGz2
+        2yw4IEFeWmotn4CXgqj0eeGy9fp2EkwvW/toITnDypSXCdvoJ3WDADTUnqG5ocjoUVFW38jye3xv
+        4dXXUoNYevDYhCrMQPfKaT5610acSAlsZhDRiqELc7kN0LuOsJe0WbFtsaBujlXHKpGsWuRgI33f
+        xBqCSSqc+SIlSHOIyZ/j2l8h0S2pnVh0+WofMxvI8MYeE8iUqaacnTqwVkRXXwsNaen1gy1k7tvU
+        KJIz88LFuBZKttfb8YDvVw5zq3jmJzPPMoClSWS2FS/EnuZMi2mIa6ksP05B4wOwY1VTlftsRuTa
+        vf0UM3vUfyMcziYB2Jyl2w3z0MBKRWLnMlgniYM744ksxG4ir2q8VY7SaKcKYRyZWm0fK2aS2pby
+        aFpK6C2BplxnFOiUEo3pziLobVsNQXrLVs+idI7zk+D1MnUH6HomphmbNA/zufSHVvTubwAAAP//
+        AwCffIx2ExMAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"db9ae51b485abcba6e95f0b2d77d3ab5"']
+      etag: ['"37d0a58a5fae32725fdd94b0b6ff0408"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -320,40 +320,40 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/8vx7md/void
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/b77g8j/void
   response:
     body:
       string: !!binary |
-        H4sIALrak1UAA9xYTW/jNhC951cYvjOybCdxAkXBAkWBomgP3U1R9BJQ1NhiLJFaknLs/PoORUmW
-        IioJUBRY9GbNPJLzxZlHRw/HIp8dQGkuxf08vFzMZyCYTLnY3c8fv/1MNvOH+CIyigpNmUFUfDGb
-        RTyNN4fjTZFGAf60Em2oqXR8kDwFlDafVmNOJcSa5hAF9U8rY5VSeM6JcC0JHgfx49efomAstmBa
-        yEqYeLm4vA2joPmyigIUy6gwhDJmhQRt0Sa53a9vXl+T56W6vnqOAh/KrpYqBYUfM8Hz+7lRFcwD
-        Z5wCaiAl1MyswffzFD8NL2CONoRXZHFDFuG3cHkXbu6urv9Gs7sF9fqqTD+5/vZuYdefFzTB0Uai
-        1fbDxToM1+vV1XLdRhulW660IYIW8NZ+VOZ0WsdkUVJx8migoDz3yF8g0dz49iozKXzyLT2Oohr0
-        3YoSnudYY2cX1y//rXPaKACsgTRVoLXP+6MBkdosTEJyyWjOjW97BTu8G74QSbwKuSvm23W4uImC
-        vqg1G+tSnaa9cmq7gtC8zOjyU6jVRyhRYT44G+eqlx50bVuJ1HdROo1uCp0qRU8DJcaz1zt8m2gw
-        JocC8GIm1LDMi8l4WfbLxVdz/8uaeSeDP0yx9LPTNC+y5ZCnuvWHKsMZL6lrvku8AkNJrz/0Vkb0
-        oAkoJRXB4JZSaPDGpMb1YjZEx7/hzHgX0G4xTPcb0C9ul3cxtf+Hw3jlWGihO2z6L/SEmmdw1wPn
-        iB5XRFQqyfA0jAOtTCYVf6U1vN7pr5vbP35dYUjfAw13GZoSLhaL/vKxoR6dwdKPv5SoOdhxP4Wo
-        Q5um3FqCwR/DRr4igWA2QVtMPK7AoktAjSNS2ZmOp7ghPoEy9EgcXfCq4AhF2c7oRMocqJjHW5pr
-        S1U6QMsJ0AvCqGpnlJF7EHGyz8rvBcLrL6dJuIjXi3C52dhGKvotaB2Hmw2SmOajuWW4Kamp0Z9c
-        U6yW7rvtMiVXLpmFFCaLQ7xBI+EIewKqkHAsFwNwLW3ObQYysT2qpnaPX89j+iw9W5nJvA63v/Pw
-        gu6AVCqPM2NKfRcEVGN315eJolzYi9NU/CW2XGwBJ9v0nwrAak2fcrmTwQH9vyzF7gHEgSspLOBe
-        U5Em8oj0oNvfnVcJ/r2CJvnYRhDMsXuoeL1im3W4TRlbsdX2+np1fbWFq3CxYrCBhGFaJpc2DUtB
-        SbEv/S5tabvfTpMBzU2GsUDGKvZCvogo6MkcKIWEm7PefTaqSmFJYH3vqtxyvh7qraabTpbAcpqf
-        oT1Z22BPSuY9RCtoEqN1hf0Z56vYnzED6bDfyy2xWiqYJeZf7IljRRsqmVas7uLn088yBzqAKCTR
-        6X7isnX6ZhIML1vztiAZx8pUpwHX6CZ1jQDcqIm0vaFIuVFRlJ+k8R2+26F5xbQNdfiwqRFTbxNX
-        oBorSsmMm5JW+R5vbS3p7OsRIy2xo0FMS452jOXOy2Ds5r/0vHmATHo+fs79AF53kqYg3ETIqZ9e
-        VolmipeT9LOn7/p3TX5JiXRHpgQZHrEB9HS8N0g0SxkvFk1+c44diwQnoIc5p1zX982rA7eLbFvV
-        RC+eeplh9xzbNtwUeal9h6NfE7e107vJiG9rAeNdMecHO8q3AFND2B4rX4jL5kiLYUgqpd3TIAWD
-        j9OWUA5V/tz03hX+44eY0V8Pn4TD0QYA55Lym2EfQVipyGl9G1aMeZ4NmJEJ363nZWXAVxrNQCVc
-        IEmt6p81iXDd9Ml20yiYAg1pXs/RIRvsM71J0Md71dzwo706AmkypA4Er5etO0DTt3IYsUHziC/+
-        AQAA//8DAPmm2E/VEgAA
+        H4sIAKlMDlYAA9xYUW/jNgx+v19R5F21neaWpHB9uAEbtofdw+66DXs5yBYdq7UlT5LT5H79KMt2
+        7FpubxiGDXuLyU8USZHUp8TvTlV5dQSluRR3q+g6XF2ByCTj4nC3uv/0Pdmt3iVvYqOo0DQziEre
+        XF3FnCXpdnvYPcQB/rQSbahpdHKUnAGLg+7Tasy5hkTTEuKg/WllWaMU7nMmXEuC20Hy3f3PcTAX
+        WzCtZCNMsg6v91EcdF9WUYHKCioMoVlmhcS69WBAmzjw6ewaqRgo/LgSvLxbGdXAKnAuKaAGGKHm
+        yrp5t2L4aXgFK9w5ekuikITrT+H+dh3d3ux+R2eHBe36pmZ/bf1lQZcSbSR6bT9chrffhLv12yjs
+        c4zSnCttiKAVPPcflSVd1mWyqqk4ezRQUV565E+Qam58tupCCp88p6dZVoNxWHHKyxIr6xJizf7Z
+        4LRRAFgDjCnQ2hf9yYBg9hQWIaXMaMmNz7yCA3aEL0USG6B0JbzfROE2Dsai3m2sS3Vejsqp7QpC
+        y7qg669C3byGEg2eB8/mZzU6HgwtbwTzNcqg0V2hU6XoeaLEfI4mhs9ITZXhmA4NxpRQATbodIXP
+        OG1MIRX/8rr5kdmUmqzwYgpe1+Nq9JX0/7IkXyiQ/0wtjk+nm40k51Ay3cdjKyjjNXWzfY0dNpWM
+        xs9oZUyPmoBSUhFMbi2FBm9OWtwoZ1N08hNeRC8CehPT434G+tFZeRHTxn88zlfOhRZ6wDvliZ5R
+        8wCuPfCa0vOKiGslM9wN89C3FW3hraVfP/y2/uFbTOlLoKmVqStRGIbj5XNHPTqDpZ+8r1FztBxi
+        CdGmljFuPcHkz2GzWJGVZPaAcjx4XIFFl4KaZ6SxlAF3cRxhAWXoiTgO4lXBCaq6pwCplCVQsUpy
+        WmrLfwZATzkwCpJR1V+BRj6CSPKbw83DAeHtl9OkXCSbMFrvdnZOi/EI2iTRbofMqPvougyNkpZv
+        /cI1xWoZvvspU3PlDrOSwhRJhB00E86wZ6AK+cw6nIBbabdvd98TO6Navnj/8cICLtKLl4Us23T7
+        Jw+v6AFIo8qkMKbWt0FANU53fZ0qyoVtnK7ir3Hk4gg426H/uQKsVva5lAcZHDH+61oc3oE4ciWF
+        BdxpKlgqT8g+BvvdWFFQU5weH6QtQPfbaQqgpSnQY0juxaOQTyIORjIHYpByc9G7z07VKDw4rMJD
+        U1riN0I91wx3iGWxeE1eoCNZPwbPSpYjRC/o0qd1g1MUb0HxeMFMpNOpLHNitVRkGObH93bHuaJP
+        lWRN1s7ay+4XmQM1gv/RQNdMKMbkc5zGKsk3+1202W7Tm806222y7T7Mt5uU7vfr3SaP9kiQl5Y6
+        y0cQlSSaPS4026DvboJps3UPFlJwrEx1nrCN4aZuEYCGujO0HYqMHhVV/ZUsf8APFrqn0YXMjF9L
+        LWLpweMSqjED/Sun/RhcG3EiLXGYQUJrji7M5S7AYB7h3w568/aloOfPw3834EHSlYG7B0rqJ5VN
+        qjPF60XSOdIPU7tl1KRGkiMZQV5HbO48c+4ZEt1SxotFl5/tYy9DgveehzEzrtv+9erAWZF9Qy1M
+        4KXnHs7MuW9To8hG7ZMe41ro0UHv7kN8sAuYW8UzP9oLPAdYunrttvKJuNOcaTENaaO0exAwMPji
+        7WnkVOU/m9Frwr/9FDP7F+Mr4XCyCcDbSPndsC8rrFRksj6DTZZ5Hgt4Igux28jrBrvKUxrdNUq4
+        QGrauNeZpQ5uhn62MzQOlkBTcjcKdMoBx/xuEfS6rZYRvmZroI2mQMJAsL1s3QG6nstpxibDI3nz
+        JwAAAP//AwARQ5o6IBMAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"739e93c2530c74dd7b46ac28f0401972"']
+      etag: ['"161d6b4e1b8666b2c2c0c4a325fc6af6"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]

--- a/tests/py/fixtures/TestRoutes.yml
+++ b/tests/py/fixtures/TestRoutes.yml
@@ -1,36 +1,36 @@
 interactions:
 - request:
-    body: !!python/unicode '<payment_method><customer_id>35060504</customer_id><options><verify_card
+    body: !!python/unicode '<payment_method><customer_id>68534907</customer_id><options><verify_card
       type="boolean">true</verify_card></options><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods
   response:
     body:
       string: !!binary |
-        H4sIAAHbk1UAA7RWS5PiNhC+8yso7h4/eM6U8dReUpVDcslODrlsyVIDGmzJkWR22F+flt+AMZ7a
-        zQ19/bnVar5+hK8faTI9gdJciu3Mf/JmUxBUMi7229nb19+czew1moRUAePGoUSxaDKdhjFPEqQ4
-        hDEFWlsMUc4ifQxdzqozzbWRKSgHkfnSW3lLbxG6XbTk7bjSxhEkhangyXZmVA4ztzIm5L6NyjQj
-        4txj0UYBmDq+HgJ8GBAM2AAlkZQk3PS5V7DHhPUYMqkNSRzMIETPC99bh24XqsPOhVHnAnJIkh1I
-        0Pu4a9b8EUvkmFdOB2j3EqmAGJsMMzXnDLYzhkfDU5hFgecvHW/teP5XP3gJvBd//Q/+ic0HlYc8
-        Y5/z0H5QKMrtkRTKTEQLzw82G2sXBWY16Ngror+5JhhJc66tB5kwlFffU61iMEWUkyR6E0chvwv0
-        0GKTTqrkzuFa50RQiN7++mJ5t4bJzydvXJm0LCtLg+rDoDqsBrVcBjE37QPLY2nYkTyp44ylTICI
-        WWQTZGmFsSTmChPuoM7zxMbacXZtmRTVlHFV3O+kUphD5AehewNeMc9AFGYo8C6oBdowgV3HuiOJ
-        huqL6vYDkMQc8K+HNswOZik8JXtwcpVEB2My/eK6RGsw+ilWhAvbLPb4mO/k/IRqcDNyTkGYbymY
-        g2TfErmX7gnV9pSJ/SuIE1dSWMJWE8Fi+YE9r/Ff3IbysFqOiTi2IV2gk7q1LSJ/s/FDtzpYHK9X
-        MukotAYKo4KMoCb+lIhXvy2u81hTxTObRF0ljShFzpXyjTyCiJ7P+yBYhW55sngu+L950TriQmz4
-        LL7joKLFnG4W/o5ROqfz3Wo1Xy13sPS9OYUNxBRL8u6nk1/QEE4gUulodrwjgMZesRVeXZbA5eur
-        /tQllFAxJYjJdVTagIVuBdR2ejqh0HWGPqFs4H9gyd2ANZ2ctANKSXVpv+23FbczGW6vGSZ03VzO
-        uivi76WnQU7trCoBtL4DLYoRG5Xum3NIti3zQAT6pEVjtH1Km/j5uFj/+BG/B2q1fA/dPlbtIVOS
-        YjDX6Yp8z/OstvutA18bHOrRlwwtJ/tn3mPUHjAU+rE+zt/blaVdberzg/Xk0YoyvKaMWlVGrisP
-        VpbBtWX06jJil+jM8raOLtfHCr3TkZr/4Wb2d9N92zbru4b2gyabI8fVLX94aNUxjJ/VnagH9paK
-        9T/16loA/ZOlsj4eshXx3vJRmz+1WbQV9GBtq98wMDoryrjhfKX1sctgk0rJclp0uzaSFmsKpacw
-        PrdOrnp28Z8fvja064F5ieCMvIr+PwAAAP//AwB6ardcSw4AAA==
+        H4sIALVLDlYAA7RWTZObOBC9+1e4fGcAD1njKcxULluVQ/aymRxySQnUtjUjJFYSzvjfbwvEh22M
+        nZrdG3r91Go1T92dPL8XfH4ApZkUm0X4ECzmIHJJmdhtFi/f/vTixXM6S3IFlBkvJ4qms/k8yRjn
+        SPEIpQq0thiijKavh8Rn1K3zShtZgPIQ+SP+9Bitg1XiD9GGt2VKG0+QAuaC8c3CqAoWvjNyct2W
+        y6Ik4jhi0UYBmDa+EQK8GxAU6ASFy5xwZsbcK9hhwkYMpdSGcA8zCOk6Cu19h1AbdiWMOtaQR3i5
+        J8vRy52zHm+xRIV5ZfkE7VoiFRBjk2Hm5ljCZkFxaVgBi3QZhJ+8MPCC5bdg/RSunqLgB/7EboPz
+        UJX09zz0G2pF+SOSQpmJNArCZRxbu6gxq0HPHpF+Z5pgJN26te4lpyivsataxWCKckZ4+iLehPwl
+        0EOPzQapkluPaV0RkUP68vdny7s0zD6evPueSc+ysjSoPgxqwOpQy6WQMdNfsFk2hi2peBtnJiUH
+        IhapTZCl1caGWClMuIc6r7iNdeDs3DKrX1PJVH2+V0hh9mm4TPwL8Ix5BKIwQ8vghFqjHRPoeaxb
+        wjW4He70PRBu9vjroQ9zgFkKK8gOvErxdG9MqZ98n2gNRj9kijBhi8UOL/OLHB9QDX5JjgUI87MA
+        s5f0J5c76R9QbQ+l2D2DODAlhSVsNBE0k+9Y8zr/9WkoD6vljIi3PqQTdNaWtigN4zhMfLewOB6v
+        JB8otAVqo4KSoCb+koi7b4vrKtO5YqVNonZJI0qRo1O+kW8g0lUWR+Uu8ZuVxSvB/qnq0pHVYsNr
+        sS0DlW6jdRxGq1X2GC3zOMpX62C7ijKyXi/jaBuu8Qlf2zr7DwrCAUQhPU3frgigszu2wqObJ3B6
+        e1efhoQGqrsEMZVOGxvQxHdAa88PBxS6LtEnNAX8Kz65C7Clk4P2QCmpTu2X9dZxB53h8phpwtDN
+        aa87I35pPE1yWmfuCaD1FfL6MWKh0mN9Dsm2ZO6JQJ95XRhtncpeDWiT+GO2dl+pZI4hnCcpDYMg
+        sIoet07sNtjK088lWg72F15jtB4wlDjevwvaDyr9QNOubwwltwaT6eHkrgHlziHlxqAyOazcPbDc
+        MUEMOnj/ek6HRodeqUPdf7jo+MN0XxbL9qypqaDL5p1N6pI/3araGO7v0IOoJ6YVx/qfKnQrgPF+
+        4qy3W6sjXhs5WvNvzRP9C7oxrLV3mGiYjnJfSz7T+r0jYJdKSau8rnZ9JD3WPZSRh/HxCfzjLdeG
+        dt4mTxHsjGfR/wsAAP//AwBZ2bAoQQ4AAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"98ee24bf55e7c9e866c13ea2eda8a37d"']
+      etag: ['"8c64d511627019440d16a4bad1582c58"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -39,37 +39,36 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/35060504
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/customers/68534907
   response:
     body:
       string: !!binary |
-        H4sIAALbk1UAA7RXS3OjOBC+51e4fCeAX3FShNRctmoOu5ed7GEvUwK1bdkgMZJw7Pn127yFMRhX
-        sjfU/alptfrxyXs7xdHkCFIxwV+n7qMznQAPBWV8+zp9//GHtZ6++Q9emCotYpD+w2TiMerPl87K
-        WToLz8ZFJkNduCNcW7jeP28/6GZPD6dzvKNb6dmmNkNvmFTa4iSGCWfR61TLFKZ2ropInyYUcUL4
-        uSOHmLCoI012gndtbMipI/uAQDF95X8SiAZqET3R5wRepxSXmsUw9WeOu7ScJ8txf7izF/fpZfH8
-        r2c3G/L9aULH7Z85aAL3NxuK/+cxtzYMIqpqlyjTVkgkVaVRIiU5TzNtW19IUBawKMLbtAilEpSq
-        5MU9qkN1g6WsumirdcmmtMH232IJ6L3L6mfXb7TUKi0BdOV3DwhOGjjNgjYIi0RIIqb7fiVhi/nf
-        o0yE0iSysCjAf164zpNnmyLzOCnX8pyLLRIlOzLrPfglcj4GyVO8AxbegA4FfGxKVynZTunSyicT
-        O7dh96Qlpiv3F447W68zDK/lWU5b2e/8f5gi6Fm9NhE7EVFM074QZBmX9SJGIv+dH7j44GipkTWw
-        IpRiYzGlUsJD8N///pZhu4p60+eDO778GmSW2hqzFx00kLW0wlMImG4OXSwb5YakUeV3IEQEhE/9
-        LHgZNFc24FTixVhYM2mU+W8YvdRUW+CUMJn7Y8WC653vzjy7I7yCPgORGL2Z04Ln0hYa6KXvGxIp
-        KHcZnuyARHqHqQKN24asgrGYbMFKZeTvtE7Ui20TpUCrx0ASxrPGtMUDfpDzI2aPnZBzDFz/jEHv
-        BP0Zia2wj5iljwnfvgE/Mil4BnhVhNNAnLDn1vbrP2I6ZfUQEH5oXGtJK2jeVhe+u167nl0uKh26
-        IkVkZHclqAESEoJ59JdAXfld6VQaqFCyJAtye740FaTFAbj/fN7OZivPLlaVLuXsV5q3qSBPVjwy
-        w/El/cU8XC/cDQ3DeTjfrFbz1XIDS9eZh7CGIMRS791a2/6CpnMEHgtL0UNPstR6Y4dEN4pSujZx
-        O6BGnE8wolPlF3qgnl0KTEx4PGLBqATtQzFQ/sQy7gjNLeSoLJBSyDbmes8v8cbE6v5uGHBpqj2X
-        L8DfC2uDGNNgWUaI2EOYFzc2RdU3i02iScK8GWc9Ueng+bB4+v072M/kark3CKeBMq0kUoTo2GUI
-        fddxnKwurmtvWNBIRvxvCWqO2WX3IUwr6FZ4ejrM920a1tA2UzaCcuWgG7SrSLsh6lUm7236lQPH
-        UbDCs0EalkOGqFgR+JF0rDzmLU5kcJF2XXapdKkZ6ID13V3lMOb1XG/f1b9vcZ068neM1e6e28O1
-        8uc+rmGc4gYfK5H/49yokqZ/6pWIccSgBA+RqQpyN0uqwjaKolbnujHuS9h4clE7cT8BrkMtaBrm
-        HbfxqpG1Cq+nyO6j0qued8rXkIbMzWsDvi0tZ3rnRC1BDvLKLglXH/CXr6HOE/2OF8LwrBieEkPz
-        YcRkGDUTBqfBwBwYOQHGPsfHPsZHP8VvDp0veSl+OrWRqDXJVi8Al006+Q//AQAA//8DAF2fqcIh
-        FAAA
+        H4sIALZLDlYAA7RXS3OjOBC+51e4fCeAw8Q4RUjNZavmsHvZyR72MiWgbRRjiZGEY//7bfEUxmBS
+        yd5Q96em1erHp+DldMgWRxCScva8dO+d5QJYzBPKds/L159/WP7yJbwL4kIqfgAR3i0WAU3CR//b
+        g7dx1oGNCy1DXZwSpixcq1zFebpLxGP8sD/uRWCbWo3eUiGVxcgBFoxmz0slCljapSojY5qYH3LC
+        zgM5HAjNBtI85WxoY0tOA9k7RJKqK/8TQBQkFlELdc7heZngUtEDLMOV436zXMdyVj+dzZPrPrmP
+        /wZ2t6HcX+TJzP3rJ8/B/d2G6v9lzK0thSyRrUsJVVZMRCJro0QIcl5qbV9fSVAW0SzD27RIkgiQ
+        spFX9/h2bG6wljUXbfUu2ZR22PFbrAGjd9n87PqN1lqpBIBq/B4BwUkBS3TQJmEZj0lG1divBOww
+        /0eUOZeKZBYWBYQbz9XxMEXmcQqmxLkUWyTLU7IaPfgl8mEOkhV4BzS+AZ0K+OyUrlOyn9K1lU8m
+        dmnDHklLTFcWeo678n2NYa1c57Slfxf+QyVBz9q1iUh5lmCajoVAZ5zuRZRk4SvbM/7O0FIn62BV
+        KPnWolIWhMUQvv79XWOHinbT54M7v/w6pE5thdmLDhrIVtrgE4io6g5dLTvllhRZ43fEeQaELUMd
+        PA0tlR24EHgxFtZMkWn/DaOXmmYLnHIqSn+sA2cqDd1VYA+EV9BnIAKjt3J68FLaQ0Ny6fuWZBLq
+        XYYnKZBMpZgq0LltyBoYPZAdWIXIwlSpXD7ZNpESlLyPBKFMN6YdHvCdnO8xe+ycnA/A1K8DqJQn
+        vzK+4/YRs/Q+Z7sXYEcqONOAZ0lYEvET9tzWfvtHTCddDxFh+861nrSBlm3VC13fdwO7XjQ6dEXw
+        zMjuRtACBOQE8+gvjrr6u9HJIpKxoLkOcn++dBWk+B5YuI58L98FdrVqdAWjv4uyTUVlsuKRKY4v
+        EW69je9663X04K1i34vXG2e79iKy2ax8b+tusEWMbW1tf0HTOQI7cEsm+5FkafXGDoFuVKV0beIO
+        QJ24nGBEFTKs9JAEdi0wMfHxiAUjc7QP1UD5E8t4IDS3kKO0QAgu+pjrPb/GGxNr+LtpwKWp/ly+
+        AP+orE1iTIN1GSHiDeKyuLEpyrFZbBJNEpfNWPfE6E2BVAbNNHTm3lzwGN25DFzoOo6jq+G69oYF
+        hRQk/J6j5qiveAxhWkG3fD89saRPvjqyZspmEK0SdINsVck2RbjqlL1NukrgPOJVeTZJvkrIFAGr
+        Aj+ThNXHvMWEDAbSr8Yhga41E32vvburzMW8nutNu/n3LYbTRv4Dw3S45/ZIbfz5GMMwTnGDhdXI
+        /3FaNEkzPutqxDw6UIOnKFQD+TA3asI2i5g257ox5GvYfErROvFx2tuGmidFXHbczqtO1iu8kSL7
+        mtfJ11AF7ea1sd6X1pN8cKKeoAQFdZeEq8/2yzfQ4GH+gXfB9KyYnhJT82HGZJg1EyanwcQcmDkB
+        5j7C5z7BZz/Abw6dL3kffjq1kZ51ydYuAJddOoV3/wEAAP//AwAeDR6oFxQAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"9f8f0e8cdcdc2bcdc26fb50e704e003b"']
+      etag: ['"8ab0c0f0d0eaf5ff13e64bf6ad21045e"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -78,16 +77,16 @@ interactions:
     body: null
     headers: {}
     method: DELETE
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/9yg226
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods/any/7b84pg
   response:
     body:
       string: !!binary |
-        H4sIAAPbk1UAA1IAAAAA//8DAEXPbOkBAAAA
+        H4sIALdLDlYAA1IAAAAA//8DAEXPbOkBAAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"5525e7db366506adfea72aa0e6a7d3af"']
+      etag: ['"6aa9d9cb0d7c525aa24b65e84ecc5609"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -96,43 +95,43 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/35060504
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/customers/68534907
   response:
     body:
       string: !!binary |
-        H4sIAAXbk1UAA5RTwXaCMBC8+xU87ikBtVQf4K1fYC+9pWSFaAi8JFT4+wZQwQLWHndmdjfsDMGu
-        yrj1DVKxXIS2+4JtC0ScUyaS0P7Yv6M3exctgrhUOs9ARgvLChiNlmv8itd4FTimaDDDxSkRGpn6
-        uEnO9HCkp6rOUprIwBmyjfrApNJIkAwswXhoa1mC7bQUJ3NMnGcFEfUIh4wwPkKLNBfjGQdSjbAz
-        fCmmJ/ZJIBooItrSdQGhTU2pWQZ25GF3jbCPsLt3va3rb1ebz8DpG9r+sqDP9Xt46zb9fUO3v705
-        OjDgVN2eRJlGMZFUXYYSKUl9eTGhVIJScM81VE92VeeiOl39a5GryejO4CF6Vc7719KzHnZrpn1s
-        OaUlgEaXt05KoNIgaHOmByKex4QzPb1EQmLSPkkVudKEI/MDQLRZudgPnCHUf0IptKxbEBFepMSb
-        +dTfuuXfOlGaa7P4oXD+uM+GtgmdPwptO+NfwfVHwTUTnEHYbgWYso9TtPgBAAD//wMAA/K1LHwE
-        AAA=
+        H4sIALhLDlYAA5RTy3aCMBDd+xUc9ikgPqoHcNcvsJvu0mSU1BA4yWDl7xtARQtYu5x77zwycxNt
+        Tpl0jqCNyFXsBi++64BiORdqH7vv2zfy6m6SScRKg3kGOpk4TiR4snidh7OVv4w8G9SY5VhKFRIb
+        Y4GsSPdcL1h4OB505N2ytXontEGiaAaOEjJ2UZfgeg0l6RjD8qygqurhkFEhe2iR5qpfY0dPPewb
+        Po3AgX4aKAInFB2sCohdbkMUGbjJ1A/mJPCJP936q3UQrIPFR+R1CU1+WfAn85frWWjzu4S2f7Nz
+        shMgubmOxAUSRjU356JUa1qdJ6acazAG7rma6sg2aq/4dbzcr0EuRyZ3B75FL8rx+zX06A3bNsN3
+        bDiDGgDJedZBCZwQFK/X9EAkc0alwOEmGvbW7YNUkRukktgPAMlqFtTvv4W6J5QKddWAhMoipdOR
+        p/7WhX/rVGm3LdhD4fhynzatNZ3fM21T41/G9XvGtRW8G7NdA7BhZ6dk8gMAAP//AwC/60BqfAQA
+        AA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"1d6edbb8f97c32fb009c4cf0cd5bdefa"']
+      etag: ['"e6142e96f923d2fb8aea81ad641c1739"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<payment_method><customer_id>35060504</customer_id><options><verify_card
+    body: !!python/unicode '<payment_method><customer_id>68534907</customer_id><options><verify_card
       type="boolean">true</verify_card></options><payment_method_nonce>an-invalid-nonce</payment_method_nonce></payment_method>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods
   response:
     body:
       string: !!binary |
-        H4sIAAbbk1UAA5RTy27CMBC85ysi302CKBVIwdz4gnJGJl6CIbajtXnk7+sQJ4SUVurNu7OPmR05
-        W99VGV8BrTR6RaaTlMSgcyOkLlZk+7WhC7JmUcYrSQHRIEWwldEWWBTH2SNlm2cfxK6uYEU4Iq9J
-        EqCK1wq0owrc0Yg2+b6jwzr0GfuM5wVsOZumiyx5vIcgdw7l/uIgzLO12puSsLB71+7eaaNzyJK+
-        +mWGAmt5AWyrz9rcdPyud5IlXdmTa/JCNoTdYZKf8ocV/jrIlf37VPnFOqMAqRRsNk8/03n64Y8w
-        yHaVpnLeSzsg5+2Vh5rmHAVzePHqh5me86hxxIQ+xDOuqdRXXsqQGIsLZb8Kb4zKmz0sR+CucaIN
-        o+CwdmjKEnDkm20c77EouIX5kfvxXv1pWdzE4STO91odRYGNSU80asl0Z/63z57lmw/wDQAA//8D
-        AEj7v6o9AwAA
+        H4sIALlLDlYAA5RTy27CMBC85ysi301AtBSkYG58QTkj42zBIn5obdLm7+sQJ4Q0rdSbd2cfMzty
+        vvtSZVoBOmn0lixmc5KCFqaQ+rwlh/c9XZMdS3JuJQVEgxTBWaMdsCRN83vKNc8+SH1tYUs4Iq9J
+        FiHLawXaUwX+Yoo2Od3RYR36iEMm8AK2WS7m6zy7v4cg9x7l6eYhznO1OpmSsLj72O4+aqMF5Flf
+        /TRDgXP8DOygr9p86nSqd5ZnXdmDa/ZENobdYbKf8ocV4TrIlfv7VOLmvFGAVBZstX5dvmzmb+EI
+        g2xXaawPXroBuWCv/Kip4Fgwj7egfpjpOY8aR0zoXTzjmkpd8VLGxFhcLPtVeGOUaPYwgcB940Qb
+        JtFh7dGUJeDIN9c43mNJdAvFhYfxQb23XtjLucCVWF6rKzYmPdCkJdOd+d8+B5YTH+AbAAD//wMA
+        klk0ET0DAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
@@ -142,160 +141,60 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 422, message: Unprocessable Entity}
 - request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/bkhpqm
-  response:
-    body:
-      string: !!binary |
-        H4sIAAjbk1UAA6RVTXPaMBC98ysY34U/MMRljDO99NhLkx566cjSGmuQJUeSSfj3XRkDDh9pM72x
-        b5+0u89PS/741sjpDowVWq2DeBYFU1BMc6E26+D56RvJgsdikjMDXDjCqOHFZDrNSyElUgjl3IC1
-        HkNU8CJ9zUPBh5h11ukGDEEkjtN0vkjSPByjB14ljHVE0QamSsh14EwHQTgkJb2fY7ppqdrfyFhn
-        ANyxvxsEeHOgOPAPKFIzKoW7db2BDQp2I9Fq66gkqCAUX9I4esjDMXRsu1PO7HuIUNnWNLk53CVr
-        /jeW6lBXwT6g3RPSAHVeDDd1+xbWAcfQiQaCIoniBYkeSBQ/xckqflgtkl/4EU8Hhhu6ln/uhvOB
-        3lHhDUuhzVSRRnGSZT6vesx7kPgSxU9hKXZyio/ZWkuO9ro1qncMSsQElcWz2ir9qvCGMzYZSaUr
-        IqztqGJQPP/46nnXicn/i/dvz+TM8rZ06D5sasQ6oZ7LoRTuPOAhPCQq2sljn6XWEqgKCi+Qp/XJ
-        A7EzKDhBn3fS9zq67DIz6V9TK0xfnzRaubqIkzy8Ai+Ye6AGFUqid9QePTGBX/ZaUWlhODFUr4FK
-        V+Onh3ObI8xTREM3QDoji9q51q7CkFoLzs5KQ4Xyy2KDw7zS/QzdELZ034Byvxtwtea/pd7ocIdu
-        m7Vq8whqJ4xWnrC2VPFSv+HOO93fV0N7eC+XVG3PLb1DJ8fVlhZxlsV5OAQex/JGy5FDj0CfNNBS
-        9MR3jfjw2+O2Ky0zovUi2kE0agzdD853eguqKLd1+9Lk4SHyeKfES9evjrI3G44lKgGmSOcsS+OK
-        MzZn82q5nC8XFSziaM4gg5Lhk7x7dPKphZCtFsvrhbAD1Whi+faOAU75gW2w9OEJXE3fv7jz/9cf
-        AAAA//8DALEILZ71BgAA
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-encoding: [gzip]
-      content-type: [application/xml; charset=utf-8]
-      etag: ['"34022798609eb2520c567ebb58f31266"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/11443524
-  response:
-    body:
-      string: !!binary |
-        H4sIAAnbk1UAA6xVTZOjOAy9969IcXcTCOnOdBG69jLHuez0HvYyZbAInhibsU0n+fcrE77SCRmm
-        em/o6ckW0rMUvx5LsXgHbbiSWy94XHoLkJliXO623tv3r2TjvSYPcVYbq0rQycNiEXOWBEEUrdZh
-        FPtoOAx9WUGlJWj//LI7sPwn2x9PZcF2OvbHXsfOuTaWSFrCQnKx9ayuwfMbl6BTnkyVFZWnKxxK
-        ysUVWhVKXp+R0+MVdoDUcHvjPg3UAiPULuypgq3H0LS8BC8Jl8GaLJ/JMvgehC/B88s6+Df2h4Am
-        vq7Y/PgQ44eA8/1NzUnOQTDTp8S4JRnVzLSHUq3pyXPeS/8ZQSzlQmA3CWVMgzEdfu5jdOg62GJd
-        o8lFk8fowJ3uYkuY7GV32e2Otl5jNYDt8p4gwdGCZK5od2lCZVRwO3WVhh3qf8JZKWOpIPgoIPkS
-        Bcvn2B9D49+ppdWnBiZUVAUNJ3/8I3M1hylr7AHPfkO9V/A/kXR4Jen2lE8KuznDn5AlylUm0TII
-        NxvHkT3uNE3cdck/3FDMrLfHjEIJhjKdKoFTnJtFnIrkTe6lOkg8acAG2rmUKifcmJrKDJK3v/9y
-        3GtHH/T54s5/fgPTSduiejHBEbNHOz6DlNvhp8/m4MxpLbq8U6UEUOklrniO2jgHcq2xMQTfTC1c
-        /qNDP3q6EDhWXDf5kFJJWyRBGPtX4A32CajG6oXLC3qDXrCBfcw9p8JAGzXKpAAqbIFSgSHtEdbR
-        eEl3QGotksLayrz4PjUGrHlMNeXSDaYd/uCBnh5RPX5FTyVI+6MEWyj2Q6id8t9RpY+V3L2CfOda
-        SUfYGipZqo44c/vz+xtRTu49pFTuh9Qu0I7ajNUoCTabIPZbo/NhKlqJkbo7oCdoqCjq6JtCX/vd
-        +UydmkzzyhX5cr8ML8iqPcgk3RfVrzL2z1bnqyX/VTdjKm3Eir/McX3pJFplmyjIWZatslX+9LR6
-        WuewDparDDaQZvjUJ0P7s2cPnc3L+un20HkHWSpi2H5CLL1/FKExjfNTulmR5hWPd+4F0Iy1uB1x
-        cHNlf5x/V0v5D2bC/YV8fx3fW8YzVvGsRXx3Dd9ZwjNX8NwFPHf9zl6+v129/8tu+PTajf2R2HoD
-        0BzklDz8BwAA//8DAM13fYwTDAAA
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-encoding: [gzip]
-      content-type: [application/xml; charset=utf-8]
-      etag: ['"b4633fa9570f8059a6d8a9df8f5f7544"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '<client_token><customer_id>11443524</customer_id><version
-      type="integer">2</version></client_token>'
-    headers: {}
-    method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/client_token
-  response:
-    body:
-      string: !!binary |
-        H4sIAAvbk1UAA7xVXW+jOhB976+o+r53wSS9i9R21TSBgMDZkASw3zCQArEhbQhfv/6O0+ym1VZX
-        K13pPiDAHs+cOXNmfPe9E/y6SV8PeVXe36h/KTfXaRlXSV4+399s1saXbzffH67uYp6nZf2lrnZp
-        +XB1fX3XRPyYPqS9jWhoD1GgH62i6p0nO0tCr2KavU+Foch1T/AjRX4fz+09K5f5Irc0ElgIm2RE
-        p1xggXOytlQXzXq8phkZjJ27nnCy5pyun4dFQDQ8fRzBf4GHZ4Wss9ydevDgDL4FCTzhTmfd1sQ9
-        DQyFBt6WhEvdLR47vFJa3Cut6y87F/C506rH+Wi8mJLBXVstLh5f3elj6xqdCu8esKix5jUs8PsQ
-        8d2P9azD0+WA15YSzjetO7WQ3CMoy1jpbaNgqUcFLxPkiUh4r+mc15HplTE/+ysnKhHdnqj6Kw13
-        uivoOA72Cg6NwUWxkpRJR3PrYAncMEH3VPV79mTdWiJTkvlkWOTfGhJO9k6JMya8nGnPR1LaWRSM
-        lVj4nCLIN0yydDUuGFJuJVYHqTwWuCLSptdfFkGiUZO+ULMepYFaUTPpHYQPUeAfE0PPYnPXJMWs
-        IUg/UgG5hFBDkzfsDRf46Q40GJc0dPMFrxOoMWcl3cdCPzLpQ+K94Mthv2AmBxtvEpvcj0ULNber
-        ZO618VA1DjLaaDUeAN+OCH3kCLsnAT8mc5vTIIHYvkbC3RHw1Itiqbi9XoPGisg0wMZtPuU713/G
-        3Eq+rLzNSYgHGnqDH9oH0GYezT0lnru3Tg85a5iDr3/jMv+p5c/Oy3WnpJwJtfnD2pz8MWEc0tDb
-        Ew24LA958rvvcx7LGvjJ2JxDD+HhT2NsV22emBn0gT/bIL8A/9wDP6BBTqFOwLFKP7Gxiv3fluga
-        hmo1Nv4nDWpeJc+HyNvGZxwOOmN4snXgqyUhb0F/BvCWM9PfAU4lLn1+2WtPPFKTD7HZZekGOAs2
-        Um/zWM6fcAK4Tjp+0/uMSx/HBDQtfcSCIxLg8YcaT6VG/REJ1JaZm5MOHW3SSk0lIebxzigl7pP2
-        P3D1KOvHU9OoAQt3ZE+vdIVBrSGW1CP/L1p8s8Of9BOuaIBfmeYrTgn5Qs7s6de5XQS8Es17usT/
-        lX/GzK5JlBN24NHrk2ADXEFegvcMjWvoe2Ut9AX0kQYz/fUd/7/PAKELCrOOiY2Mq8I+4PU4nV20
-        AOdhXneD1OD7fJeo28tYq0DeD3YNWBXZ8+deGCT37+buhCDcJBf7ITGtcTQstbTc51Fh97jwX04z
-        QIN7B/IhGrdjpE8Z8rjk3/fxzCqV09wFDKfavO8TCn0aI8nFBfs51qdaPmkD4rDgm7RpqCD5dnl/
-        f/f17Z68uvv68Qb9BwAA//8DABOH89l4BwAA
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-encoding: [gzip]
-      content-type: [application/xml; charset=utf-8]
-      etag: ['"9d2182db15015e1b03843dc36d579675"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 201, message: Created}
-- request:
     body: !!python/unicode '<customer><custom_fields><participant_id type="integer">4</participant_id></custom_fields></customer>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/customers
   response:
     body:
       string: !!binary |
-        H4sIAAzbk1UAA5SRzVKDMBSF930KJvvIT+sInUB3PkHduLtyL5CWBCYJFt5egjh1RBcuzzn57l/E
-        aVRt8E7Gyk7nLH6IWEC67FDqOmcv52eeslOxE+VgXafIFLsgEBKLNMv2h30ci3AW3puzsgHt+Kwv
-        WX3D6oLXcVIN1kaE31P/upLGOq5BUaBlmzNnBmLhErXwV1J2qgc9bXxSINuN2zed3taoYNx4N3qz
-        0v3SzxA4Qg4ucFNPOcNZOqmIFUkUP/LoiUfxOU6OSXRM0lcR3oGFH3r8H38HPvsvN+eVpBatd/xW
-        YJwsZb/e8iDCH44Hww3pd0HpeAkG7ToNGAPTuiogGrKWNtlXLf/zHwAAAP//AwCkB3xhLAIAAA==
+        H4sIALtLDlYAA5SRz1LDIBDG732KDHfMH2OjHZLefIJ68bbCtmGaEAY2tXl7Q4xTR/Qgt/0+frt8
+        i9hf+y65oPN6MDXL7zKWoJGD0uZUs5fDM39k+2Yj5Ohp6NE1myQRWjXbvCir+Yh0LoI2e7IFQ3yu
+        yZK07Um5rbw/X85OpN/dcPuonSduoMfE6K5m5EZk6WJ18Jcjh96CmSIde9BdpNp2MHGPI1wj7R3f
+        vKZf5jkEQsWBEpos1kzNJekeWVNk+QPPM54Vh+xpl1e7snoV6Q1Y+NGq//E34HP+snN+1NgpH5SQ
+        Chxpqe26y1KkP5QAphEZsihNXIJTfn0NOAfTGhWUcug9Rt5Xr/DzHwAAAP//AwBJCVqSLAIAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"2d142edff1cdee2ca3180332c3c9a30a"']
+      etag: ['"473e2779c563472acc276b09f9a2f7a9"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '<client_token><customer_id>89934311</customer_id><version
+    body: !!python/unicode '<client_token><customer_id>61247777</customer_id><version
       type="integer">2</version></client_token>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/client_token
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/client_token
   response:
     body:
       string: !!binary |
-        H4sIAA7bk1UAA7xVXW+jOhB976+o+r53wSS9i9R21TSBgAJsSALYb9iQ8mGTNCF8/fo7TrPbVltd
-        rXSl+xQFj2fOnDlnfPe9E/y6SQ/HfFfd36h/KTfXacV2SV49399s1saXbzffH67uGM/Tqv5S78q0
-        eri6vr5rYn5KH9LeRiSyhzjUT1ax6xdPdpZE/o5q9j4VhiK/+4KfCAp6Nrf3tFrmXm61rjBKss4E
-        Me3SGWaaN3XGZPrckQIjbz3JnXA58qbW4A4kd0zcY0Q4HsqRE2JF3sNFxr11qckYMnUFCYNya7o9
-        CQ2FhP4WR0vdKR47d6W0bq+0TrDsHMDnTHe9txqNnbXTeVMG/8uDM31sHaNT4bd3hasyzW9oGPQR
-        4uWP9fPYWzsKYOyi+aZ1phaSZxhlGa38bRwu9bjgVYJ8EQv/kM55HZt+xfglXzVRsej2WNUPJCp1
-        R5AxC/eKGxmDg5iSVElHcutoCbehguyJGvT0ybq1RKYk88ng5d8aHE32i8rNqPBzqj2fcGVncThW
-        mAg4QdBvlGTpalxQpNy60+WwQCpnwt1hGdPrL16YaMQkL8SsR2mo7oiZ9AvkHuMwOCWGnjGzbJJi
-        1mCkn4iAXiKYockb+ooL8nRHEo4rEjm5x+sEZsxpRfZM6Ccqc0i8b/hyOC+oySHGnzCTB0y0MHN7
-        l8z9lg27ZoGMNl6NB8BXYqGPFsLucchPydzmJEygdqDhqDwBntorlorT6zVorIhNA2Kc5lO+c/1n
-        za3ky8rbHEegnsgfgsg+gjbzeO4rbO7cLnroWXM55Po3LvOfWv7svvy+qAinQm3+cDbnfFQYxzTy
-        91gDLqtjnvye+9LHsgZ+Mjrn4CF3+NMa21WbJ2YGPghmGxQUkJ/7kAc0yAnMCThWyScxVrH/2xJd
-        Q1GtMuN/0qDm7+T9CPlbdsGxQBcMT7YOfLU44i3ozwDecmoGJeBUWBXwt7P2zCMx+cDMLks3wFm4
-        kXqbM7l/ogngOuv4Ve8zLnOcEtC0zMEERzh0xx9mPJUaDUY4VFtqbs46XGiTVmoqiVzOSqOSuM/a
-        /8DVo5wfT02jBix8IT290hUKs4ZaUo/8v2jxNc79xE/ujoTugWqBsqigX+iZPv26V8bAK9b8p7f6
-        v/rPqNk1iXLGDjz6fRJugCvoS/CeonENvlfWQvfARxrs9MM7/n/fAUIXBHYdFRtZV4VzwOtzMnvT
-        AtwXMM9BavB9v0vU7WWtVSjfB7sGrIr0/MULg+T+3d6dYOQ2yVv8kJjWOB6WWlrt87iwe7cIXs47
-        QIN3B/rBGrcZ0qcU+VzyHwTuzKqU894FDOfZvPcJAZ8yJLl4w36p9amWz9qAOjT8JmMaInC+Xd7f
-        3319fSev7r5+fEH/AQAA//8DAAocDD14BwAA
+        H4sIALxLDlYAA7xVTXOjOBC951ekcp8dEHY2VCWZij/AUEZesA1INwQ4gCVwxTZfv35bjjN2alMz
+        c9oTLqv1uvv166fHH63gt3X6ts+r8ulO/Uu5u03LuEry8vXpbr0yvj3c/Xi+eYx5npaHb4dqm5bP
+        N7e3j3XEj+lz2tmIhnYfBfrRKqpuPrazJPQqptm7VBiK/N8T/EiR38Uze8dKN1/ktlhMXlvHnGqk
+        cNrFZMTpJNmSfto7Bd7i4rUnPdGcfqsRNB04q/UQT15VurIGuHCHuHcaOnEQKV4GC9POncBtMXw3
+        Ju5oYCg08DYkdHWneGnxUmmdsdI43G0Wq6rFfaUsxoPemcDd1QtgxW/wu3GMVoVvhwVWY82rWeB3
+        IeLbf1akdQpXgzgtnK0bZ2IheUZQlrHS20SBqyezkUK0UUWRB/edPtLoW8zPeOVIJaLdEVV/o+FW
+        T0MH4RltI4SPWBs10SQZ0M7aWwLXTNAdVf2Oja17S2QK4PaL/KEm4Wg3L3HGhJcz7fVISjuLgqES
+        C59TBP2GSZYuhwVDyj2euP0cqTwWuCIyptOVeOYVsZmVdGYh0uO3RBy6OcL7KPCPiaFnsbmtk2Ja
+        E6QfqeBlEsIMTV6z/FQX4LR7GgxLGjr5gh8SmDFnJd3FQj8yiSHrvdSXw3nBTA4x3ig2uR+LRs68
+        SmZeE/dVPUdGEy2HPdS3JUIfzIXdkYAfk5nNaZBAbl8j4fYI9RwWhas4nX4AjRWRaUCMU3/Jd65/
+        5NxIvqy8yUmIexp6vR/ae9BmHs084MK5n3fQs4Y5YP2Ky/xDy1/dl//PS8qZUOs/nM0Jjwljn4be
+        DtSdL8p9nvwX+9yHewB+MjbjsEO4/9Mcm2WTJ2YGe+BP18gvAJ97gAMa5BTmBByr9IsYq9j9bYm2
+        Zuigxsb/pEHNq+T9EHmb+FzHHJ1rGNs68NWQkDegPwN4y5npb6FOJS59fjlrTjxSk/ex2WbpGjgL
+        1lJv4yX3eKy513q0JQes9Pds3OTSjxJhFKl/3e+LnAFPTeMAeHwu93KpN/EYdqH0QU/2iGpSp6rE
+        +6RtyRMNwRfC0Z6+c1Enpt6ftCiMnvpf8fqu0V/twG+0DHvhFxHS1WQ8/ODk5z3gBeaMFfcq/0f/
+        cq+Zlliy9iteP+/2dFivhK8kSO+i7qIf8AMUhTZ4luTh5Ok1FRQ8Zchl3gTOoV7pxfjn7kJuCvqP
+        0Rp85arf9dmLpnwre2OB0UP/4LHtDvLA/ksfgrfDbHdMJNf899favmBftOcGuGDaBZuIHWgVKydO
+        NXiThH8kGrdjpE8Y8riM8Xx/aZXKyZOhH8k9/12eZXDi4Eudn/iAPCx4OPNE8o379PT4/f0NvXn8
+        /vl1/RcAAP//AAAA//8DAHptzwSUBwAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"af32680b1bb8ebd131ada7b99adcb467"']
+      etag: ['"8c4481336eb06c0f06d176d7d6f61784"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -304,28 +203,28 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/bkhpqm
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods/any/f3g3jg
   response:
     body:
       string: !!binary |
-        H4sIAA/bk1UAA6RVTXPaMBC98ysY34U/MMRljDO99NhLkx566cjSGmuQJUeSSfj3XRkDDh9pM72x
-        b5+0u89PS/741sjpDowVWq2DeBYFU1BMc6E26+D56RvJgsdikjMDXDjCqOHFZDrNSyElUgjl3IC1
-        HkNU8CJ9zUPBh5h11ukGDEEkjtN0vkjSPByjB14ljHVE0QamSsh14EwHQTgkJb2fY7ppqdrfyFhn
-        ANyxvxsEeHOgOPAPKFIzKoW7db2BDQp2I9Fq66gkqCAUX9I4esjDMXRsu1PO7HuIUNnWNLk53CVr
-        /jeW6lBXwT6g3RPSAHVeDDd1+xbWAcfQiQaCIoniBYkeSBQ/xckqflgtkl/4EU8Hhhu6ln/uhvOB
-        3lHhDUuhzVSRRnGSZT6vesx7kPgSxU9hKXZyio/ZWkuO9ro1qncMSsQElcWz2ir9qvCGMzYZSaUr
-        IqztqGJQPP/46nnXicn/i/dvz+TM8rZ06D5sasQ6oZ7LoRTuPOAhPCQq2sljn6XWEqgKCi+Qp/XJ
-        A7EzKDhBn3fS9zq67DIz6V9TK0xfnzRaubqIkzy8Ai+Ye6AGFUqid9QePTGBX/ZaUWlhODFUr4FK
-        V+Onh3ObI8xTREM3QDoji9q51q7CkFoLzs5KQ4Xyy2KDw7zS/QzdELZ034Byvxtwtea/pd7ocIdu
-        m7Vq8whqJ4xWnrC2VPFSv+HOO93fV0N7eC+XVG3PLb1DJ8fVlhZxlsV5OAQex/JGy5FDj0CfNNBS
-        9MR3jfjw2+O2Ky0zovUi2kE0agzdD853eguqKLd1+9Lk4SHyeKfES9evjrI3G44lKgGmSOcsS+OK
-        MzZn82q5nC8XFSziaM4gg5Lhk7x7dPKphZCtFsvrhbAD1Whi+faOAU75gW2w9OEJXE3fv7jz/9cf
-        AAAA//8DALEILZ71BgAA
+        H4sIAL1LDlYAA6RVTXPaMBC98ysY34U/cIphjDK99NhLkx566cjW2qjIkivJJPz7rowBh4+0md7Y
+        t0/a3eenJX98beR0B8YKrdZBPIuCKahSc6HqdfD89IVkwSOd5KUBLhwpmeF0Mp3mhZASKYRxbsBa
+        jyEqOG15Hgo+xGVnnW7AEEQWn6IseYijPByjB14ljHVEsQamSsh14EwHQTgkJbufK3XTMrW/kbHO
+        ALhjfzcI8OpAceDvUKQumRTu1vUGahTsRqLV1jFJUEGgyzSOFnk4ho5td8qZfQ8RJtsNS24Od8ma
+        /42lOtRVlO/Q7glpgDkvhpu6fQvrgGPoRAMBTaL4gcQRiZKnaLmK41Wc/cCPeDow3NC1/GM3nA/0
+        jgpvWAptpmgaxUmW+bzqMe9B4kvQ78Iy7OQUH7MbLTna69ao3jEoUSmYpM9qq/SLwhvO2GQkla6I
+        sLZjqgT6/O2z510nJv8v3r89kzPL29Kh+7CpEeuEei6HQrjzgIfwkKhYJ499FlpLYCqgXiBP65MH
+        YmdQcII+76TvdXTZZWbSv6ZWmL4+abRyGxoneXgFXjD3wAwqlERvqD16YgK/7LVi0sJwYqi+ASbd
+        Bj89nNscYZ4iGlYD6YykG+dauwpDZi04OysME8ovixqHeWH7GbohbNm+AeV+NuA2mv+UutbhDt02
+        a1X9CGonjFaesLZM8UK/4s473d9XQ3t4LxdMbc8tvUEnx9WW0jjL4jwcAo9jeaPlyKFHoE8aaBl6
+        4qtGfPjtcdsVtjSi9SLaQTRmDNsPznd6C4pW83r+q87DQ+TxTonfXb86it5sOJaoBBhapcssTheL
+        Yp4mZZaWi2VULdKCLZdJllbxEp/wvaOTDy2E+ephcb0QdqAaTSzf3jHAKT+wDZY+PIGr6fsXd/7/
+        +gMAAP//AwBFipqT9QYAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"225c87288dfc0c475f473b8e50394ef5"']
+      etag: ['"ccbe762b89d4c37527c4ca2268b41ac7"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -334,68 +233,68 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/11443524
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/customers/76082510
   response:
     body:
       string: !!binary |
-        H4sIABDbk1UAA6xVTZOjOAy9969IcXcTCOnOdBG69jLHuez0HvYyZbAInhibsU0n+fcrE77SCRmm
-        em/o6ckW0rMUvx5LsXgHbbiSWy94XHoLkJliXO623tv3r2TjvSYPcVYbq0rQycNiEXOWBEEUrdZh
-        FPtoOAx9WUGlJWj//LI7sPwn2x9PZcF2OvbHXsfOuTaWSFrCQnKx9ayuwfMbl6BTnkyVFZWnKxxK
-        ysUVWhVKXp+R0+MVdoDUcHvjPg3UAiPULuypgq3H0LS8BC8Jl8GaLJ/JMvgehC/B88s6+Df2h4Am
-        vq7Y/PgQ44eA8/1NzUnOQTDTp8S4JRnVzLSHUq3pyXPeS/8ZQSzlQmA3CWVMgzEdfu5jdOg62GJd
-        o8lFk8fowJ3uYkuY7GV32e2Otl5jNYDt8p4gwdGCZK5od2lCZVRwO3WVhh3qf8JZKWOpIPgoIPkS
-        Bcvn2B9D49+ppdWnBiZUVAUNJ3/8I3M1hylr7AHPfkO9V/A/kXR4Jen2lE8KuznDn5AlylUm0TII
-        NxvHkT3uNE3cdck/3FDMrLfHjEIJhjKdKoFTnJtFnIrkTe6lOkg8acAG2rmUKifcmJrKDJK3v/9y
-        3GtHH/T54s5/fgPTSduiejHBEbNHOz6DlNvhp8/m4MxpLbq8U6UEUOklrniO2jgHcq2xMQTfTC1c
-        /qNDP3q6EDhWXDf5kFJJWyRBGPtX4A32CajG6oXLC3qDXrCBfcw9p8JAGzXKpAAqbIFSgSHtEdbR
-        eEl3QGotksLayrz4PjUGrHlMNeXSDaYd/uCBnh5RPX5FTyVI+6MEWyj2Q6id8t9RpY+V3L2CfOda
-        SUfYGipZqo44c/vz+xtRTu49pFTuh9Qu0I7ajNUoCTabIPZbo/NhKlqJkbo7oCdoqCjq6JtCX/vd
-        +UydmkzzyhX5cr8ML8iqPcgk3RfVrzL2z1bnqyX/VTdjKm3Eir/McX3pJFplmyjIWZatslX+9LR6
-        WuewDparDDaQZvjUJ0P7s2cPnc3L+un20HkHWSpi2H5CLL1/FKExjfNTulmR5hWPd+4F0Iy1uB1x
-        cHNlf5x/V0v5D2bC/YV8fx3fW8YzVvGsRXx3Dd9ZwjNX8NwFPHf9zl6+v129/8tu+PTajf2R2HoD
-        0BzklDz8BwAA//8DAM13fYwTDAAA
+        H4sIAL5LDlYAA6xVTXOjOBC951e4uCt8mIxxCpOayxznsske9jIlUANaC4mRhGP/+5UwX46Nh1T2
+        Rr9+LTXdT93xy7FiqwNIRQXfOf6j56yAZ4JQXuyct9cfKHJekoc4a5QWFcjkYbWKKUk237woePK9
+        2DWGxYwvKzHXyNi61lldFkR+y9b7w17G7tRr2TmVSiOOK1hxynaOlg04butieM6TiarG/HSFQ4Up
+        u0LrUvDrM3J8vMLeIVVU37hPAtZAENYrfaph5xBjalqBkwSe/4R8D3nBq7d99v1nf/NP7I4BbXxT
+        k+XxkYkfA873tzVHOQVG1JASoRplWBLVHYqlxCfHei/9Z8RgKWXMdBNhQiQo1ePnPtak72CH9Y1G
+        F02eoiN3vosdYbaX/WW3O9p5lZYAus97hgRHDZzYot2lMZFhRvXcVRIKo/8ZZy2UxgyZRwHJNvS9
+        TexOoenvNFzLUwsjzOoSB7M//pG5XsLkjekBzf5AvVfwz0g6upJ0d8oXhd2e4c7I0siVJ6HnB1Fk
+        OXzAraaRvS75mypsMhvsKaMUjBiZzpXAKs7OIopZ8sb3XLxzc9KIjbRzKUWOqFIN5hkkb399t9xr
+        xxD09eIuf34j00pbG/WaBCfMAe35BFKqx58+m6Mzxw3r806FYIC5k9jiWWrrHMmNNI1B5s00zOY/
+        OfSjpw+BY01lmw+qBNdl4gexewXeYJ8AS1O9wLugt+gFG8jH3HPMFHRRk0xKwEyXRiowpj3Behqt
+        cAGokSwpta7Vs+tipUCrx1Riyu1gKswPvuPTo1GPW+NTBVz/qkCXgvxiohDuwaj0sebFC/ADlYJb
+        wk5hTlJxNDN3OH+40cjJvocU8/2Y2gXaU9uxGiZ+FPmx2xm9z6QiBZuouwcGgoQaGx39FMbXffc+
+        1aQqk7S2Rb7cL+ML0mIPPMnXxfrfInbPVu9rOP3dtGMqbcVqfpma9SWTPNxGfrjZpOswyKIw22y9
+        fBOmeLsNojD3t2ZEzIUOZy8eOuvnp83toXMAXgmkyH5GLIN/EiFNGuendLMi7Sue7twLoB1rcTfi
+        4ObK/jj/rpbyJ2bC/YV8fx3fW8YLVvGiRXx3Dd9ZwgtX8NIFvHT9Ll6+f1y9/8tu+PLajd2J2AYD
+        jDnKKXn4DwAA//8DAMu5GuwTDAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"b95b2eb5c6738835caf30b3b8ac6cdd0"']
+      etag: ['"1b366308452ab42c80400d141122ba09"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<client_token><customer_id>11443524</customer_id><version
+    body: !!python/unicode '<client_token><customer_id>76082510</customer_id><version
       type="integer">2</version></client_token>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/client_token
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/client_token
   response:
     body:
       string: !!binary |
-        H4sIABLbk1UAA7xVXW+jOhB976+o+r53wZTeRWq7aj4goOAsJAHsNwykQGySNoSvX3/HaXbTaqur
-        la50n0D2eObMmTMz9987wa+b7PVQ7KqHG/Uv5eY6q5JdWlTPDzfrlfnl2833x6v7hBdZVX+pd9us
-        ery6vr5vYn7MHrPeQTRyhjg0jna56+djJ08jf8c0Z58JU5HnvuBHioI+mTl7VnnForD7xWSLqCCt
-        a/mcllsND7RwJ7bmWp7urrzWFbaOJ7yg5XNHEOnd8hm5wlVImZcEuRpZEZ2UU5UILNzyqSWrJ2Vj
-        4Z6GpkJDf0Miz4DzDi+VFvdK6wZe5wI+d7Ib8Pi2XayeWoij48F+dSfwb3YqfHsssJpofsPCoI8Q
-        3/5YTTs88Qa8spVotm4BI5J3BOU5q/xNHHpGXPIqRb6Ihf+azXgdW36V8LO/agQYuz1RjVcabQ1X
-        UD0J9wqOzMFFiZJWaUcL+2AL3DBB91QNeja272yRK+lsNCyKbw2JRvt5hXMm/IJpz0dSOXkc6koi
-        Ak4R5BulebbUS4aUO4l1jlSeCLwj0qY3XhZhqlGLvlCrvs1CdUettJ8jfIjD4JiaRp5Y2yYtpw1B
-        xpEKyCWCGlq8YW+4wE93oKFe0cgtFrxOocacVXSfCOPIpA+J94KvgPuSWRxs/FFi8SARLdTc2aUz
-        v02GXTNHZhsv9QHwbYkwbufC6UnIj+nM4TRMIXagkWh7BDz1ovQUtzdq0FgZWybYuM2nfBfGz5gb
-        yZddtAWJQFWRPwSRcwBtFvHMV5KZezfvIWcNc/D1b1wWP7X82Xt5Pq8oZ0Jt/rA2J39MmIcs8vdE
-        Ay6rQ5H+7vuch1cDPzmbceghPPxpjM2yLVIrhz4IpmsUlOCf++AHNMgp1Ak4VuknNna5/9sWXcNQ
-        rSbm/6RBzd/J9xHyN8kZxxydMYwdA/hqScRb0J8JvBXMCraAU0mqgF/u2hOP1OJDYnV5tgbOwrXU
-        2yyR8ycaAa6Tjt/0PuXSxzEFTUsfieCIhFj/UOOJ1GhwS0K1Zdb6pMO5NmqlptII82RrVhL3Sfsf
-        uHqS9eOZZdaAhc9lTy8NhUGtIZbUI/8vWnyzw5/0E97REL8yLVDmFeQLObPxr3fbGHglmj++xP+V
-        f86srkmVE3bg0e/TcA1cQV6C9wzpNfS9shLGAvpIg5n++o7/32eAMASFWcfEWsZV4R7wwnyfXrQA
-        7wXUc5AafJ+vh7q9jLUM5X5wasCqyJ4/98IguX83d0cE4Sa92A+pZevx4GlZtS/i0ulxGbycZoAG
-        ewfyIRp3EmRMGPK55D8I8NSulNPcBQyn2rzvEwp9miDJxQX7OdanWj5pA+Kw8Ju0aWC3FRvv4eH+
-        69uevLr/+nGD/gMAAP//AwA0Ow2YeAcAAA==
+        H4sIAL9LDlYAA7xV23KjOBB9z1ek8j47IOJsqHIyFV/AUEZesM1Fb0jgAJbAFdvcvn5bjjN2alMz
+        87RPuKzW6e7Tp4+GP1rBb+v0bZ9X5dOd+pdyd5uWrEry8vXpbr0yvj3e/Xi+GTKep+Xh26HapuXz
+        ze3tsI75MX1OOxuR0O7jQD9aRdXNx3aWhF5FNXuXCkOR/3uCHwnyOzazd7R080VuDchq2xPhtE4B
+        vwXmUf/akGLbRUUmcLAeOCs7g+/9YrUekMBVSGAL3DNtseKCmG6zMKe9I1yEJw6KkJctJi/3GxN3
+        JDAg1ttEoas7xUuLl0rrjJXG4XBnVbW4r1Rnea86/auGiynkd9+cyUvjGK0K3w4LrDLNq2ngdyHi
+        239WDDmT1w6vpk04WzfOxELyLEJZRktvEweunsxGSqSNKoI8uO/0sUbeGD/jlSM1Eu0uUvU3Em71
+        NHQQnpE2RviItVETT5J70ll7S+CaCrIjqt/RsfVgiUwB3H6RP9ZRONrNS5xR4eVUez1GpZ3FwUBh
+        wucEQb9hkqXLQUGR8oAnbj9HKmcCV5GM6XSFzbyCmVlJZhaKevyWiEM3R3gfB/4xMfSMmds6KaZ1
+        hPQjEbxMQpihyWuan+oCnHZPgkFJQidf8EMCM+a0JDsm9COVGLLeS305nBfU5BDjjZjJfSYamLld
+        JTOvYX1Vz5HRxMtBD/VtI6Hfz4XdRQE/JjObkyCB3L4Whdsj1HNYFK7idPoBNFbEpgExTv0l37n+
+        kXMj+bLyJo9C3JPQ6/3Q3oM283jmARfOw7yDnjXMAetXXOYfWv7qvvx/XhJOhVr/4WxOeFQY+zT0
+        dpEGXJb7PPkv9rkP9wD8ZHTGYYdw/6c5NssmT8wM9sCfrpFfAD73AAc0yAnMCThWyRcxVrH72xJt
+        TdFBZcb/pEHNq+T9EHkbdq5jjs41jG0d+GqikDegPwN4y6npb6FOhZU+v5w1Jx6JyXtmtlm6Bs6C
+        tdTbeMk9zjT3Wo+25ICW/p6Om1z6USKMIvWv+32RM+CpaRwAj8/lXi71ho1hF0of9GSPiCZ1qkq8
+        T9qWPJEQfCEc7ck7F3Vi6v1Ji8Loif8Vr+8a/dUO/EbLsBd+ESNdTcaDD05+3gNeYM5Yca/yf/Qv
+        95pqiSVrv+L1825PB/VK+EqC9C7uLvoBP0BxaINnSR6kp9s1EQQ8ZcBl3gTOoV7pxfjn7kJuAvpn
+        aA2+ctXv+uxFU76VvdHA6KF/8Nh2B3lg/6UPwdthtjsqkmv++2ttX7Av2nMDXFDtgh2JHWgVKydO
+        NXiThH+MNG4zpE8o8riM8Xx/aZXKyZOhH8k9/12eZXDi4Eudn/iAPDR4PPMU5Rv36Wn4/f0NvRl+
+        //y6/gsAAP//AAAA//8DAMXSUgOUBwAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"6a5cf952b2f06dc9d39e7365ef937023"']
+      etag: ['"0f1b35f430f86b90ea4a771def4160a0"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -404,28 +303,128 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/bkhpqm
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods/any/f3g3jg
   response:
     body:
       string: !!binary |
-        H4sIABPbk1UAA6RVTXPaMBC98ysY34U/MMRljDO99NhLkx566cjSGmuQJUeSSfj3XRkDDh9pM72x
-        b5+0u89PS/741sjpDowVWq2DeBYFU1BMc6E26+D56RvJgsdikjMDXDjCqOHFZDrNSyElUgjl3IC1
-        HkNU8CJ9zUPBh5h11ukGDEEkjtN0vkjSPByjB14ljHVE0QamSsh14EwHQTgkJb2fY7ppqdrfyFhn
-        ANyxvxsEeHOgOPAPKFIzKoW7db2BDQp2I9Fq66gkqCAUX9I4esjDMXRsu1PO7HuIUNnWNLk53CVr
-        /jeW6lBXwT6g3RPSAHVeDDd1+xbWAcfQiQaCIoniBYkeSBQ/xckqflgtkl/4EU8Hhhu6ln/uhvOB
-        3lHhDUuhzVSRRnGSZT6vesx7kPgSxU9hKXZyio/ZWkuO9ro1qncMSsQElcWz2ir9qvCGMzYZSaUr
-        IqztqGJQPP/46nnXicn/i/dvz+TM8rZ06D5sasQ6oZ7LoRTuPOAhPCQq2sljn6XWEqgKCi+Qp/XJ
-        A7EzKDhBn3fS9zq67DIz6V9TK0xfnzRaubqIkzy8Ai+Ye6AGFUqid9QePTGBX/ZaUWlhODFUr4FK
-        V+Onh3ObI8xTREM3QDoji9q51q7CkFoLzs5KQ4Xyy2KDw7zS/QzdELZ034Byvxtwtea/pd7ocIdu
-        m7Vq8whqJ4xWnrC2VPFSv+HOO93fV0N7eC+XVG3PLb1DJ8fVlhZxlsV5OAQex/JGy5FDj0CfNNBS
-        9MR3jfjw2+O2Ky0zovUi2kE0agzdD853eguqKLd1+9Lk4SHyeKfES9evjrI3G44lKgGmSOcsS+OK
-        MzZn82q5nC8XFSziaM4gg5Lhk7x7dPKphZCtFsvrhbAD1Whi+faOAU75gW2w9OEJXE3fv7jz/9cf
-        AAAA//8DALEILZ71BgAA
+        H4sIAMBLDlYAA6RVTXPaMBC98ysY34U/cIphjDK99NhLkx566cjW2qjIkivJJPz7rowBh4+0md7Y
+        t0/a3eenJX98beR0B8YKrdZBPIuCKahSc6HqdfD89IVkwSOd5KUBLhwpmeF0Mp3mhZASKYRxbsBa
+        jyEqOG15Hgo+xGVnnW7AEEQWn6IseYijPByjB14ljHVEsQamSsh14EwHQTgkJbufK3XTMrW/kbHO
+        ALhjfzcI8OpAceDvUKQumRTu1vUGahTsRqLV1jFJUEGgyzSOFnk4ho5td8qZfQ8RJtsNS24Od8ma
+        /42lOtRVlO/Q7glpgDkvhpu6fQvrgGPoRAMBTaL4gcQRiZKnaLmK41Wc/cCPeDow3NC1/GM3nA/0
+        jgpvWAptpmgaxUmW+bzqMe9B4kvQ78Iy7OQUH7MbLTna69ao3jEoUSmYpM9qq/SLwhvO2GQkla6I
+        sLZjqgT6/O2z510nJv8v3r89kzPL29Kh+7CpEeuEei6HQrjzgIfwkKhYJ499FlpLYCqgXiBP65MH
+        YmdQcII+76TvdXTZZWbSv6ZWmL4+abRyGxoneXgFXjD3wAwqlERvqD16YgK/7LVi0sJwYqi+ASbd
+        Bj89nNscYZ4iGlYD6YykG+dauwpDZi04OysME8ovixqHeWH7GbohbNm+AeV+NuA2mv+UutbhDt02
+        a1X9CGonjFaesLZM8UK/4s473d9XQ3t4LxdMbc8tvUEnx9WW0jjL4jwcAo9jeaPlyKFHoE8aaBl6
+        4qtGfPjtcdsVtjSi9SLaQTRmDNsPznd6C4pW83r+q87DQ+TxTonfXb86it5sOJaoBBhapcssTheL
+        Yp4mZZaWi2VULdKCLZdJllbxEp/wvaOTDy2E+ephcb0QdqAaTSzf3jHAKT+wDZY+PIGr6fsXd/7/
+        +gMAAP//AwBFipqT9QYAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"ab541b17a61ab30a59c86c02083b0168"']
+      etag: ['"1831a73003ecf7173bb34e221b2fa9ad"']
+      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/customers/76082510
+  response:
+    body:
+      string: !!binary |
+        H4sIAMFLDlYAA6xVTXOjOBC951e4uCt8mIxxCpOayxznsske9jIlUANaC4mRhGP/+5UwX46Nh1T2
+        Rr9+LTXdT93xy7FiqwNIRQXfOf6j56yAZ4JQXuyct9cfKHJekoc4a5QWFcjkYbWKKUk237woePK9
+        2DWGxYwvKzHXyNi61lldFkR+y9b7w17G7tRr2TmVSiOOK1hxynaOlg04butieM6TiarG/HSFQ4Up
+        u0LrUvDrM3J8vMLeIVVU37hPAtZAENYrfaph5xBjalqBkwSe/4R8D3nBq7d99v1nf/NP7I4BbXxT
+        k+XxkYkfA873tzVHOQVG1JASoRplWBLVHYqlxCfHei/9Z8RgKWXMdBNhQiQo1ePnPtak72CH9Y1G
+        F02eoiN3vosdYbaX/WW3O9p5lZYAus97hgRHDZzYot2lMZFhRvXcVRIKo/8ZZy2UxgyZRwHJNvS9
+        TexOoenvNFzLUwsjzOoSB7M//pG5XsLkjekBzf5AvVfwz0g6upJ0d8oXhd2e4c7I0siVJ6HnB1Fk
+        OXzAraaRvS75mypsMhvsKaMUjBiZzpXAKs7OIopZ8sb3XLxzc9KIjbRzKUWOqFIN5hkkb399t9xr
+        xxD09eIuf34j00pbG/WaBCfMAe35BFKqx58+m6Mzxw3r806FYIC5k9jiWWrrHMmNNI1B5s00zOY/
+        OfSjpw+BY01lmw+qBNdl4gexewXeYJ8AS1O9wLugt+gFG8jH3HPMFHRRk0xKwEyXRiowpj3Behqt
+        cAGokSwpta7Vs+tipUCrx1Riyu1gKswPvuPTo1GPW+NTBVz/qkCXgvxiohDuwaj0sebFC/ADlYJb
+        wk5hTlJxNDN3OH+40cjJvocU8/2Y2gXaU9uxGiZ+FPmx2xm9z6QiBZuouwcGgoQaGx39FMbXffc+
+        1aQqk7S2Rb7cL+ML0mIPPMnXxfrfInbPVu9rOP3dtGMqbcVqfpma9SWTPNxGfrjZpOswyKIw22y9
+        fBOmeLsNojD3t2ZEzIUOZy8eOuvnp83toXMAXgmkyH5GLIN/EiFNGuendLMi7Sue7twLoB1rcTfi
+        4ObK/jj/rpbyJ2bC/YV8fx3fW8YLVvGiRXx3Dd9ZwgtX8NIFvHT9Ll6+f1y9/8tu+PLajd2J2AYD
+        jDnKKXn4DwAA//8DAMu5GuwTDAAA
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: ['"8f1c665373dc813dc7738a3f216d39d1"']
+      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<client_token><customer_id>76082510</customer_id><version
+      type="integer">2</version></client_token>'
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/client_token
+  response:
+    body:
+      string: !!binary |
+        H4sIAMNLDlYAA7yVTXPiOBCG7/kVqdxnx5ZDNq5KMhUgNnYhsTZgW7pZtoltJEMF8Nev3xYhA6lN
+        zcxpD5SrkPR296O3Ww8/Wimu6+xtV2yqxxv9L+3mOquSTVpUr483y4X17f7mx9PVQyKKrNp/22/W
+        WfV0dX39UMfikD1lnYtY5PZxaB6cctNNR26eRv6GG+42k5am/velODAUdMnE3fLKK2aF02DktbMF
+        7VjoFrMFERR+OPQavFgatCdrWroSj7GBQ7+YjVmJQ6fH0tNoSVu68HS2wPAVBZZuyUKWY8nkyiag
+        Z2ks9Fc08kxcPrdkrrV4pDVYeM1ssWlJv9HJ6HZAytcWL157iPeGx88Ntlodvh2RRE8Mv+Zh0EVI
+        rP9ZJAiPXzuyeGmiybLBYwepNYrynFf+Kg49M50MNWoMNwz5cB73scHeEnHSq4Y6le2W6uYbi9Zm
+        FmFEJqyNETkQY9jE4/SWdc7OkaTmkm2ZHnR85Nw5MtdAt58V9zWNhttpRXIu/YIbrwdauXkcDrRE
+        BoIhqDdK82w+KDnS7sjY66dIF4kkG6r2dKaWTPwysfOKTRwEbN9Sue+miOziMDiklpkn9rpOy5ea
+        IvPApKjSCO7QFjUvjnmBTrtj4aBiES5mYp/CHQtesW0izQNXGirfc34FrJfcFrDHHya2CBLZwJ27
+        m3TiN0m/qafIauL5oIf81lSat1PpdjQUh3TiChamEDswaLQ+QD77WelpuDP34LEyti3Yg+sveRfm
+        R8yV4uUUTUEj0rPI74PI3YE3i3jiAwt8N+2gZoMI0PoVy+LDy1+dV/9PKya41Os/vJujHpfWLov8
+        LTWAZbUr0v9qn+rw9sAn5xMBPUT6P42xmjdFaufQB8HLEgUl6AsfdMCDgsE9AWOdfbHHKbd/O7Kt
+        OdrrifU/edDwN+p8hPxVcspjik45jFwTeDU0Eg34zwJuBbeDNeSpJVUgzmvNkSOzRZ/YbZ4tgVm4
+        VH4bzYUvEsO79KOrGPAq2PFRU6h5lEqrzILLep/VHYjMtvagJ6aqL+dmk4ygF6oA/OQOmaF8qiu9
+        T95WnFgEcyEa7tg7izq1zf7oRWn1LPiK67tHf9UDv/Ey9EVQxsjU09Hgg8nPc8AF7plo3kX8j/pV
+        X3MjdVTuF1w/9/bLoF7IQEuR2cXd2T8wD1AcuTCzFAc1092aSQYzZSBU3BTWIV81i8nP3oXYDPyf
+        oCXMlYt6l6dZ9CLWqjYeWj3UDzO23UIc6H81h+DtsNstl+kl//7S22fts/e8kJTcOGtTuQWvEu3I
+        1IA3SQYHagg3QeaYI1+oPX4QzJ1KO85kqEexF7+LMw+PDL70+ZEHxOHh/YkTLVbe4+PD9/c39Orh
+        ++fX9V8AAAD//wAAAP//AwBndJXPlAcAAA==
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: ['"f2c4d4610bcbe4b3f8719110e241c4d1"']
+      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/payment_methods/any/f3g3jg
+  response:
+    body:
+      string: !!binary |
+        H4sIAMRLDlYAA6RVTXPaMBC98ysY34U/cIphjDK99NhLkx566cjW2qjIkivJJPz7rowBh4+0md7Y
+        t0/a3eenJX98beR0B8YKrdZBPIuCKahSc6HqdfD89IVkwSOd5KUBLhwpmeF0Mp3mhZASKYRxbsBa
+        jyEqOG15Hgo+xGVnnW7AEEQWn6IseYijPByjB14ljHVEsQamSsh14EwHQTgkJbufK3XTMrW/kbHO
+        ALhjfzcI8OpAceDvUKQumRTu1vUGahTsRqLV1jFJUEGgyzSOFnk4ho5td8qZfQ8RJtsNS24Od8ma
+        /42lOtRVlO/Q7glpgDkvhpu6fQvrgGPoRAMBTaL4gcQRiZKnaLmK41Wc/cCPeDow3NC1/GM3nA/0
+        jgpvWAptpmgaxUmW+bzqMe9B4kvQ78Iy7OQUH7MbLTna69ao3jEoUSmYpM9qq/SLwhvO2GQkla6I
+        sLZjqgT6/O2z510nJv8v3r89kzPL29Kh+7CpEeuEei6HQrjzgIfwkKhYJ499FlpLYCqgXiBP65MH
+        YmdQcII+76TvdXTZZWbSv6ZWmL4+abRyGxoneXgFXjD3wAwqlERvqD16YgK/7LVi0sJwYqi+ASbd
+        Bj89nNscYZ4iGlYD6YykG+dauwpDZi04OysME8ovixqHeWH7GbohbNm+AeV+NuA2mv+UutbhDt02
+        a1X9CGonjFaesLZM8UK/4s473d9XQ3t4LxdMbc8tvUEnx9WW0jjL4jwcAo9jeaPlyKFHoE8aaBl6
+        4qtGfPjtcdsVtjSi9SLaQTRmDNsPznd6C4pW83r+q87DQ+TxTonfXb86it5sOJaoBBhapcssTheL
+        Yp4mZZaWi2VULdKCLZdJllbxEp/wvaOTDy2E+ephcb0QdqAaTSzf3jHAKT+wDZY+PIGr6fsXd/7/
+        +gMAAP//AwBFipqT9QYAAA==
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: ['"bc89c4e3e06353e5248ccc24a2e36958"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
@@ -434,17 +433,17 @@ interactions:
     body: !!python/unicode '<search><status type="array"><item>authorized</item></status></search>'
     headers: {}
     method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search_ids
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/tptcphgdr6c3kvkr/transactions/advanced_search_ids
   response:
     body:
       string: !!binary |
-        H4sIABTbk1UAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
+        H4sIAMVLDlYAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
         sNGHS4KVZqYUQxUlFhUlViqBBfWBonZcNvroRgMAAAD//wMA9crnoGwAAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"060fb2445c8687e6771a9289daf0d95d"']
+      etag: ['"f3f1efef0d0a21713f08d1aba0bf5739"']
       strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]


### PR DESCRIPTION
This is for a preliminary review - have a few issues and questions. 

Got things working with my credentials, with ```tests/local.env``` and after adding the custom field participant_id in settings. 'Working' only in the sense that I get ```success``` and ```authorized```, though. When I tried checking on the dashboard, things are less clear - all transactions are shown as 'sale' and some say 'voided', 'submitted for settlement', 'gateway rejected', etc. 
The transaction summary page shows credit values as 0.

I've got the functionality worked out, but am facing the following issues:

1. A rather quirky problem. The new method ```test_refund_of_excess_balance``` that I added to ```test_billing_payday.py``` works as expected, but not along with the existing method ```test_payday_preserves_due_until_charged```. If both methods run, the credit part of ```test_refund_of_excess_balance``` fails with an authorisation error. I see a small possibility that this behaviour may be something to do with my local environment.
2. I managed to get things running with my own Braintree credentials, using ```tests/local.env```. I get 'success' and 'authorized' responses. However, things do not look ok when checking on the Braintree dashboard - credit in the transaction summary is always 0.

In addition, I have the following questions:

1. For the moment, I'm just looking for ```balances > 0``` to do refunds. I believe I will need to apply some other conditions e.g. to exclude 1.0 balances?
2. I've uploaded changed test fixtures as well, but since I'm now working with my own Braintree credentials, will these be relevant?
