### PR TITLE
Refactor tip migration

### DIFF
--- a/bin/migrate-tips.py
+++ b/bin/migrate-tips.py
@@ -1,27 +1,7 @@
 from gratipay.wireup import db, env
-from gratipay.models.team import AlreadyMigrated
+from gratipay.models.team import migrate_all_tips
 
 db = db(env())
 
-teams = db.all("""
-    SELECT distinct ON (t.slug) t.*::teams
-      FROM teams t
-      JOIN tips ON t.owner = tips.tippee    -- Only fetch teams whose owners had tips under Gratipay 1.0
-     WHERE t.is_approved IS TRUE            -- Only fetch approved teams
-       AND NOT EXISTS (                     -- Make sure tips haven't been migrated for any teams with same owner
-            SELECT 1
-              FROM payment_instructions pi
-              JOIN teams t2 ON t2.slug = pi.team
-             WHERE t2.owner = t.owner
-               AND pi.ctime < t2.ctime
-       )
-""")
-
-for team in teams:
-    try:
-        ntips = team.migrate_tips()
-        print("Migrated {} tip(s) for '{}'".format(ntips, team.slug))
-    except AlreadyMigrated:
-        print("'%s' already migrated." % team.slug)
-
-print("Done.")
+if __name__ == '__main__':
+    migrate_all_tips(db)

--- a/gratipay/models/__init__.py
+++ b/gratipay/models/__init__.py
@@ -18,6 +18,8 @@ def just_yield(obj):
 
 
 class GratipayDB(Postgres):
+    """Model the Gratipay database.
+    """
 
     def get_cursor(self, cursor=None, **kw):
         if cursor:

--- a/gratipay/models/team.py
+++ b/gratipay/models/team.py
@@ -1,5 +1,7 @@
 """Teams on Gratipay receive payments and distribute payroll.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import re
 from decimal import Decimal
 
@@ -378,6 +380,36 @@ class Team(Model):
             with self.db.get_connection() as c:
                 image = c.lobject(oid, mode='rb').read()
         return image
+
+
+def migrate_all_tips(db, print=print):
+    """Migrate tips for all teams.
+
+    :param GratipayDatabase db:
+
+    """
+    teams = db.all("""
+        SELECT distinct ON (t.slug) t.*::teams
+          FROM teams t
+          JOIN tips ON t.owner = tips.tippee    -- Only fetch teams whose owners had tips under Gratipay 1.0
+         WHERE t.is_approved IS TRUE            -- Only fetch approved teams
+           AND NOT EXISTS (                     -- Make sure tips haven't been migrated for any teams with same owner
+                SELECT 1
+                  FROM payment_instructions pi
+                  JOIN teams t2 ON t2.slug = pi.team
+                 WHERE t2.owner = t.owner
+                   AND pi.ctime < t2.ctime
+           )
+    """)
+
+    for team in teams:
+        try:
+            ntips = team.migrate_tips()
+            print("Migrated {} tip(s) for '{}'".format(ntips, team.slug))
+        except AlreadyMigrated:
+            print("'%s' already migrated." % team.slug)
+
+    print("Done.")
 
 
 class AlreadyMigrated(Exception): pass

--- a/gratipay/models/team.py
+++ b/gratipay/models/team.py
@@ -304,6 +304,15 @@ class Team(Model):
         }
 
     def migrate_tips(self):
+        """Migrate the Team owner's Gratipay 1.0 tips into 2.0 payment instructions to the Team.
+
+        :return: ``None``
+        :raises: :py:exc:`~gratipay.models.team.AlreadyMigrated` if payment
+            instructions already exist for this Team
+
+        This method gets called under :py:func:`migrate_all_tips` during payday.
+
+        """
         payment_instructions = self.db.all("""
             SELECT pi.*
               FROM payment_instructions pi
@@ -385,7 +394,19 @@ class Team(Model):
 def migrate_all_tips(db, print=print):
     """Migrate tips for all teams.
 
-    :param GratipayDatabase db:
+    :param GratipayDB db: a database object
+    :param func print: a function that takes lines of log output
+    :returns: ``None``
+
+    This function loads :py:class:`~gratipay.models.team.Team` objects for all
+    Teams where the owner had tips under Gratipay 1.0 but those tips have not
+    yet been migrated into payment instructions under Gratipay 2.0. It then
+    migrates the tips using :py:meth:`~gratipay.models.team.Team.migrate_tips`.
+
+    This function is wrapped in a script, ``bin/migrate-tips.py``, which is
+    `used during payday`_.
+
+    .. _used during payday: http://inside.gratipay.com/howto/run-payday
 
     """
     teams = db.all("""
@@ -412,4 +433,6 @@ def migrate_all_tips(db, print=print):
     print("Done.")
 
 
-class AlreadyMigrated(Exception): pass
+class AlreadyMigrated(Exception):
+    """Raised by :py:meth:`~gratipay.models.team.migrate_tips`.
+    """

--- a/tests/py/test_tip_migration.py
+++ b/tests/py/test_tip_migration.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
+from gratipay.testing import Harness
+from gratipay.models.team import AlreadyMigrated, migrate_all_tips
+
+
+class Tests(Harness):
+
+    def setUp(self):
+        self.admin = self.make_participant('admin', is_admin=True)
+        alice = self.make_participant('alice', claimed_time='now')
+        bob = self.make_participant('bob', claimed_time='now')
+        self.make_participant('old_team')
+        self.make_tip(alice, 'old_team', '1.00')
+        self.make_tip(bob, 'old_team', '2.00')
+        self.new_team = self.make_team('new_team', owner='old_team', is_approved=True)
+
+    def setTeamStatus(self, status):
+        self.client.POST('/new_team/set-status.json', data={'status': status}, auth_as='admin')
+
+    def capturer(self):
+        captured = []
+        def capture(line):
+            captured.append(line)
+        return capture, captured
+
+
+    # mt - migrate_tips
+
+    def test_mt_migrates_tips_to_payment_instructions(self):
+        assert self.new_team.migrate_tips() == 2
+
+        payment_instructions = self.db.all("SELECT * FROM payment_instructions ORDER BY participant ASC")
+        assert len(payment_instructions) == 2
+        assert payment_instructions[0].participant == 'alice'
+        assert payment_instructions[0].team == 'new_team'
+        assert payment_instructions[0].amount == 1
+        assert payment_instructions[1].participant == 'bob'
+        assert payment_instructions[1].team == 'new_team'
+        assert payment_instructions[1].amount == 2
+
+    def test_mt_only_runs_once(self):
+        self.new_team.migrate_tips()
+        with pytest.raises(AlreadyMigrated):
+            self.new_team.migrate_tips()
+        assert len(self.db.all("SELECT * FROM payment_instructions")) == 2
+
+    def test_mt_checks_for_multiple_teams(self):
+        self.new_team.migrate_tips()
+        newer_team = self.make_team('newer_team', owner='old_team')
+        with pytest.raises(AlreadyMigrated):
+            newer_team.migrate_tips()
+        assert len(self.db.all("SELECT * FROM payment_instructions")) == 2
+
+
+    # mat - migrate_all_tips
+
+    def test_mat_migrates_all_tips(self):
+        capture, captured = self.capturer()
+        migrate_all_tips(self.db, capture)
+        assert captured == ["Migrated 2 tip(s) for 'new_team'", "Done."]
+
+    def test_mat_ignores_already_migrated_teams(self):
+        capture, captured = self.capturer()
+        migrate_all_tips(self.db, capture)
+        del captured[:]  # clear first run output
+        migrate_all_tips(self.db, capture)
+        assert captured == ["Done."]
+
+    def test_mat_ignores_unreviewed_teams(self):
+        self.setTeamStatus('unreviewed')
+        capture, captured = self.capturer()
+        migrate_all_tips(self.db, capture)
+        assert captured == ["Done."]
+
+    def test_mat_ignores_rejected_teams(self):
+        self.setTeamStatus('rejected')
+        capture, captured = self.capturer()
+        migrate_all_tips(self.db, capture)
+        assert captured == ["Done."]


### PR DESCRIPTION
A lack of test coverage of the `bin/migrate-tips.py` script surfaced during a refactor (#4046). Therefore, here we:

 - Move heavy lifting from the `bin/migrate-tips.py` executable into a `migrate_all_tips` function in the gratipay library for easier testing
 - Split out tip migration tests into their own test script
 - Add a few tests for `migrate_all_tips`