### PR TITLE
Limit user statement size

### DIFF
--- a/tests/py/test_statement_json.py
+++ b/tests/py/test_statement_json.py
@@ -30,3 +30,9 @@ class Tests(Harness):
                                         , expecting_error=True
                                          )
         assert response.code == 403, response.code
+
+    def test_participant_cannot_change_their_statement_if_too_big(self):
+        too_big_statement = 'A' * ((256 * 1024) + 1)
+        response = self.change_statement('en', too_big_statement, expecting_error=True)
+        assert response.code == 400
+        assert response.body == 'Statement too big!'

--- a/www/~/%username/statement.json.spt
+++ b/www/~/%username/statement.json.spt
@@ -17,7 +17,7 @@ if request.method == 'POST':
 
     # Statements are limited to 256kB to avoid DoS'ing the markdown parser.
     if len(content) > (256 * 1024):
-        raise Response(400, "Statement too big!")
+        raise Response(400, _("Statement too big!"))
 
     participant.upsert_statement(lang, content)
     r = {"html": markdown.render(content)}

--- a/www/~/%username/statement.json.spt
+++ b/www/~/%username/statement.json.spt
@@ -15,6 +15,10 @@ if request.method == 'POST':
     if lang not in LANGUAGES_2:
         raise Response(400, "unknown lang")
 
+    # Statements are limited to 256kB to avoid DoS'ing the markdown parser.
+    if len(content) > (256 * 1024):
+        raise Response(400, "Statement too big!")
+
     participant.upsert_statement(lang, content)
     r = {"html": markdown.render(content)}
 


### PR DESCRIPTION
This aims to close [H1-127824](https://hackerone.com/reports/127824). When parsing very large user statements, the markdown parser may take too much resources. We are already safe against nested elements attacks.

**Questions**: 
- should we restrict the "product or project" field for teams? The teams are manually reviewed and they don't have any interest in voluntarily slowing down the display of their pages.
- should we add one hard limit on the database field? It's hard to predict, since we (want to) restrict the size before the md-to-html translation process.