### PR TITLE
Add script to fix stale cached values

### DIFF
--- a/sql/branch.py
+++ b/sql/branch.py
@@ -1,0 +1,16 @@
+from gratipay import wireup
+
+db = wireup.db(wireup.env())
+
+participants = db.all("""
+    SELECT p.*::participants
+      FROM participants p
+      JOIN payment_instructions pi ON pi.participant = p.username -- Only include those with tips
+""")
+total = len(participants)
+counter = 0
+
+for p in participants:
+    print("Participant %s/%s" % (counter, total))
+    p.update_giving_and_teams()
+    counter += 1


### PR DESCRIPTION
Earlier (in Gratipay 1.0), we used to fund tips using the Gratipay balance that participants had. We used to refresh these values after every Payday. 

Now that we've moved to charging in arrears and never using one's balance to fund tips - the old 'funded' values have to be corrected.

This was picked off https://github.com/gratipay/gratipay.com/pull/3876#issuecomment-164177764 (https://github.com/gratipay/gratipay.com/pull/3876#issuecomment-164177764 for reference)
