### PR TITLE
Simplify some APIs to not take Team slugs

### DIFF
--- a/gratipay/exceptions.py
+++ b/gratipay/exceptions.py
@@ -55,7 +55,6 @@ class ProblemChangingNumber(Exception):
 class TooGreedy(Exception): pass
 class NoSelfTipping(Exception): pass
 class NoTippee(Exception): pass
-class NoTeam(Exception): pass
 class BadAmount(Exception): pass
 class InvalidTeamName(Exception): pass
 

--- a/templates/your-payment.html
+++ b/templates/your-payment.html
@@ -5,7 +5,7 @@
     </div>
 {% else %}
     <div class="cta">
-        {% set payment_instruction = user.participant.get_payment_instruction(team.slug) %}
+        {% set payment_instruction = user.participant.get_payment_instruction(team) %}
         <h2>{{ _('You Give') }}</h2>
         <div class="js-edit your-payment {{ 'anon' if user.ANON }}" data-team="{{ team.id }}">
             <div class="view">

--- a/tests/py/test_billing_payday.py
+++ b/tests/py/test_billing_payday.py
@@ -31,7 +31,7 @@ class TestPayday(BillingHarness):
 
         assert picard.balance == D(MINIMUM_CHARGE)
         assert obama.balance == D('0.00')
-        assert obama.get_due('TheEnterprise') == D('0.00')
+        assert obama.get_due(Enterprise) == D('0.00')
 
     @mock.patch.object(Payday, 'fetch_card_holds')
     def test_payday_moves_money_cumulative_above_min_charge(self, fch):
@@ -47,7 +47,7 @@ class TestPayday(BillingHarness):
 
         """)
 
-        assert self.obama.get_due('TheEnterprise') == D('5.00')
+        assert self.obama.get_due(Enterprise) == D('5.00')
 
         fch.return_value = {}
         Payday.start().run()
@@ -57,7 +57,7 @@ class TestPayday(BillingHarness):
 
         assert picard.balance == D('10.00')
         assert obama.balance == D('0.00')
-        assert obama.get_due('TheEnterprise') == D('0.00')
+        assert obama.get_due(Enterprise) == D('0.00')
 
     @mock.patch.object(Payday, 'fetch_card_holds')
     def test_payday_preserves_due_until_charged(self, fch):
@@ -67,7 +67,7 @@ class TestPayday(BillingHarness):
         fch.return_value = {}
         Payday.start().run()    # payday 0
 
-        assert self.obama.get_due('TheEnterprise') == D('2.00')
+        assert self.obama.get_due(Enterprise) == D('2.00')
 
         self.obama.set_payment_instruction(Enterprise, '3.00')  # < MINIMUM_CHARGE
         self.obama.set_payment_instruction(Enterprise, '2.50')  # cumulatively still < MINIMUM_CHARGE
@@ -75,19 +75,19 @@ class TestPayday(BillingHarness):
         fch.return_value = {}
         Payday.start().run()    # payday 1
 
-        assert self.obama.get_due('TheEnterprise') == D('4.50')
+        assert self.obama.get_due(Enterprise) == D('4.50')
 
         fch.return_value = {}
         Payday.start().run()    # payday 2
 
-        assert self.obama.get_due('TheEnterprise') == D('7.00')
+        assert self.obama.get_due(Enterprise) == D('7.00')
 
         self.obama.set_payment_instruction(Enterprise, '1.00')  # cumulatively still < MINIMUM_CHARGE
 
         fch.return_value = {}
         Payday.start().run()    # payday 3
 
-        assert self.obama.get_due('TheEnterprise') == D('8.00')
+        assert self.obama.get_due(Enterprise) == D('8.00')
 
         self.obama.set_payment_instruction(Enterprise, '4.00')  # cumulatively > MINIMUM_CHARGE
 
@@ -99,29 +99,29 @@ class TestPayday(BillingHarness):
 
         assert picard.balance == D('12.00')
         assert obama.balance == D('0.00')
-        assert obama.get_due('TheEnterprise') == D('0.00')
+        assert obama.get_due(Enterprise) == D('0.00')
 
     @mock.patch.object(Payday, 'fetch_card_holds')
     def test_payday_only_adds_to_dues_if_valid_cc_exists(self, fch):
         Enterprise = self.make_team(is_approved=True)
         self.obama.set_payment_instruction(Enterprise, '4.00')
-        assert self.obama.get_due('TheEnterprise') == D('0.00')
+        assert self.obama.get_due(Enterprise) == D('0.00')
 
         fch.return_value = {}
         Payday.start().run()    # payday 0
 
-        assert self.obama.get_due('TheEnterprise') == D('4.00')
+        assert self.obama.get_due(Enterprise) == D('4.00')
 
         fch.return_value = {}
         self.obama_route.update_error("failed") # card fails
         Payday.start().run()    # payday 1
 
-        assert self.obama.get_due('TheEnterprise') == D('4.00')
+        assert self.obama.get_due(Enterprise) == D('4.00')
 
         fch.return_value = {}
         Payday.start().run()    # payday 2
 
-        assert self.obama.get_due('TheEnterprise') == D('4.00')
+        assert self.obama.get_due(Enterprise) == D('4.00')
 
     @mock.patch.object(Payday, 'fetch_card_holds')
     def test_payday_does_not_move_money_below_min_charge(self, fch):
@@ -135,7 +135,7 @@ class TestPayday(BillingHarness):
 
         assert picard.balance == D('0.00')
         assert obama.balance == D('0.00')
-        assert obama.get_due('TheEnterprise') == D('6.00')
+        assert obama.get_due(Enterprise) == D('6.00')
 
 
     @mock.patch.object(Payday, 'fetch_card_holds')

--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -171,16 +171,16 @@ class TestPages(Harness):
         assert expected in actual
 
     def test_giving_page(self):
-        self.make_team(is_approved=True)
+        Enterprise = self.make_team(is_approved=True)
         alice = self.make_participant('alice', claimed_time='now')
-        alice.set_payment_instruction('TheEnterprise', "1.00")
+        alice.set_payment_instruction(Enterprise, "1.00")
         assert "The Enterprise" in self.client.GET("/~alice/giving/", auth_as="alice").body
 
     def test_giving_page_shows_cancelled(self):
-        self.make_team(is_approved=True)
+        Enterprise = self.make_team(is_approved=True)
         alice = self.make_participant('alice', claimed_time='now')
-        alice.set_payment_instruction('TheEnterprise', "1.00")
-        alice.set_payment_instruction('TheEnterprise', "0.00")
+        alice.set_payment_instruction(Enterprise, "1.00")
+        alice.set_payment_instruction(Enterprise, "0.00")
         assert "Cancelled" in self.client.GET("/~alice/giving/", auth_as="alice").body
 
     def test_new_participant_can_edit_profile(self):

--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -235,3 +235,8 @@ class TestPages(Harness):
     def test_dashboard_barely_works(self):
         self.make_participant('admin', is_admin=True)
         assert 'Unreviewed Accounts' in self.client.GET('/dashboard/', auth_as='admin').body
+
+    def test_your_payment_template_basically_works(self):
+        self.make_team(is_approved=True)
+        self.make_participant('alice')
+        assert 'your-payment' in self.client.GET('/TheEnterprise/', auth_as='alice').body

--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -16,7 +16,6 @@ from gratipay.exceptions import (
     UsernameAlreadyTaken,
     UsernameContainsInvalidCharacters,
     UsernameIsRestricted,
-    NoTeam,
     BadAmount,
 )
 from gratipay.models.account_elsewhere import AccountElsewhere
@@ -471,10 +470,6 @@ class Tests(Harness):
         alice = self.make_participant('alice', claimed_time='now', last_bill_result='')
         team = self.make_team()
         self.assertRaises(BadAmount, alice.set_payment_instruction, team, '-0.01')
-
-    def test_spi_fails_to_set_a_payment_instruction_to_an_unknown_team(self):
-        alice = self.make_participant('alice', claimed_time='now', last_bill_result='')
-        self.assertRaises(NoTeam, alice.set_payment_instruction, 'The Stargazer', '1.00')
 
     def test_spi_is_free_rider_defaults_to_none(self):
         alice = self.make_participant('alice', claimed_time='now', last_bill_result='')

--- a/www/about/pricing.spt
+++ b/www/about/pricing.spt
@@ -1,7 +1,10 @@
 # encoding=utf8
+from gratipay.models.team import Team
 [---]
 banner = _("About")
 title = _("Pricing")
+
+Gratipay = Team.from_slug('Gratipay')
 [---] text/html
 {% extends "templates/about-basic-info.html" %}
 {% block content %}
@@ -32,7 +35,7 @@ href="http://en.wikipedia.org/wiki/Pay_what_you_want">pay-what-you-want</a>.&rdq
 
 {% if not user.ANON %}
     {% set p = user.participant %}
-    {% set payment = p.get_payment_instruction('Gratipay')['amount'] %}
+    {% set payment = p.get_payment_instruction(Gratipay)['amount'] %}
 
     <div class="payment">
     {% if payment > 0 %}


### PR DESCRIPTION
This simplifies three APIs that previously accepted *either* a Team object *or* a slug. They now only accept a Team object. The reason is that the additional flexibility wasn't adding much value for the additional complexity. 

Salvaged from #4046.

 - [ ] rebase after #4060 lands