### PR TITLE
Change emails foreign key - 2

### DIFF
--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,5 @@
+UPDATE emails AS e
+SET participant_id = p.id
+FROM participants AS p
+WHERE p.username = e.participant
+AND e.participant_id IS NULL;

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -3,3 +3,5 @@ SET participant_id = p.id
 FROM participants AS p
 WHERE p.username = e.participant
 AND e.participant_id IS NULL;
+
+ALTER TABLE emails ALTER COLUMN participant_id SET NOT NULL;

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -102,8 +102,8 @@ class TestEmail(EmailHarness):
         self.db.run("""
             UPDATE emails
                SET verification_start = (now() - INTERVAL '25 hours')
-             WHERE participant = 'alice'
-        """)
+             WHERE participant_id = %s;
+        """, (self.alice.id,))
         nonce = self.alice.get_email(address).nonce
         r = self.alice.verify_email(address, nonce)
         assert r == emails.VERIFICATION_EXPIRED


### PR DESCRIPTION
This is the next step after #3893. Pr includes a migration to fill the new `emails.participant_id` column with existing data and modifies email reads to then read from the new column instead of `emails.participant`.