### PR TITLE
update some python APIs

### DIFF
--- a/gratipay/models/participant/__init__.py
+++ b/gratipay/models/participant/__init__.py
@@ -1091,7 +1091,7 @@ class Participant(Model, mixins.Identity):
         """Given a Team object, return a boolean.
         """
         for take in team.get_current_takes():
-            if take['member'] == self.username:
+            if take['participant'] == self:
                 return True
         return False
 

--- a/gratipay/models/team/mixins/takes.py
+++ b/gratipay/models/team/mixins/takes.py
@@ -202,7 +202,7 @@ class TakesMixin(object):
         for take in nominal_takes:
             nominal_amount = take['nominal_amount'] = take.pop('amount')
             actual_amount = take['actual_amount'] = min(nominal_amount, balance)
-            take['balance'] = balance
+            take['balance'] = balance = balance - actual_amount
             take['percentage'] = actual_amount / available
             actual_takes[take['participant'].id] = take
         return actual_takes

--- a/gratipay/models/team/mixins/takes.py
+++ b/gratipay/models/team/mixins/takes.py
@@ -91,9 +91,8 @@ class TakesMixin(object):
             # Compute the current takes
             old_takes = self.compute_actual_takes(cursor)
 
-            old_take = self.get_take_for(participant, cursor=cursor)
             if recorder.username != self.owner:
-                if recorder == participant and not old_take:
+                if recorder == participant and participant.id not in old_takes:
                     raise NotAllowed('can only set take if already a member of the team')
 
             cursor.one( """

--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -718,3 +718,25 @@ class Tests(Harness):
     def test_suggested_payment_is_zero_for_new_user(self):
         alice = self.make_participant('alice')
         assert alice.suggested_payment == 0
+
+
+    # mo - member_of
+
+    def test_mo_indicates_membership(self):
+        enterprise = self.make_team(available=50)
+        alice = self.make_participant( 'alice'
+                                     , email_address='alice@example.com'
+                                     , verified_in='TT'
+                                     , claimed_time='now'
+                                      )
+        picard = Participant.from_username('picard')
+        enterprise.add_member(alice, picard)
+        assert alice.member_of(enterprise)
+
+    def test_mo_indicates_non_membership(self):
+        enterprise = self.make_team()
+        assert not self.make_participant('alice').member_of(enterprise)
+
+    def test_mo_is_false_for_owners(self):
+        enterprise = self.make_team()
+        assert not Participant.from_username('picard').member_of(enterprise)

--- a/tests/py/test_team_takes.py
+++ b/tests/py/test_team_takes.py
@@ -54,21 +54,23 @@ class Tests(TeamTakesHarness):
 
     # stf - set_take_for
 
-    def test_stf_sets_take_for_new_member(self):
-        self.enterprise.set_take_for(self.crusher, PENNY, self.picard)
-        assert self.enterprise.get_take_for(self.crusher) == PENNY
+    def test_stf_sets_take_for(self):
+        assert self.enterprise.set_take_for(self.crusher, PENNY, self.picard) == PENNY
 
     def test_stf_updates_take_for_an_existing_member(self):
         self.enterprise.set_take_for(self.crusher, PENNY, self.picard)
-        self.enterprise.set_take_for(self.crusher, 537, self.crusher)
-        assert self.enterprise.get_take_for(self.crusher) == 537
+        assert self.enterprise.set_take_for(self.crusher, 537, self.crusher) == 537
 
-    def test_stf_calls_update_taking(self):
+    def test_stf_actually_sets_take(self):
+        self.enterprise.set_take_for(self.crusher, PENNY, self.picard)
+        assert self.enterprise.get_take_for(self.crusher) == PENNY
+
+    def test_stf_updates_taking(self):
         assert self.crusher.taking == ZERO
         self.enterprise.set_take_for(self.crusher, PENNY, self.picard)
         assert self.crusher.taking == PENNY
 
-    def test_stf_calls_update_distributing(self):
+    def test_stf_updates_distributing(self):
         assert self.enterprise.ndistributing_to == 0
         assert self.enterprise.distributing == ZERO
         self.enterprise.set_take_for(self.crusher, PENNY, self.picard)

--- a/tests/py/test_team_takes.py
+++ b/tests/py/test_team_takes.py
@@ -185,16 +185,17 @@ class Tests(TeamTakesHarness):
         self.enterprise.set_take_for(self.crusher, PENNY * 80, self.crusher)
         self.enterprise.set_take_for(self.bruiser, PENNY, self.picard)
         self.enterprise.set_take_for(self.bruiser, PENNY * 30, self.bruiser)
+
         takes = self.enterprise.compute_actual_takes()
 
         assert tuple(takes) == (self.bruiser.id, self.crusher.id)
 
-        takes[self.bruiser.id]['actual_amount'] = PENNY * 30
-        takes[self.bruiser.id]['nominal_amount'] = PENNY * 30
-        takes[self.bruiser.id]['balance'] = PENNY * 70
-        takes[self.bruiser.id]['percentage'] = D('0.3')
+        assert takes[self.bruiser.id]['actual_amount'] == PENNY * 30
+        assert takes[self.bruiser.id]['nominal_amount'] == PENNY * 30
+        assert takes[self.bruiser.id]['balance'] == PENNY * 70
+        assert takes[self.bruiser.id]['percentage'] == D('0.3')
 
-        takes[self.crusher.id]['actual_amount'] = PENNY * 70
-        takes[self.crusher.id]['nominal_amount'] = PENNY * 80
-        takes[self.crusher.id]['balance'] = ZERO
-        takes[self.crusher.id]['percentage'] = D('0.7')
+        assert takes[self.crusher.id]['actual_amount'] == PENNY * 70
+        assert takes[self.crusher.id]['nominal_amount'] == PENNY * 80
+        assert takes[self.crusher.id]['balance'] == ZERO
+        assert takes[self.crusher.id]['percentage'] == D('0.7')


### PR DESCRIPTION
&#x2B11; #3994

&larr; #4094 ([diff](https://github.com/gratipay/gratipay.com/compare/require-docs...update-some-python-APIs)) — #4077 &rarr;

This fixes a few bugs and warts with Python APIs that we want to use in bringing back the takes UI.

- [x] rebase once #4094 lands
- [x] make Travis builds for each commit (or use [this hack](https://github.com/AspenWeb/aspen.py/pull/14#issuecomment-233931932)).