### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ containing `team_slug` and `amount` to bulk upsert payment instructions (make
 sure to set `Content-Type` to `application/json`). The `amount` must be encoded
 as a string rather than a number. In case the upsert is not successful for any
 object, there will be an `error` attribute in the response explaining the error
-along with the `team_slug` to identify the object for which the error occured.
+along with the `team_slug` to identify the object for which the error occurred.
 
 This endpoint requires authentication. Look up your user ID and API key on your
 [account page](https://gratipay.com/about/me/settings/) and pass them using


### PR DESCRIPTION
`occured` → `occurred`