### PR TITLE
Change emails foreign key

### DIFF
--- a/gratipay/models/participant.py
+++ b/gratipay/models/participant.py
@@ -409,9 +409,9 @@ class Participant(Model):
                 add_event(c, 'participant', dict(id=self.id, action='add', values=dict(email=email)))
                 c.run("""
                     INSERT INTO emails
-                                (address, nonce, verification_start, participant)
-                         VALUES (%s, %s, %s, %s)
-                """, (email, nonce, verification_start, self.username))
+                                (address, nonce, verification_start, participant, participant_id)
+                         VALUES (%s, %s, %s, %s, %s)
+                """, (email, nonce, verification_start, self.username, self.id))
         except IntegrityError:
             nonce = self.db.one("""
                 UPDATE emails

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,4 @@
+ALTER TABLE emails ADD COLUMN participant_id bigint DEFAULT NULL
+	REFERENCES participants(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+ALTER TABLE emails ADD UNIQUE (participant_id, address);


### PR DESCRIPTION
This pr only introduces a new column in `emails` table which references `participants.id` and modifies email writes to include `email.participant_id` as well. Ideally we would want this to be deployed before we start copying old values from `participant.id` to `email.participant_id`. So that would come in a separate migration. 