### PR TITLE
fix plusses in emails

### DIFF
--- a/gratipay/models/participant.py
+++ b/gratipay/models/participant.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from decimal import Decimal
 import pickle
 from time import sleep
-from urllib import quote
 import uuid
 
 from aspen.utils import utcnow
@@ -40,7 +39,14 @@ from gratipay.models.account_elsewhere import AccountElsewhere
 from gratipay.models.exchange_route import ExchangeRoute
 from gratipay.models.team import Team
 from gratipay.security.crypto import constant_time_compare
-from gratipay.utils import i18n, is_card_expiring, emails, notifications, pricing
+from gratipay.utils import (
+    i18n,
+    is_card_expiring,
+    emails,
+    notifications,
+    pricing,
+    b64encode_s,
+)
 from gratipay.utils.username import safely_reserve_a_username
 
 
@@ -427,8 +433,8 @@ class Participant(Model):
 
         base_url = gratipay.base_url
         username = self.username_lower
-        quoted_email = quote(email)
-        link = "{base_url}/~{username}/emails/verify.html?email={quoted_email}&nonce={nonce}"
+        base64_email = b64encode_s(email)
+        link = "{base_url}/~{username}/emails/verify.html?email64={base64_email}&nonce={nonce}"
         r = self.send_email('verification',
                             email=email,
                             link=link.format(**locals()),

--- a/gratipay/models/participant.py
+++ b/gratipay/models/participant.py
@@ -433,8 +433,8 @@ class Participant(Model):
 
         base_url = gratipay.base_url
         username = self.username_lower
-        base64_email = encode_for_querystring(email)
-        link = "{base_url}/~{username}/emails/verify.html?email64={base64_email}&nonce={nonce}"
+        encoded_email = encode_for_querystring(email)
+        link = "{base_url}/~{username}/emails/verify.html?email2={encoded_email}&nonce={nonce}"
         r = self.send_email('verification',
                             email=email,
                             link=link.format(**locals()),

--- a/gratipay/models/participant.py
+++ b/gratipay/models/participant.py
@@ -45,7 +45,7 @@ from gratipay.utils import (
     emails,
     notifications,
     pricing,
-    b64encode_s,
+    encode_for_querystring,
 )
 from gratipay.utils.username import safely_reserve_a_username
 
@@ -433,7 +433,7 @@ class Participant(Model):
 
         base_url = gratipay.base_url
         username = self.username_lower
-        base64_email = b64encode_s(email)
+        base64_email = encode_for_querystring(email)
         link = "{base_url}/~{username}/emails/verify.html?email64={base64_email}&nonce={nonce}"
         r = self.send_email('verification',
                             email=email,

--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -149,6 +149,7 @@ def b64encode_s(s):
 def b64decode_s(s, **kw):
     def error():
         if 'default' in kw:
+            # Enable callers to handle errors without using try/except.
             return kw['default']
         raise Response(400, "invalid base64 input")
 

--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -143,6 +143,10 @@ def encode_for_querystring(s):
 
 def decode_from_querystring(s, **kw):
     """Given a unicode computed by encode_for_querystring, return the inverse.
+
+    We raise Response(400) if the input value can't be decoded (i.e., it's not
+    ASCII, not padded properly, or not decodable as UTF-8 once Base64-decoded).
+
     """
     if not isinstance(s, unicode):
         raise TypeError('unicode required')

--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from base64 import b64decode, b64encode
+from base64 import urlsafe_b64encode, urlsafe_b64decode
 from datetime import datetime, timedelta
 
 from aspen import Response, json
@@ -138,7 +138,7 @@ def encode_for_querystring(s):
     """
     if not isinstance(s, unicode):
         raise TypeError('unicode required')
-    return b64encode(s.encode('utf8'), b'-_').replace(b'=', b'~').decode('ascii')
+    return urlsafe_b64encode(s.encode('utf8')).replace(b'=', b'~').decode('ascii')
 
 
 def decode_from_querystring(s, **kw):
@@ -147,7 +147,7 @@ def decode_from_querystring(s, **kw):
     if not isinstance(s, unicode):
         raise TypeError('unicode required')
     try:
-        return b64decode(s.encode('ascii').replace(b'~', b'='), b'-_').decode('utf8')
+        return urlsafe_b64decode(s.encode('ascii').replace(b'~', b'=')).decode('utf8')
     except:
         if 'default' in kw:
             # Enable callers to handle errors without using try/except.

--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -133,7 +133,7 @@ def get_team(state):
     return team
 
 
-def b64encode_s(s):
+def encode_for_querystring(s):
     prefix = b''
     if not isinstance(s, bytes):
         s = s.encode('utf8')
@@ -146,7 +146,7 @@ def b64encode_s(s):
     return prefix + b64encode(s, b'-_').replace(b'=', b'~')
 
 
-def b64decode_s(s, **kw):
+def decode_from_querystring(s, **kw):
     def error():
         if 'default' in kw:
             # Enable callers to handle errors without using try/except.

--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -151,7 +151,7 @@ def decode_from_querystring(s, **kw):
         if 'default' in kw:
             # Enable callers to handle errors without using try/except.
             return kw['default']
-        raise Response(400, "invalid base64 input")
+        raise Response(400, "invalid input")
 
     try:
         s = s.encode('ascii')

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -6,7 +6,7 @@ from gratipay.exceptions import CannotRemovePrimaryEmail, EmailAlreadyTaken, Ema
 from gratipay.exceptions import TooManyEmailAddresses, ResendingTooFast
 from gratipay.models.participant import Participant
 from gratipay.testing.emails import EmailHarness
-from gratipay.utils import emails, b64encode_s
+from gratipay.utils import emails, encode_for_querystring
 
 
 class TestEmail(EmailHarness):
@@ -27,8 +27,9 @@ class TestEmail(EmailHarness):
         return P('/~alice/emails/modify.json', data, auth_as=user, **headers)
 
     def verify_email(self, email, nonce, username='alice', should_fail=False):
-        # Email address is base64 encoded in url.
-        url = '/~%s/emails/verify.html?email64=%s&nonce=%s' % (username, b64encode_s(email), nonce)
+        # Email address is encoded in url.
+        url = '/~%s/emails/verify.html?email64=%s&nonce=%s'
+        url %= (username, encode_for_querystring(email), nonce)
         G = self.client.GxT if should_fail else self.client.GET
         return G(url, auth_as=username)
 
@@ -51,9 +52,9 @@ class TestEmail(EmailHarness):
         expected = "We've received a request to connect alice@gratipay.com to the alice account on Gratipay"
         assert expected in last_email['text']
 
-    def test_email_address_is_base64_encoded_in_sent_verification_link(self):
+    def test_email_address_is_encoded_in_sent_verification_link(self):
         address = 'alice@gratipay.com'
-        encoded = b64encode_s(address)
+        encoded = encode_for_querystring(address)
         self.hit_email_spt('add-email', address)
         last_email = self.get_last_email()
         assert "~alice/emails/verify.html?email64="+encoded in last_email['text']

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import json
 import time
 
@@ -23,7 +25,7 @@ class TestEmail(EmailHarness):
     def hit_email_spt(self, action, address, user='alice', should_fail=False):
         P = self.client.PxST if should_fail else self.client.POST
         data = {'action': action, 'address': address}
-        headers = {'HTTP_ACCEPT_LANGUAGE': 'en'}
+        headers = {b'HTTP_ACCEPT_LANGUAGE': b'en'}
         return P('/~alice/emails/modify.json', data, auth_as=user, **headers)
 
     def verify_email(self, email, nonce, username='alice', should_fail=False):

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -28,7 +28,7 @@ class TestEmail(EmailHarness):
 
     def verify_email(self, email, nonce, username='alice', should_fail=False):
         # Email address is encoded in url.
-        url = '/~%s/emails/verify.html?email64=%s&nonce=%s'
+        url = '/~%s/emails/verify.html?email2=%s&nonce=%s'
         url %= (username, encode_for_querystring(email), nonce)
         G = self.client.GxT if should_fail else self.client.GET
         return G(url, auth_as=username)
@@ -57,7 +57,7 @@ class TestEmail(EmailHarness):
         encoded = encode_for_querystring(address)
         self.hit_email_spt('add-email', address)
         last_email = self.get_last_email()
-        assert "~alice/emails/verify.html?email64="+encoded in last_email['text']
+        assert "~alice/emails/verify.html?email2="+encoded in last_email['text']
 
     def test_verification_email_doesnt_contain_unsubscribe(self):
         self.hit_email_spt('add-email', 'alice@gratipay.com')

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -128,7 +128,7 @@ class TestEmail(EmailHarness):
         assert expected == actual
 
     def test_email_verification_is_backwards_compatible(self):
-        """Test email verification still works with unencoded email in verifcation link.
+        """Test email verification still works with unencoded email in verification link.
         """
         self.hit_email_spt('add-email', 'alice@example.com')
         nonce = self.alice.get_email('alice@example.com').nonce

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -1,6 +1,7 @@
 import json
 import time
 
+import mock
 from gratipay.exceptions import CannotRemovePrimaryEmail, EmailAlreadyTaken, EmailNotVerified
 from gratipay.exceptions import TooManyEmailAddresses, ResendingTooFast
 from gratipay.models.participant import Participant
@@ -218,6 +219,13 @@ class TestEmail(EmailHarness):
         last_email = self.get_last_email()
         assert 'foo&#39;bar' in last_email['html']
         assert '&#39;' not in last_email['text']
+
+    @mock.patch('gratipay.models.participant.Participant.send_email')
+    def test_emails_with_plus_are_linked_properly(self, send_email):
+        send_email.return_value = 1
+        self.alice.add_email("foo+bar@example.com")
+        link = send_email.args[1]
+        assert link.startswith('/~alice/emails/verify.html?email=foo%2Bbar%40example.com&nonce=')
 
     def test_can_dequeue_an_email(self):
         larry = self.make_participant('larry', email_address='larry@example.com')

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 import time
 
-import mock
 from gratipay.exceptions import CannotRemovePrimaryEmail, EmailAlreadyTaken, EmailNotVerified
 from gratipay.exceptions import TooManyEmailAddresses, ResendingTooFast
 from gratipay.models.participant import Participant
@@ -241,13 +240,6 @@ class TestEmail(EmailHarness):
         last_email = self.get_last_email()
         assert 'foo&#39;bar' in last_email['html']
         assert '&#39;' not in last_email['text']
-
-    @mock.patch('gratipay.models.participant.Participant.send_email')
-    def test_emails_with_plus_are_linked_properly(self, send_email):
-        send_email.return_value = 1
-        self.alice.add_email("foo+bar@example.com")
-        link = send_email.args[1]
-        assert link.startswith('/~alice/emails/verify.html?email=foo%2Bbar%40example.com&nonce=')
 
     def test_can_dequeue_an_email(self):
         larry = self.make_participant('larry', email_address='larry@example.com')

--- a/tests/py/test_utils.py
+++ b/tests/py/test_utils.py
@@ -218,8 +218,8 @@ class Tests(Harness):
         assert pricing.suggested_payment_low_high(D('98.33')) == (D('4.90'), D('9.85'))
 
 
-    # querystring encoding/decoding
-    # =============================
+    # encoding/decoding querystring values
+    # ====================================
 
     # efq = encode_for_querystring
 
@@ -230,11 +230,20 @@ class Tests(Harness):
     def test_efq_replaces_equals_with_tilde(self):
         assert encode_for_querystring('TheEnterprise') == 'VGhlRW50ZXJwcmlzZQ~~'
 
+    def test_efq_doesnt_accept_bytes(self):
+        with self.assertRaises(TypeError):
+            encode_for_querystring(b'TheEnterprise')
+
 
     # dfq - decode_from_querystring
 
-    def test_dfq_decodes(self):
+    def test_dfq_decodes_properly(self):
         assert decode_from_querystring('VGhlRW50ZXI_cHJpc2U~') == 'TheEnter?prise'
+        assert decode_from_querystring('VGhlRW50ZXJwcmlzZQ~~') == 'TheEnterprise'
+
+    def test_dfq_doesnt_accept_bytes(self):
+        with self.assertRaises(TypeError):
+            decode_from_querystring(b'VGhlRW50ZXI_cHJpc2U~')
 
     def test_dfq_raises_response_on_error(self):
         with self.assertRaises(Response) as cm:

--- a/tests/py/test_utils.py
+++ b/tests/py/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 from aspen.http.response import Response
 from gratipay import utils
 from gratipay.testing import Harness
-from gratipay.utils import i18n, markdown, pricing, b64encode_s, b64decode_s
+from gratipay.utils import i18n, markdown, pricing, encode_for_querystring, decode_from_querystring
 from gratipay.utils.username import safely_reserve_a_username, FailedToReserveUsername, \
                                                                            RanOutOfUsernameAttempts
 from psycopg2 import IntegrityError
@@ -218,23 +218,28 @@ class Tests(Harness):
         assert pricing.suggested_payment_low_high(D('98.33')) == (D('4.90'), D('9.85'))
 
 
-    # Base64 encoding/decoding
-    # ========================
+    # querystring encoding/decoding
+    # =============================
 
-    def test_b64encode_s_replaces_slash_with_underscore(self):
+    # efq = encode_for_querystring
+
+    def test_efq_replaces_slash_with_underscore(self):
         # TheEnter?prise => VGhlRW50ZXI/cHJpc2U=
-        assert b64encode_s('TheEnter?prise') == 'VGhlRW50ZXI_cHJpc2U~'
+        assert encode_for_querystring('TheEnter?prise') == 'VGhlRW50ZXI_cHJpc2U~'
 
-    def test_b64encode_s_replaces_equals_with_tilde(self):
-        assert b64encode_s('TheEnterprise') == 'VGhlRW50ZXJwcmlzZQ~~'
+    def test_efq_replaces_equals_with_tilde(self):
+        assert encode_for_querystring('TheEnterprise') == 'VGhlRW50ZXJwcmlzZQ~~'
 
-    def test_b64decode_s_decodes(self):
-        assert b64decode_s('VGhlRW50ZXI_cHJpc2U~') == 'TheEnter?prise'
 
-    def test_b64decode_s_raises_response_on_error(self):
+    # dfq - decode_from_querystring
+
+    def test_dfq_decodes(self):
+        assert decode_from_querystring('VGhlRW50ZXI_cHJpc2U~') == 'TheEnter?prise'
+
+    def test_dfq_raises_response_on_error(self):
         with self.assertRaises(Response) as cm:
-            b64decode_s('abcd')
+            decode_from_querystring('abcd')
         assert cm.exception.code == 400
 
-    def test_b64decode_s_returns_default_if_passed_on_error(self):
-        assert b64decode_s('abcd', default='error') == 'error'
+    def test_dfq_returns_default_if_passed_on_error(self):
+        assert decode_from_querystring('abcd', default='error') == 'error'

--- a/tests/py/test_utils.py
+++ b/tests/py/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 from aspen.http.response import Response
 from gratipay import utils
 from gratipay.testing import Harness
-from gratipay.utils import i18n, markdown, pricing
+from gratipay.utils import i18n, markdown, pricing, b64encode_s, b64decode_s
 from gratipay.utils.username import safely_reserve_a_username, FailedToReserveUsername, \
                                                                            RanOutOfUsernameAttempts
 from psycopg2 import IntegrityError
@@ -216,3 +216,25 @@ class Tests(Harness):
 
     def test_splh_rounds_to_nearest_five_cents(self):
         assert pricing.suggested_payment_low_high(D('98.33')) == (D('4.90'), D('9.85'))
+
+
+    # Base64 encoding/decoding
+    # ========================
+
+    def test_b64encode_s_replaces_slash_with_underscore(self):
+        # TheEnter?prise => VGhlRW50ZXI/cHJpc2U=
+        assert b64encode_s('TheEnter?prise') == 'VGhlRW50ZXI_cHJpc2U~'
+
+    def test_b64encode_s_replaces_equals_with_tilde(self):
+        assert b64encode_s('TheEnterprise') == 'VGhlRW50ZXJwcmlzZQ~~'
+
+    def test_b64decode_s_decodes(self):
+        assert b64decode_s('VGhlRW50ZXI_cHJpc2U~') == 'TheEnter?prise'
+
+    def test_b64decode_s_raises_response_on_error(self):
+        with self.assertRaises(Response) as cm:
+            b64decode_s('abcd')
+        assert cm.exception.code == 400
+
+    def test_b64decode_s_returns_default_if_passed_on_error(self):
+        assert b64decode_s('abcd', default='error') == 'error'

--- a/www/~/%username/emails/verify.html.spt
+++ b/www/~/%username/emails/verify.html.spt
@@ -19,7 +19,7 @@ if participant == user.participant:
 
         email = request.qs['email']
     else:
-        email = decode_from_querystring(request.qs.get('email64', ''), default='')
+        email = decode_from_querystring(request.qs.get('email2', ''), default='')
     nonce = request.qs.get('nonce', '')
     result = participant.verify_email(email, nonce)
     if not participant.email_lang:

--- a/www/~/%username/emails/verify.html.spt
+++ b/www/~/%username/emails/verify.html.spt
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from aspen import Response
 from aspen.utils import utcnow
-from gratipay.utils import emails, get_participant, b64decode_s
+from gratipay.utils import emails, get_participant, decode_from_querystring
 
 [-----------------------------------------------------------------------------]
 
@@ -19,7 +19,7 @@ if participant == user.participant:
 
         email = request.qs['email']
     else:
-        email = b64decode_s(request.qs.get('email64', ''), default='')
+        email = decode_from_querystring(request.qs.get('email64', ''), default='')
     nonce = request.qs.get('nonce', '')
     result = participant.verify_email(email, nonce)
     if not participant.email_lang:

--- a/www/~/%username/emails/verify.html.spt
+++ b/www/~/%username/emails/verify.html.spt
@@ -12,6 +12,11 @@ participant = get_participant(state, restrict=False)
 banner = '~' + participant.username
 if participant == user.participant:
     if 'email' in request.qs:
+
+        # Deprecated in GH-3965. We shouldn't be generating any more of these,
+        # and this can be removed when we're confident that there are no more
+        # old-style verification links hanging out there.
+
         email = request.qs['email']
     else:
         email = b64decode_s(request.qs.get('email64', ''), default='')

--- a/www/~/%username/emails/verify.html.spt
+++ b/www/~/%username/emails/verify.html.spt
@@ -4,14 +4,17 @@ from datetime import timedelta
 
 from aspen import Response
 from aspen.utils import utcnow
-from gratipay.utils import emails, get_participant
+from gratipay.utils import emails, get_participant, b64decode_s
 
 [-----------------------------------------------------------------------------]
 
 participant = get_participant(state, restrict=False)
 banner = '~' + participant.username
 if participant == user.participant:
-    email = request.qs.get('email', '')
+    if 'email' in request.qs:
+        email = request.qs['email']
+    else:
+        email = b64decode_s(request.qs.get('email64', ''), default='')
     nonce = request.qs.get('nonce', '')
     result = participant.verify_email(email, nonce)
     if not participant.email_lang:


### PR DESCRIPTION
Let's fix #3110. I don't know yet what the issue is, but so far here's a *passing* test for escaping plusses in emails in the links we send out. At what point are those getting unescaped?