### PR TITLE
Change emails foreign key - 3

### DIFF
--- a/gratipay/models/participant.py
+++ b/gratipay/models/participant.py
@@ -410,9 +410,9 @@ class Participant(Model):
                 add_event(c, 'participant', dict(id=self.id, action='add', values=dict(email=email)))
                 c.run("""
                     INSERT INTO emails
-                                (address, nonce, verification_start, participant, participant_id)
-                         VALUES (%s, %s, %s, %s, %s)
-                """, (email, nonce, verification_start, self.username, self.id))
+                                (address, nonce, verification_start, participant_id)
+                         VALUES (%s, %s, %s, %s)
+                """, (email, nonce, verification_start, self.id))
         except IntegrityError:
             nonce = self.db.one("""
                 UPDATE emails

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE emails DROP COLUMN participant;


### PR DESCRIPTION
Last step for changing emails table. Changes writes to only use `participant_id` and drops `participant` column.

EDIT by @rohitpaulk: 

Issue: https://github.com/gratipay/gratipay.com/issues/835

Follows https://github.com/gratipay/gratipay.com/pull/3893 and https://github.com/gratipay/gratipay.com/pull/3896