### PR TITLE
Tweak paths to payday logs

### DIFF
--- a/payday.sh
+++ b/payday.sh
@@ -67,9 +67,9 @@ start () {
 # ====
 
 if [ "$2" == "for_real_please" ]; then
-    LOG="../logs/paydays/gratipay-$1.log"
+    LOG="../logs/payday/gratipay-$1.log"
 else
-    LOG="../logs/paydays/test-$1.log"
+    LOG="../logs/payday/test-$1.log"
 fi
 
 if [ -f $LOG ]; then


### PR DESCRIPTION
@clone1018 @rohitpaulk Did you not get bit by this? The path is [`payday`](https://github.com/gratipay/logs/tree/master/payday), not `paydays`. Crept in in #3901, prior to that I had symlinks masking the issue.