### PR TITLE
Show dues in team pages

### DIFF
--- a/gratipay/models/participant.py
+++ b/gratipay/models/participant.py
@@ -1013,15 +1013,17 @@ class Participant(Model):
                AND p.id != %(id)s
         """, dict(username=self.username,team=team,id=id))
 
-        # Update summary value in teams
+        # Update summary values in teams
         (cursor or self.db).run("""
             UPDATE teams t
-               SET due = pi.due
-              FROM (select team, sum(due) as due
+               SET due = pi.due, ndue = pi.ndue
+              FROM (select team, sum(due) as due, count(*) as ndue
               FROM payment_instructions
+             WHERE due > 0
           GROUP BY team) as pi
              WHERE t.slug = pi.team
-        """)
+               AND t.slug = %(team)s
+        """, dict(team=team))
 
     def _reset_due(self, team, except_for=-1, cursor=None):
         (cursor or self.db).run("""

--- a/gratipay/models/participant.py
+++ b/gratipay/models/participant.py
@@ -1013,6 +1013,16 @@ class Participant(Model):
                AND p.id != %(id)s
         """, dict(username=self.username,team=team,id=id))
 
+        # Update summary value in teams
+        (cursor or self.db).run("""
+            UPDATE teams t
+               SET due = pi.due
+              FROM (select team, sum(due) as due
+              FROM payment_instructions
+          GROUP BY team) as pi
+             WHERE t.slug = pi.team
+        """)
+
     def _reset_due(self, team, except_for=-1, cursor=None):
         (cursor or self.db).run("""
             UPDATE payment_instructions p

--- a/scss/pages/homepage.scss
+++ b/scss/pages/homepage.scss
@@ -91,7 +91,7 @@
             }
             .numbers {
                 position: absolute;
-                bottom: 8px;
+                bottom: 4px;
                 right: 0;
                 z-index: 0;
                 font-size: 11px;

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE teams ADD COLUMN due numeric(35,2) DEFAULT 0;

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,1 +1,2 @@
 ALTER TABLE teams ADD COLUMN due numeric(35,2) DEFAULT 0;
+ALTER TABLE teams ADD COLUMN ndue integer DEFAULT 0;

--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -214,3 +214,13 @@ class TestPages(Harness):
         self.make_participant('alice', claimed_time='now')
         body = self.client.GET("/~alice/routes/credit-card.html", auth_as="alice").body
         assert  "Braintree" in body
+
+    def test_teams_page_shows_due(self):
+        alice = self.make_participant('alice', claimed_time='now')
+        team = self.make_team(is_approved=True)
+        self.db.run("UPDATE teams SET due = 5.00 WHERE owner = 'picard'")
+        page_body = self.client.GET("/", auth_as="alice").body
+        assert "TheEnterprise" in page_body
+        assert "Due" in page_body
+        assert "$5.00" in page_body
+

--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -216,8 +216,8 @@ class TestPages(Harness):
         assert  "Braintree" in body
 
     def test_teams_page_shows_due(self):
-        alice = self.make_participant('alice', claimed_time='now')
-        team = self.make_team(is_approved=True)
+        self.make_participant('alice', claimed_time='now')
+        self.make_team(is_approved=True)
         self.db.run("UPDATE teams SET due = 5.00 WHERE owner = 'picard'")
         page_body = self.client.GET("/", auth_as="alice").body
         assert "TheEnterprise" in page_body

--- a/www/%team/index.html.spt
+++ b/www/%team/index.html.spt
@@ -43,12 +43,11 @@ suppress_sidebar = not(team.is_approved or user.ADMIN)
             <td class="total-receiving" data-team="{{ team.id }}">{{ format_currency(team.receiving, 'USD') }}</td>
             <td class="nreceiving-from" data-team="{{ team.id }}">{{ team.nreceiving_from }}</td>
         </tr>
-        {% if team.due > 0 %}
         <tr>
             <td class="label">{{ _("Due") }}</td>
             <td class="total-receiving" data-team="{{ team.id }}">{{ format_currency(team.due, 'USD') }}</td>
+            <td class="nreceiving-from" data-team="{{ team.id }}">{{ team.ndue }}</td>
         </tr>
-        {% endif %}
         <tr>
             <td class="label">{{ _("Sharing") }}</td>
             <td>{{ format_currency(0, 'USD') }}</td>

--- a/www/%team/index.html.spt
+++ b/www/%team/index.html.spt
@@ -43,6 +43,12 @@ suppress_sidebar = not(team.is_approved or user.ADMIN)
             <td class="total-receiving" data-team="{{ team.id }}">{{ format_currency(team.receiving, 'USD') }}</td>
             <td class="nreceiving-from" data-team="{{ team.id }}">{{ team.nreceiving_from }}</td>
         </tr>
+        {% if team.due > 0 %}
+        <tr>
+            <td class="label">{{ _("Due") }}</td>
+            <td class="total-receiving" data-team="{{ team.id }}">{{ format_currency(team.due, 'USD') }}</td>
+        </tr>
+        {% endif %}
         <tr>
             <td class="label">{{ _("Sharing") }}</td>
             <td>{{ format_currency(0, 'USD') }}</td>

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -136,6 +136,10 @@ suppress_welcome = 'suppress-welcome' in request.cookie
                         <td>{{ team.nreceiving_from if team.nreceiving_from else '-' }}</td>
                     </tr>
                     <tr>
+                        <td class="label">{{ _("Due") }}</td>
+                        <td>{{ format_currency(team.due, 'USD') }}</td>
+                    </tr>
+                    <tr>
                         <td class="label">{{ _("Sharing") }}</td>
                         <td>- &nbsp;</td>
                         <td>-</td>


### PR DESCRIPTION
Changes to show ```due``` values, if any, on the teams list and individual team pages.

The value shown is from a new column ```due``` in table ```teams```, updated with the summary of values from table ```payment_instructions```.