### PR TITLE
Updated schema for emails.participant to refer to participants.id

### DIFF
--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,9 @@
+ALTER TABLE emails DROP CONSTRAINT emails_participant_fkey;
+
+ALTER TABLE emails ALTER COLUMN participant TYPE bigint USING participant::bigint;
+
+CREATE SEQUENCE emails_participant_seq;
+ALTER TABLE emails ALTER COLUMN participant SET DEFAULT nextval('emails_participant_seq');
+ALTER SEQUENCE emails_participant_seq OWNED BY emails.participant;
+
+ALTER TABLE emails ADD FOREIGN KEY (participant) REFERENCES participants(id) ON UPDATE CASCADE ON DELETE RESTRICT;


### PR DESCRIPTION
Changes made in this PR:
* Added `sql/branch.sql`. The `emails.participant` now refers to `participants.id` rather than `participants.username`.

@whit537 , the tests fail now as the schema is now changed. Please let me know if the schema change looks good and I will move ahead with fixing the tests.