### PR TITLE
third step of 835 for payment_instructions

### DIFF
--- a/gratipay/models/participant/__init__.py
+++ b/gratipay/models/participant/__init__.py
@@ -839,7 +839,7 @@ class Participant(Model, mixins.Identity):
         NEW_PAYMENT_INSTRUCTION = """\
 
             INSERT INTO payment_instructions
-                        (ctime, participant, participant_id, team, team_id, amount)
+                        (ctime, participant_id, team_id, amount)
                  VALUES ( COALESCE (( SELECT ctime
                                         FROM payment_instructions
                                        WHERE (   participant_id=%(participant_id)s
@@ -847,13 +847,12 @@ class Participant(Model, mixins.Identity):
                                               )
                                        LIMIT 1
                                       ), CURRENT_TIMESTAMP)
-                        , %(participant)s, %(participant_id)s, %(team)s, %(team_id)s, %(amount)s
+                        , %(participant_id)s, %(team_id)s, %(amount)s
                          )
               RETURNING *
 
         """
-        args = dict(participant=self.username, participant_id=self.id, team=team.slug,
-                                                                    team_id=team.id, amount=amount)
+        args = dict(participant_id=self.id, team_id=team.id, amount=amount)
         t = (cursor or self.db).one(NEW_PAYMENT_INSTRUCTION, args)
         t_dict = t._asdict()
 

--- a/gratipay/models/team.py
+++ b/gratipay/models/team.py
@@ -329,13 +329,10 @@ class Team(Model):
         WITH rows AS (
 
             INSERT INTO payment_instructions
-                        (ctime, mtime, participant, participant_id, team, team_id, amount,
-                                                                                         is_funded)
+                        (ctime, mtime, participant_id, team_id, amount, is_funded)
                  SELECT ct.ctime
                       , ct.mtime
-                      , ct.tipper
                       , (SELECT id FROM participants WHERE username=ct.tipper)
-                      , %(slug)s
                       , %(team_id)s
                       , ct.amount
                       , ct.is_funded
@@ -348,7 +345,7 @@ class Team(Model):
               RETURNING 1
 
         ) SELECT count(*) FROM rows;
-        """, {'slug': self.slug, 'team_id': self.id, 'owner': self.owner})
+        """, {'team_id': self.id, 'owner': self.owner})
 
 
     # Images

--- a/gratipay/utils/fake_data.py
+++ b/gratipay/utils/fake_data.py
@@ -154,9 +154,7 @@ def fake_payment_instruction(db, participant, team):
                            , "payment_instructions"
                            , ctime=faker.date_time_this_year()
                            , mtime=faker.date_time_this_month()
-                           , participant=participant.username
                            , participant_id=participant.id
-                           , team=team.slug
                            , team_id=team.id
                            , amount=fake_tip_amount()
                             )

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+    DROP VIEW current_payment_instructions;
+
+    ALTER TABLE payment_instructions DROP COLUMN participant;
+    ALTER TABLE payment_instructions DROP COLUMN team;
+
+    CREATE VIEW current_payment_instructions AS
+        SELECT DISTINCT ON (participant_id, team_id) *
+          FROM payment_instructions
+      ORDER BY participant_id, team_id, mtime DESC;
+
+    CREATE TRIGGER update_current_payment_instruction
+        INSTEAD OF UPDATE ON current_payment_instructions
+        FOR EACH ROW EXECUTE PROCEDURE update_payment_instruction();
+
+END;

--- a/tests/py/test_tip_migration.py
+++ b/tests/py/test_tip_migration.py
@@ -34,14 +34,10 @@ class Tests(Harness):
         payment_instructions = self.db.all("SELECT * FROM payment_instructions "
                                            "ORDER BY participant_id ASC")
         assert len(payment_instructions) == 2
-        assert payment_instructions[0].participant == 'alice'
         assert payment_instructions[0].participant_id == self.alice.id
-        assert payment_instructions[0].team == 'new_team'
         assert payment_instructions[0].team_id == self.new_team.id
         assert payment_instructions[0].amount == 1
-        assert payment_instructions[1].participant == 'bob'
         assert payment_instructions[1].participant_id == self.bob.id
-        assert payment_instructions[1].team == 'new_team'
         assert payment_instructions[1].team_id == self.new_team.id
         assert payment_instructions[1].amount == 2
 


### PR DESCRIPTION
Drops the old non-id columns.

- [x] rebase once #4061 lands