### PR TITLE
fix the Makefile for Sphinx

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = ../env/bin/swaddle ../tests/env ../env/bin/sphinx-build
+SPHINXBUILD   = ../env/bin/honcho -e ../tests/env run ../env/bin/sphinx-build
 BUILDDIR      = _build
 
 # User-friendly check for sphinx-build


### PR DESCRIPTION
It was depending on swaddle, which is gone in favor of honcho. Still requires that you `pip install sphinx`, but then you can `make html` and `cd _build/html && python -m SimpleHTTPServer &`.