### PR TITLE
Hide gunicorn version

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn gratipay.main:website --bind :$PORT $GUNICORN_OPTS
+web: gunicorn gratipay.main:website --conf hide_gunicorn_version.py --bind :$PORT $GUNICORN_OPTS

--- a/hide_gunicorn_version.py
+++ b/hide_gunicorn_version.py
@@ -1,0 +1,2 @@
+import gunicorn
+gunicorn.SERVER_SOFTWARE = 'gunicorn'


### PR DESCRIPTION
This is a slight security improvement.

https://hackerone.com/reports/123742

Verified working in a sandbox:

```
$ curl -IL http://gratipay537.herokuapp.com/
HTTP/1.1 200 OK
Connection: keep-alive
Server: gunicorn
Date: Tue, 14 Jun 2016 16:13:59 GMT
Transfer-Encoding: chunked
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Gratipay-Version: 1967
X-Xss-Protection: 1; mode=block
Content-Type: text/html; charset=UTF-8
Cache-Control: no-cache
Set-Cookie: csrf_token=[]; expires=Tue, 21 Jun 2016 16:13:59 GMT; Path=/
Via: 1.1 vegur

$
```