### PR TITLE
fix method whitelisting

### DIFF
--- a/gratipay/main.py
+++ b/gratipay/main.py
@@ -98,8 +98,6 @@ algorithm.functions = [
     algorithm['parse_environ_into_request'],
     algorithm['parse_body_into_request'],
 
-    security.only_allow_certain_methods,
-
     utils.use_tildes_for_participants,
     algorithm['redirect_to_base_url'],
     i18n.set_up_i18n,
@@ -107,6 +105,7 @@ algorithm.functions = [
     authentication.authenticate_user_if_possible,
     csrf.extract_token_from_cookie,
     csrf.reject_forgeries,
+    security.only_allow_certain_methods,
 
     algorithm['dispatch_request_to_filesystem'],
 

--- a/tests/py/test_security.py
+++ b/tests/py/test_security.py
@@ -25,6 +25,9 @@ class TestSecurity(Harness):
             response = raises(Response, security.only_allow_certain_methods, request).value
             assert response.code == 405
 
+    def test_oacm_doesnt_choke_error_handling(self):
+        assert self.client.hit("OPTIONS", "/", raise_immediately=False).code == 405
+
 
     # ahtr - add_headers_to_response
 


### PR DESCRIPTION
We're ending up with 500 instead of 405, because of a misordering in the algorithm functions. The error handling needs a `user` object, and also apparently some `i18n`.

This surfaced on [H1-127218](https://hackerone.com/reports/127218).