### PR TITLE
Fix usernames restriction

### DIFF
--- a/gratipay/models/participant/__init__.py
+++ b/gratipay/models/participant/__init__.py
@@ -1137,8 +1137,8 @@ class Participant(Model, mixins.Identity):
 
         # Don't allow any username which is the name of a
         # file existing on the web_root folder.
-        for ext in ['', '.spt', '.ico', '.txt', '.osdd']:
-            if (lowercased + ext) in gratipay.RESTRICTED_USERNAMES:
+        for name in (lowercased, lowercased + '.spt'):
+            if name in gratipay.RESTRICTED_USERNAMES:
                 raise UsernameIsRestricted(suggested)
 
         if suggested != self.username:

--- a/gratipay/models/participant/__init__.py
+++ b/gratipay/models/participant/__init__.py
@@ -1135,8 +1135,11 @@ class Participant(Model, mixins.Identity):
 
         lowercased = suggested.lower()
 
-        if lowercased in gratipay.RESTRICTED_USERNAMES:
-            raise UsernameIsRestricted(suggested)
+        # Don't allow any username which is the name of a
+        # file existing on the web_root folder.
+        for ext in ['', '.spt', '.ico', '.txt', '.osdd']:
+            if (lowercased + ext) in gratipay.RESTRICTED_USERNAMES:
+                raise UsernameIsRestricted(suggested)
 
         if suggested != self.username:
             try:

--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, unicode_literals
 
 import datetime
+import os
 import random
 
 import mock
@@ -358,7 +359,7 @@ class TestParticipant(Harness):
 class Tests(Harness):
 
     def random_restricted_username(self):
-        """helper method to chooses a restricted username for testing """
+        """Helper method to chooses a restricted username for testing"""
         from gratipay import RESTRICTED_USERNAMES
         random_item = random.choice(RESTRICTED_USERNAMES)
         while any(map(random_item.startswith, ('%', '~'))):
@@ -418,9 +419,10 @@ class Tests(Harness):
             self.participant.change_username(u"\u2603") # Snowman
 
     def test_changing_username_to_restricted_name(self):
+        username = self.random_restricted_username()
         with self.assertRaises(UsernameIsRestricted):
-            self.participant.change_username(self.random_restricted_username())
-
+            self.participant.change_username(username)
+        assert os.path.exists(self.client.www_root + '/' + username)
 
     # id
 

--- a/tests/py/test_username_json.py
+++ b/tests/py/test_username_json.py
@@ -45,6 +45,30 @@ class Tests(Harness):
         assert code == 400
         assert body['error_message_long'] == "The username '1.0-payout' is restricted."
 
+    def test_robots_txt_is_not_an_available_username(self):
+        code, body = self.change_username("robots.txt")
+        assert code == 400
+        assert body['error_message_long'] == "The username 'robots.txt' is restricted."
+
+    def test_but_robots_txt_is_still_available_when_theres_a_robots_username(self):
+        self.make_participant('robots', claimed_time='now')
+
+        # manually follow redirects from /robots -> /~robots/
+        response = self.client.GxT("/robots")
+        assert response.code == 302
+        assert response.headers['Location'] == '/robots/'
+        response = self.client.GxT("/robots/")
+        assert response.code == 302
+        assert response.headers['Location'] == '/~robots/'
+        response = self.client.GET("/~robots/")
+        assert response.code == 200
+        assert '<h1>~robots</h1>' in response.body
+
+        # /robots.txt
+        response = self.client.GET("/robots.txt")
+        assert response.code == 200
+        assert response.body == 'User-agent: *\nDisallow: /*.json\nDisallow: /on/*\n'
+
     def test_unavailable(self):
         self.make_participant("bob")
         code, body = self.change_username("bob")

--- a/tests/py/test_username_json.py
+++ b/tests/py/test_username_json.py
@@ -35,10 +35,15 @@ class Tests(Harness):
         assert code == 400
         assert body['error_message_long'] == "The username '§' contains invalid characters."
 
-    def test_restricted_username(self):
+    def test_restricted_username_without_extension(self):
         code, body = self.change_username("assets")
         assert code == 400
         assert body['error_message_long'] == "The username 'assets' is restricted."
+
+    def test_restricted_username_with_extension(self):
+        code, body = self.change_username("1.0-payout")
+        assert code == 400
+        assert body['error_message_long'] == "The username '1.0-payout' is restricted."
 
     def test_unavailable(self):
         self.make_participant("bob")


### PR DESCRIPTION
This aims to fix [H1-128121](https://hackerone.com/reports/128121). 

We're currently listing all the existing files inside `www_root` and comparing the username to each file/folder to ensure an user won't try to use it. However, there is a mapping between the files and the website route (`lookup.json.spt` is served as`lookup.json`), so the comparison is little bit more complicated.

I'm just adding a list of forbidden extensions, and it will to to match the list of files with `username`, `username.txt`, ... It won't really affect performances since it's only called when creating an account or changing the username. I would really know if somebody has a more elegant way to do it 🐱 