### PR TITLE
Edit TOS to decouple payins and payouts

### DIFF
--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -41,11 +41,11 @@ these Terms.
      ("Work").
 
   1. A Participant may establish a Project on the Service. The Participant who
-     establishes a Project is the "Project Owner". Projects may optionally have
-other Participants as "Project Members."
+     establishes a Project is the Project Owner. Projects may optionally have
+other Participants as Project Members.
 
   1. A Participant may give money to a Project. A Participant who gives money
-     to a Project is a "Giver."
+     to a Project is a Giver.
 
 1.  Obligations of Project Owners
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -42,7 +42,7 @@ these Terms.
 
   1. A Participant may establish a Project on the Service. The Participant who
      establishes a Project is the Project Owner. Projects may optionally have
-other Participants as Project Members.
+other Participants as Collaborators.
 
   1. A Participant may give money to a Project. A Participant who gives money
      to a Project is a Giver.
@@ -55,7 +55,7 @@ the Service, you agree that payments will be used exclusively to support the
 Project Work described in your Project's profile.
 
   1. By accepting a payment from a Giver, the Project forms an agreement with
-     that Giver to perform the Project Work.  The Service is a platform to
+     that Giver to perform the Project Work. The Service is a platform to
 facilitate this agreement. Gratipay is not a party to the agreement, and is not
 responsible to either the Project or the Giver if either party breaches the
 terms of the agreement (e.g. if the Project fails to provide the promised
@@ -78,24 +78,24 @@ opportunity to publicly evaluate and provide commentary about the Project.
 However, all decisions regarding whether to accept, reject, suspend, remove, or
 take any other action regarding a Project belong solely to Gratipay.
 
-1.  Obligations of Project Members
+1.  Obligations of Collaborators
 
-  1. Projects can use the Service to distribute payments to Project Members.
+  1. Projects can use the Service to distribute payments to Collaborators.
 
-  1. When you become a Project Member, you agree that payments to you by the
+  1. When you become a Collaborator, you agree that payments to you by the
      Project are made exclusively because of your contribution ("Project
 Tasks") to the Project Work decribed in the Project's profile.
 
-  1. By accepting a payment from a Project, the Project Member forms an
-     agreement with that Project to contribute to the Project Work described in
-the Project's profile.  The Service is a platform to facilitate this agreement.
+  1. By accepting a payment from a Project, the Collaborator forms an agreement
+     with that Project to contribute to the Project Work described in the
+Project's profile.  The Service is a platform to facilitate this agreement.
 Gratipay is not a party to the agreement, and is not responsible to either the
-Project or the Project Member if either party breaches the terms of the
-agreement (e.g. if the Project Member fails to provide the promised services).
+Project or the Collaborator if either party breaches the terms of the agreement
+(e.g. if the Collaborator fails to provide the promised services).
 
   1. Gratipay does not determine how payments are allocated and is not
      responsible for how Projects internally distribute payments. The agreement
-between the Project's Owner and Project Members regarding the allocation of
+between the Project's Owner and Collaborators regarding the allocation of
 payments is solely between those parties.
 
 1.  Obligations of Givers
@@ -112,11 +112,11 @@ Projects will provide the work they promise.
 
 1. Fees and Taxes
 
-  1. Gratipay does not take any fee from payments made by Givers to
-     Projects, or by Projects to Project Members. Gratipay and the Service are funded
-through the Service itself, by voluntary payments from Givers
-who wish to fund our own Work. To contribute to Gratipay, please [visit
-Gratipay's Project page](/Gratipay/).
+  1. Gratipay does not take any fee from payments made by Givers to Projects,
+     or by Projects to Collaborators. Gratipay and the Service are funded
+through the Service itself, by voluntary payments from Givers who wish to fund
+our own Work. To contribute to Gratipay, please [visit Gratipay's Project
+page](/Gratipay/).
 
   1. You are responsible for paying any third-party fees associated with your
      use of the Service, such as credit card and bank fees.
@@ -124,12 +124,12 @@ Gratipay's Project page](/Gratipay/).
   1. You are responsible for paying any taxes and withholdings associated with
      your use of the Service. In particular, Project Owners, and not Gratipay,
 are responsible for compliance with all laws, as well as any taxes and
-withholding requirements, applicable to payments made to Project Members
-(whether through the Service or otherwise), including without limitation
-payroll tax, unemployment insurance, and worker compensation insurance
-payments. Project Owners are also responsible for providing any required tax
-and other documentation to employees, independent contractors, tax authorities,
-or any other person.
+withholding requirements, applicable to payments made to Collaborators (whether
+through the Service or otherwise), including without limitation payroll tax,
+unemployment insurance, and worker compensation insurance payments. Project
+Owners are also responsible for providing any required tax and other
+documentation to employees, independent contractors, tax authorities, or any
+other person.
 
 1. Content Accessible on the Service
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -56,6 +56,8 @@ these Terms.
 on the Service, you agree that payments via the Project will be used
 exclusively to support the Work described in the Project's profile.
 
+  1. Project Owners may only make payments to a Collaborator for their contributions.
+
   1. Gratipay is not a party to any agreement between Project Owners and
      Givers, and is not responsible to either the Project Owner or the Giver if
 either party breaches the terms of any such agreement (e.g. if the Project
@@ -79,9 +81,8 @@ take any other action regarding a Project belong solely to Gratipay.
   1. Project Owners can use the Service to distribute payments to
      Collaborators.
 
-  1. When you become a Collaborator, you agree that payments to you by the
-     Project Owner are made exclusively because of your collaboration in the
-Work described in the Project's profile.
+  1. Collaborators can receive payments from Project Owners because of their 
+     collaboration in the Project's Work and for no other reason.
 
   1. Gratipay is not a party to any agreement between Project Owners and
      Collaborators, and is not responsible to either the Project Owner or the
@@ -101,10 +102,11 @@ acknowledge that your payment does not entitle you personally to receive any
 goods or services from the Project Owner, unless the Project Owner explicitly
 offers those things to Givers.
 
-  1. Gratipay is not obligated to provide refunds under any circumstance.
-     Project Owners are responsible for producing the Work they offer. Gratipay
-does not hold funds on behalf of Project Owners, and does not warrant or
-guarantee that Project Owners will provide the Work they promise.
+  1. Project Owners are the only party responsible to Givers for producing the 
+     Work their Project describes. Gratipay is not obligated to provide refunds 
+to Givers or produce work under any circumstance. Gratipay does not hold funds 
+on behalf of Project Owners, and does not warrant or guarantee that Project Owners 
+will provide the Work they promise.
 
 1. Fees and Taxes
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -18,22 +18,22 @@ legal@gratipay.com
 
   1. When you register for the Service, you agree to provide Gratipay with
      complete and accurate registration information. You are responsible for
-keeping your account information, including your contact and payment
-information, up to date. Gratipay takes our Participants' privacy seriously. We
-will only use or share your information and Content as described in our
-[Privacy Policy](/about/policies/privacy), which is incorporated into these
-Terms.
+    keeping your account information, including your contact and payment
+    information, up to date. Gratipay takes our Participants' privacy seriously. We
+    will only use or share your information and Content as described in our
+    [Privacy Policy](/about/policies/privacy), which is incorporated into these
+    Terms.
 
   1. You are responsible for maintaining the security of your account
      information, including your authentication credentials. You agree to
-notify Gratipay immediately of any actual or suspected loss, theft, or
-unauthorized use of your credentials. Gratipay shall not be liable for any loss
-or damage arising from your failure to keep your account secure.
+    notify Gratipay immediately of any actual or suspected loss, theft, or
+    unauthorized use of your credentials. Gratipay shall not be liable for any loss
+    or damage arising from your failure to keep your account secure.
 
   1. You may only use the Service if you are 13 years old or older, and you
      represent to us that you are 13 or older. If you are under the age of 18,
-your legal guardian must consent to your use and must agree to be bound by
-these Terms.
+    your legal guardian must consent to your use and must agree to be bound by
+    these Terms.
 
 1. General Rules
 
@@ -42,66 +42,60 @@ these Terms.
 
   1. A Participant may establish a Project on the Service. The Participant who
      establishes a Project is the "Project Owner". Projects may optionally have other
-Participants as "Project Members."
+    Participants as "Project Members."
 
   1. A Participant may give money to a Project. A Participant who gives money to a Project is a "Giver."
 
 1.  Obligations of Project Owners
 
-  1. A Project may receive payments from Givers for Work provided by the
+  1. A Project can use the Service to receive payments from Givers for Work provided by the
      Project ("Project Work"). When you establish a Project on the Service, you agree that
-payments will be used exclusively to support the Project Work described in your
-Project's profile.
-
-  1. Projects can use the Service to receive payments from Givers.
+    payments will be used exclusively to support the Project Work described in your
+    Project's profile.
 
   1. By accepting a payment from a Giver, the Project forms an agreement
      with that Giver to perform the Project Work. 
      The Service is a platform to facilitate this agreement. Gratipay is
-not a party to the agreement, and is not responsible to either the Project or
-the Giver if either party breaches the terms of the agreement (e.g. if
-the Project fails to provide the promised services).
+    not a party to the agreement, and is not responsible to either the Project or
+    the Giver if either party breaches the terms of the agreement (e.g. if
+    the Project fails to provide the promised services).
 
   1. A Project can only begin receiving payments from Givers once the
      Project Owner has provided a working withdrawal mechanism for receiving payments
-(e.g. bank account information).
+    (e.g. bank account information).
 
   1. Projects and Project Work must be consistent with Gratipay's [Brand
      Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
-Use Policy.
+    Use Policy. 
 
   1. Gratipay reserves the right to reject, suspend, or remove a Project at any
      time, and for any reason.
 
   1. Establishing a Project on Gratipay involves an application and approval
      process. As part of this process, the Gratipay community will have the
-opportunity to publicly evaluate and provide commentary about the Project.
-However, all decisions regarding whether to accept, reject, suspend, remove, or
-take any other action regarding a Project belong solely to Gratipay.
+     opportunity to publicly evaluate and provide commentary about the Project.
+     However, all decisions regarding whether to accept, reject, suspend, remove, or
+     take any other action regarding a Project belong solely to Gratipay.
 
 1.  Obligations of Project Members
 
   1. Projects can use the Service to distribute payments to Project Members.
 
-  1. When you receive a payment from a Project, it is a payment to fund the
-     Project Tasks you contribute to the Project.
-     
-       1. When you become a Project Member, you agree
-that payments to you by the Project are made exclusively because of your
-contribution ("Project Tasks") to the Project Work decribed in the Project's profile. A Project may make 
-payments to its Project Members for Project Tasks performed by the Project Members. 
+  1. When you become a Project Member, you agree that payments to you by the 
+  Project are made exclusively because of your contribution ("Project Tasks") 
+  to the Project Work decribed in the Project's profile. 
 
   1. By accepting a payment from a Project, the Project Member forms an agreement with
      that Project to contribute to the Project Work described in the Project's profile.
-The Service is a platform to facilitate this agreement. Gratipay is not a party
-to the agreement, and is not responsible to either the Project or the Project Member if
-either party breaches the terms of the agreement (e.g. if the Project Member fails to
-provide the promised services).
+     The Service is a platform to facilitate this agreement. Gratipay is not a party
+     to the agreement, and is not responsible to either the Project or the Project Member if
+     either party breaches the terms of the agreement (e.g. if the Project Member fails to
+     provide the promised services).
 
   1. Gratipay does not determine how payments are allocated and is not
      responsible for how Projects internally distribute payments. The agreement
-between the Project's Owner and Project Members regarding the allocation of
-payments is solely between those parties.
+     between the Project's Owner and Project Members regarding the allocation of
+     payments is solely between those parties.
 
 1.  Obligations of Givers
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -38,8 +38,10 @@ these Terms.
 1. General Terms
 
   1. A Participant may establish a Project on the Service. The Participant who
-     establishes a Project is the Project Owner. Projects may optionally have
-other Participants as Collaborators. The Project Owner is also a Collaborator.
+     establishes a Project is the Project Owner.
+
+  1. Projects may optionally have other Participants as Collaborators. The
+     Project Owner is also a Collaborator.
 
   1. A Participant may make payments to a Project Owner via a Project. A
      Participant who makes payments via a Project is a Giver.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -37,24 +37,28 @@ these Terms.
 
 1. General Rules
 
-  1. The Service is a platform to facilitate payments for goods or services
-     ("Work").
-
   1. A Participant may establish a Project on the Service. The Participant who
      establishes a Project is the Project Owner. Projects may optionally have
 other Participants as Collaborators.
 
-  1. A Participant may give money to a Project. A Participant who gives money
+  1. A Participant may give payments to a Project. A Participant who gives payments
      to a Project is a Giver.
+     
+  1. Projects and their Work must be consistent with Gratipay's [Brand
+     Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
+Use Policy.
 
-1. Obligations of Project Owners
+  1. Gratipay reserves the right to reject, suspend, or remove a Project at any
+     time, and for any reason.
+
+1. Terms for Project Owners
 
   1. A Project can use the Service to receive payments from Givers for Work
      provided by the Project. When you establish a Project on the Service, you
 agree that payments will be used exclusively to support the Work described in
 your Project's profile.
 
-  1. By accepting a payment from a Giver, the Project forms an agreement with
+  1. By accepting a payment from a Giver, the Project Owner forms an agreement with
      that Giver to provide the Project's Work. The Service is a platform to
 facilitate this agreement. Gratipay is not a party to the agreement, and is not
 responsible to either the Project or the Giver if either party breaches the
@@ -65,20 +69,13 @@ or services).
      Owner has provided a working withdrawal mechanism for receiving payments
 (e.g. bank account information).
 
-  1. Projects and their Work must be consistent with Gratipay's [Brand
-     Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
-Use Policy.
-
-  1. Gratipay reserves the right to reject, suspend, or remove a Project at any
-     time, and for any reason.
-
   1. Establishing a Project on Gratipay involves an application and approval
      process. As part of this process, the Gratipay community will have the
 opportunity to publicly evaluate and provide commentary about the Project.
 However, all decisions regarding whether to accept, reject, suspend, remove, or
 take any other action regarding a Project belong solely to Gratipay.
 
-1. Obligations of Collaborators
+1. Terms for Collaborators
 
   1. Projects can use the Service to distribute payments to Collaborators.
 
@@ -98,7 +95,7 @@ the Collaborator fails to provide the promised goods or services).
 between the Project's Owner and Collaborators regarding the allocation of
 payments is solely between those parties.
 
-1. Obligations of Givers
+1. Terms for Givers
 
   1. When you make a payment to a Project, it is a payment to fund the Work
      described in the Project's profile. You understand and acknowledge that

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -38,7 +38,7 @@ these Terms.
 1. General Terms
 
   1. The Service is a platform to facilitate payments for goods or services
-     ("Work").
+     ("Work"). The scope of Work is defined by Projects.
 
   1. A Participant may establish a Project on the Service. A Participant who 
      establishes a Project is also a Project Owner.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -63,15 +63,15 @@ provide the promised services).
 hold funds on behalf of Teams, and does not warrant or guarantee that Teams
 will provide the work they promise.
 
-1. Take-What-You-Want Payout Rules
+1. Payout Rules
 
-  1. Teams can use the Service's Take-What-You-Want Payouts feature to automatically divide
+  1. Teams can use the Service's Payouts feature to automatically divide
      incoming payments among Team Members, according to the allocation set by
 the Owner and/or Members.
 
-  1. Gratipay does not determine how a Team's Take-What-You-Want Payouts are allocated and is not
+  1. Gratipay does not determine how a Payouts are allocated and is not
      responsible for how Teams internally distribute payments. The agreement
-between Team Members and Owners regarding the allocation of payouts is solely
+between Team Members and Owners regarding the allocation of Payouts is solely
 between those parties.
 
 1. Rules for Gratipay Teams
@@ -109,8 +109,8 @@ page](/Gratipay/).
   1. You are responsible for paying any taxes and withholdings associated with
      your use of the Service. Team Owners, and not Gratipay, are responsible
 for compliance with all laws, as well as any taxes and withholding
-requirements, applicable to payouts made to Team Members (whether through the
-Take-What-You-Want Payout feature or otherwise), including without limitation payroll tax,
+requirements, applicable to Payouts made to Team Members (whether through the
+Payouts feature or otherwise), including without limitation payroll tax,
 unemployment insurance, and worker compensation insurance payments. Team Owners
 are also responsible for providing any required tax and other documentation to
 employees, independent contractors, tax authorities, or any other person.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -37,8 +37,9 @@ these Terms.
 
 1. General Terms
 
-  1. The Service is a platform to facilitate payments for goods or services
-     ("Work"). The scope of Work is defined by Projects.
+  1. The Service is a platform to facilitate payments for goods or services. 
+       The nature and scope of such goods or services (the "Work") is defined 
+by each Project.
 
   1. A Participant may establish a Project on the Service. A Participant who 
      establishes a Project is also a Project Owner.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -38,12 +38,7 @@ these Terms.
 1. The Gratipay Model and General Rules
 
   1. The Service is a platform to enable Teams of Gratipay Participants to
-     receive payments to fund **Open Work. Open Work means that the Team provides
-a clear path for any individual to voluntarily begin contributing to the Team's
-work and to share in any revenue the Team generates. Some examples of Teams
-performing Open Work include an open source software project that pays
-contributors, or a hackerspace that pays individuals to teach classes or manage
-its operations.**
+     receive payments to fund development of a product or service ("work").
 
   1. The Participant who establishes a Team is its Owner. Teams may optionally
      have other Members.
@@ -81,10 +76,7 @@ between those parties.
 
 1. Rules for Gratipay Teams
 
-  1. Teams may accept payments on the Service only for **Open Work, meaning that
-     they provide a clear path for any individual to voluntarily begin
-contributing to the Team's work, and to share in any revenue the Team
-generates.**
+  1. Teams may accept payments on the Service only for a defined product or service ("work").
 
   1. A Team can only begin receiving payments from Participants once it has
      provided a working withdrawal mechanism for receiving payments (e.g. bank
@@ -108,7 +100,7 @@ take any other action regarding a Team belong solely to Gratipay.
   1. Gratipay does not take any fee from payments made by Participants to
      Teams. Gratipay and the Service are funded through the Service itself, by
 voluntary contributions from Gratipay Participants and Teams who wish to fund
-our own **Open Work**. To contribute to Gratipay, please [visit Gratipay's Team
+our own [Open Work](http://www.opencompany.org/). To contribute to Gratipay, please [visit Gratipay's Team
 page](/Gratipay/).
 
   1. You are responsible for paying any third-party fees associated with your

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -238,7 +238,7 @@ agreement](https://www.braintreepayments.com/legal/bank-agreement-us).
 1. Nonprofits and Charities using Gratipay
 
   1. If you are a nonprofit organization, soliciting payments on Gratipay may
-     subject you to certain state laws regarding charitable solicitations,
+     subject you to local laws regarding charitable solicitations,
 including various registration, reporting, and audit requirements. You are
 solely responsible for compliance with these and any other applicable law or
 regulation.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -6,7 +6,7 @@ These Terms of Service ("Terms") are an agreement between you, a user
 Gratipay. When you register as a Gratipay Participant, you agree to be bound by
 these Terms.
 
-If you have any questions about these terms, please contact us:
+If you have any questions about these Terms, please contact us:
 
 Gratipay, LLC
 716 Park Road
@@ -35,85 +35,97 @@ or damage arising from your failure to keep your account secure.
 your legal guardian must consent to your use and must agree to be bound by
 these Terms.
 
-1. The Gratipay Model and General Rules
+1. General Rules
 
-  1. The Service is a platform to enable Teams of Gratipay Participants to
-     receive payments to fund development of a product or service ("work").
+  1. The Service is a platform to facilitate payments for goods or services
+     ("Work").
 
-  1. The Participant who establishes a Team is its Owner. Teams may optionally
-     have other Members.
+  1. A Participant may establish a Project on the Service. The Participant who
+     establishes a Project is its Owner. Projects may optionally have other
+Members. The Owner is also a Member.
 
-  1. When you establish a Team on the Service, you agree that payments will be 
-    used exclusively to support the work described in your Team's profile.
+  1. A Project may receive payments from Participants for Work provided by the
+     Project. When you establish a Project on the Service, you agree that
+payments will be used exclusively to support the Work described in your
+Project's profile.
 
-  1. When you make a payment to a Team, it is a payment to fund the work
-     the Team provides. You understand and acknowledge that your payment does
-not entitle you personally to receive any goods or services from the Team,
-unless the Team explicitly offers those things to Participants.
+  1. A Project may make payments to its Members for Work provided to the
+     Project by the Members. When you become a Member of a Project, you agree
+that payments to you by the Project are made exclusively because of your
+contribution to the Work decribed in the Project's profile.
 
-  1. By accepting a payment from a Participant, a Team forms an agreement with
-     that Participant to perform the work described in its profile. The
+1. Payments from Participants to Projects
+
+  1. Projects can use the Service to receive payments from Participants.
+
+  1. When you make a payment to a Project, it is a payment to fund the Work the
+     Project provides. You understand and acknowledge that your payment does
+not entitle you personally to receive any goods or services from the Project,
+unless the Project explicitly offers those things to Participants.
+
+  1. By accepting a payment from a Participant, the Project forms an agreement
+     with that Participant to perform the work described in its profile. The
 Service is a platform to facilitate this agreement. Gratipay is not a party to
-the agreement, and is not responsible to either the Team or the Participant if
-either party breaches the terms of the agreement (e.g. if the Team fails to
-provide the promised services).
+the agreement, and is not responsible to either the Project or the Participant
+if either party breaches the terms of the agreement (e.g. if the Project fails
+to provide the promised services).
 
-  1. Gratipay is not obligated to provide refunds under any circumstance. Teams
-     are responsible for producing the work they offer. Gratipay does not
-hold funds on behalf of Teams, and does not warrant or guarantee that Teams
-will provide the work they promise.
+  1. Gratipay is not obligated to provide refunds under any circumstance.
+     Projects are responsible for producing the work they offer. Gratipay does
+not hold funds on behalf of Projects, and does not warrant or guarantee that
+Projects will provide the work they promise.
 
-1. Payout Rules
+1. Payments from Projects to Members
 
-  1. Teams can use the Service's Payouts feature to automatically divide
-     incoming payments among Team Members, according to the allocation set by
-the Owner and/or Members.
+  1. Projects can use the Service to distribute payments to Project Members.
 
-  1. Gratipay does not determine how Payouts are allocated and is not
-     responsible for how Teams internally distribute payments. The agreement
-between Team Members and Owners regarding the allocation of Payouts is solely
-between those parties.
+  1. When a Project makes a payment to you, it is a payment to fund the Work
+     you contribute to the Project.
 
-1. Rules for Gratipay Teams
+  1. Gratipay does not determine how payments are allocated and is not
+     responsible for how Projects internally distribute payments. The agreement
+between the Project Owner and other Members regarding the allocation of
+payments is solely between those parties.
 
-  1. Teams may accept payments on the Service only for a defined product or service ("work").
+1. Additional Rules for Gratipay Projects
 
-  1. A Team can only begin receiving payments from Participants once it has
-     provided a working withdrawal mechanism for receiving payments (e.g. bank
-account information).
+  1. A Project can only begin receiving payments from Participants once the
+     Owner has provided a working withdrawal mechanism for receiving payments
+(e.g. bank account information).
 
-  1. Teams and their work must be consistent with Gratipay's [Brand
+  1. Projects and their Work must be consistent with Gratipay's [Brand
      Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
 Use Policy.
 
-  1. Gratipay reserves the right to reject, suspend, or remove a Team at any
+  1. Gratipay reserves the right to reject, suspend, or remove a Project at any
      time, and for any reason.
 
-  1. Establishing a Team on Gratipay involves an application and approval
+  1. Establishing a Project on Gratipay involves an application and approval
      process. As part of this process, the Gratipay community will have the
-opportunity to publicly evaluate and provide commentary about the Team.
+opportunity to publicly evaluate and provide commentary about the Project.
 However, all decisions regarding whether to accept, reject, suspend, remove, or
-take any other action regarding a Team belong solely to Gratipay.
+take any other action regarding a Project belong solely to Gratipay.
 
 1. Fees and Taxes
 
   1. Gratipay does not take any fee from payments made by Participants to
-     Teams. Gratipay and the Service are funded through the Service itself, by
-voluntary contributions from Gratipay Participants and Teams who wish to fund
-our own [Open Work](http://www.opencompany.org/). To contribute to Gratipay, please [visit Gratipay's Team
-page](/Gratipay/).
+     Projects, or by Projects to Members. Gratipay and the Service are funded
+through the Service itself, by voluntary contributions from Gratipay
+Participants who wish to fund our own Work. To contribute to Gratipay, please
+[visit Gratipay's Project page](/Gratipay/).
 
   1. You are responsible for paying any third-party fees associated with your
      use of the Service, such as credit card and bank fees.
 
   1. You are responsible for paying any taxes and withholdings associated with
-     your use of the Service. Team Owners, and not Gratipay, are responsible
-for compliance with all laws, as well as any taxes and withholding
-requirements, applicable to Payouts made to Team Members (whether through the
-Payouts feature or otherwise), including without limitation payroll tax,
-unemployment insurance, and worker compensation insurance payments. Team Owners
-are also responsible for providing any required tax and other documentation to
-employees, independent contractors, tax authorities, or any other person.
+     your use of the Service. In particular, Project Owners, and not Gratipay,
+are responsible for compliance with all laws, as well as any taxes and
+withholding requirements, applicable to payments made to Project Members
+(whether through the Service or otherwise), including without limitation
+payroll tax, unemployment insurance, and worker compensation insurance
+payments.  Project Owners are also responsible for providing any required tax
+and other documentation to employees, independent contractors, tax authorities,
+or any other person.
 
 1. Content Accessible on the Service
 
@@ -139,8 +151,8 @@ content. However, Gratipay has no obligation to monitor, filter, or disable
 access to any content, and shall not be responsible if you encounter
 objectionable content by using the Service.
 
-  1. The Service, including Participant and Team profiles, may contain links to
-     other websites. When you access third-party websites linked to from the
+  1. The Service, including Participant and Project profiles, may contain links
+     to other websites. When you access third-party websites linked to from the
 Service, you do so at your own risk. Gratipay does not review, control, or
 endorse those sites.
 
@@ -220,15 +232,15 @@ agreement](https://www.braintreepayments.com/legal/bank-agreement-us).
 
 1. Nonprofits and Charities using Gratipay
 
-  1. If your Team is associated with a nonprofit organization, soliciting
+  1. If your Project is associated with a nonprofit organization, soliciting
      payments on Gratipay may subject you to certain state laws regarding
 charitable solicitations, including various registration, reporting, and audit
 requirements. You are solely responsible for compliance with these and any
 other applicable law or regulation.
 
   1. Gratipay makes no representation or warranty regarding the tax-exempt
-     status of any Team, or the tax-deductible status of any payment made via
-the Service.
+     status of any Project, or the tax-deductible status of any payment made
+via the Service.
 
 1. Copyright Policy
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -47,25 +47,25 @@ other Participants as Collaborators.
   1. A Participant may give money to a Project. A Participant who gives money
      to a Project is a Giver.
 
-1.  Obligations of Project Owners
+1. Obligations of Project Owners
 
   1. A Project can use the Service to receive payments from Givers for Work
-     provided by the Project ("Project Work"). When you establish a Project on
-the Service, you agree that payments will be used exclusively to support the
-Project Work described in your Project's profile.
+     provided by the Project. When you establish a Project on the Service, you
+agree that payments will be used exclusively to support the Work described in
+your Project's profile.
 
   1. By accepting a payment from a Giver, the Project forms an agreement with
-     that Giver to perform the Project Work. The Service is a platform to
+     that Giver to provide the Project's Work. The Service is a platform to
 facilitate this agreement. Gratipay is not a party to the agreement, and is not
 responsible to either the Project or the Giver if either party breaches the
-terms of the agreement (e.g. if the Project fails to provide the promised
-services).
+terms of the agreement (e.g. if the Project fails to provide the promised goods
+or services).
 
   1. A Project can only begin receiving payments from Givers once the Project
      Owner has provided a working withdrawal mechanism for receiving payments
 (e.g. bank account information).
 
-  1. Projects and Project Work must be consistent with Gratipay's [Brand
+  1. Projects and their Work must be consistent with Gratipay's [Brand
      Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
 Use Policy.
 
@@ -78,32 +78,32 @@ opportunity to publicly evaluate and provide commentary about the Project.
 However, all decisions regarding whether to accept, reject, suspend, remove, or
 take any other action regarding a Project belong solely to Gratipay.
 
-1.  Obligations of Collaborators
+1. Obligations of Collaborators
 
   1. Projects can use the Service to distribute payments to Collaborators.
 
   1. When you become a Collaborator, you agree that payments to you by the
-     Project are made exclusively because of your contribution ("Project
-Tasks") to the Project Work decribed in the Project's profile.
+     Project are made exclusively because of your collaboration in the Work
+described in the Project's profile.
 
   1. By accepting a payment from a Project, the Collaborator forms an agreement
-     with that Project to contribute to the Project Work described in the
-Project's profile.  The Service is a platform to facilitate this agreement.
-Gratipay is not a party to the agreement, and is not responsible to either the
-Project or the Collaborator if either party breaches the terms of the agreement
-(e.g. if the Collaborator fails to provide the promised services).
+     with that Project to collaborate in the Work described in the Project's
+profile. The Service is a platform to facilitate this agreement. Gratipay is
+not a party to the agreement, and is not responsible to either the Project or
+the Collaborator if either party breaches the terms of the agreement (e.g. if
+the Collaborator fails to provide the promised goods or services).
 
   1. Gratipay does not determine how payments are allocated and is not
      responsible for how Projects internally distribute payments. The agreement
 between the Project's Owner and Collaborators regarding the allocation of
 payments is solely between those parties.
 
-1.  Obligations of Givers
+1. Obligations of Givers
 
-  1. When you make a payment to a Project, it is a payment to fund the Project
-     Work.  You understand and acknowledge that your payment does not entitle
-you personally to receive any goods or services from the Project, unless the
-Project explicitly offers those things to Givers.
+  1. When you make a payment to a Project, it is a payment to fund the Work
+     described in the Project's profile. You understand and acknowledge that
+your payment does not entitle you personally to receive any goods or services
+from the Project, unless the Project explicitly offers those things to Givers.
 
   1. Gratipay is not obligated to provide refunds under any circumstance.
      Projects are responsible for producing the work they offer. Gratipay does

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -41,8 +41,8 @@ these Terms.
      establishes a Project is the Project Owner. Projects may optionally have
 other Participants as Collaborators. The Project Owner is also a Collaborator.
 
-  1. A Participant may give payments to a Project. A Participant who gives
-     payments to a Project is a Giver.
+  1. A Participant may make payments to a Project Owner via a Project. A
+     Participant who makes payments via a Project is a Giver.
      
   1. Projects and their Work must be consistent with Gratipay's [Brand
      Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
@@ -53,21 +53,21 @@ Use Policy.
 
 1. Terms for Project Owners
 
-  1. A Project can use the Service to receive payments from Givers for Work
-     provided by the Project. When you establish a Project on the Service, you
-agree that payments will be used exclusively to support the Work described in
-your Project's profile.
+  1. A Project Owner can use the Service to receive payments from Givers for
+     Work provided by the Project's Collaborators. When you establish a Project
+on the Service, you agree that payments will be used exclusively to support the
+Work described in your Project's profile.
 
   1. By accepting a payment from a Giver, the Project Owner forms an agreement
      with that Giver to provide the Project's Work. The Service is a platform
 to facilitate this agreement. Gratipay is not a party to the agreement, and is
-not responsible to either the Project or the Giver if either party breaches the
-terms of the agreement (e.g. if the Project fails to provide the promised goods
-or services).
+not responsible to either the Project Owner or the Giver if either party
+breaches the terms of the agreement (e.g. if the Project Owner fails to provide
+the promised goods or services).
 
-  1. A Project can only begin receiving payments from Givers once the Project
-     Owner has provided a working withdrawal mechanism for receiving payments
-(e.g. bank account information).
+  1. A Project Owner can only begin receiving payments from Givers once the
+     Project Owner has provided a working withdrawal mechanism for receiving
+payments (e.g. bank account information).
 
   1. Establishing a Project on Gratipay involves an application and approval
      process. As part of this process, the Gratipay community will have the
@@ -77,18 +77,19 @@ take any other action regarding a Project belong solely to Gratipay.
 
 1. Terms for Collaborators
 
-  1. Projects can use the Service to distribute payments to Collaborators.
+  1. Project Owners can use the Service to distribute payments to
+     Collaborators.
 
   1. When you become a Collaborator, you agree that payments to you by the
-     Project are made exclusively because of your collaboration in the Work
-described in the Project's profile.
+     Project Owner are made exclusively because of your collaboration in the
+Work described in the Project's profile.
 
   1. By becoming a Collaborator, the Collaborator forms an agreement with that
-     Project to collaborate in the Work described in the Project's profile. The
-Service is a platform to facilitate this agreement. Gratipay is not a party to
-the agreement, and is not responsible to either the Project or the Collaborator
-if either party breaches the terms of the agreement (e.g. if the Collaborator
-fails to provide the promised goods or services).
+     Project Owner to collaborate in the Work described in the Project's
+profile. The Service is a platform to facilitate this agreement. Gratipay is
+not a party to the agreement, and is not responsible to either the Project
+Owner or the Collaborator if either party breaches the terms of the agreement
+(e.g. if the Collaborator fails to provide the promised goods or services).
 
   1. Gratipay does not determine how payments are allocated and is not
      responsible for how Projects internally distribute payments. The agreement
@@ -97,23 +98,24 @@ payments is solely between those parties.
 
 1. Terms for Givers
 
-  1. When you make a payment to a Project, it is a payment to fund the Work
-     described in the Project's profile. You understand and acknowledge that
-your payment does not entitle you personally to receive any goods or services
-from the Project, unless the Project explicitly offers those things to Givers.
+  1. When you make a payment to a Project Owner, it is a payment to fund the
+     Work described in the Project's profile. You understand and acknowledge
+that your payment does not entitle you personally to receive any goods or
+services from the Project Owner, unless the Project Owner explicitly offers
+those things to Givers.
 
   1. Gratipay is not obligated to provide refunds under any circumstance.
-     Projects are responsible for producing the work they offer. Gratipay does
-not hold funds on behalf of Projects, and does not warrant or guarantee that
-Projects will provide the work they promise.
+     Project Owners are responsible for producing the Work they offer. Gratipay
+does not hold funds on behalf of Project Owners, and does not warrant or
+guarantee that Project Owners will provide the Work they promise.
 
 1. Fees and Taxes
 
-  1. Gratipay does not take any fee from payments made by Givers to Projects,
-     or by Projects to Collaborators. Gratipay and the Service are funded
-through the Service itself, by voluntary payments from Givers who wish to fund
-our own Work. To contribute to Gratipay, please [visit Gratipay's Project
-page](/Gratipay/).
+  1. Gratipay does not take any fee from payments made by Givers to Project
+     Owners, or by Project Owners to Collaborators. Gratipay and the Service
+are funded through the Service itself, by voluntary payments from Givers who
+wish to fund our own Work. To contribute to Gratipay, please [visit Gratipay's
+Project page](/Gratipay/).
 
   1. You are responsible for paying any third-party fees associated with your
      use of the Service, such as credit card and bank fees.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -42,7 +42,7 @@ these Terms.
 
   1. A Participant may establish a Project on the Service. The Participant who
      establishes a Project is its Owner. Projects may optionally have other
-Members. The Owner is also a Member.
+Members. The Owner is a Member.
 
   1. A Project may receive payments from Participants for Work provided by the
      Project. When you establish a Project on the Service, you agree that
@@ -64,7 +64,7 @@ not entitle you personally to receive any goods or services from the Project,
 unless the Project explicitly offers those things to Participants.
 
   1. By accepting a payment from a Participant, the Project forms an agreement
-     with that Participant to perform the work described in its profile. The
+     with that Participant to perform the Work described in its profile. The
 Service is a platform to facilitate this agreement. Gratipay is not a party to
 the agreement, and is not responsible to either the Project or the Participant
 if either party breaches the terms of the agreement (e.g. if the Project fails
@@ -110,9 +110,9 @@ take any other action regarding a Project belong solely to Gratipay.
 
   1. Gratipay does not take any fee from payments made by Participants to
      Projects, or by Projects to Members. Gratipay and the Service are funded
-through the Service itself, by voluntary contributions from Gratipay
-Participants who wish to fund our own Work. To contribute to Gratipay, please
-[visit Gratipay's Project page](/Gratipay/).
+through the Service itself, by voluntary payments from Gratipay Participants
+who wish to fund our own Work. To contribute to Gratipay, please [visit
+Gratipay's Project page](/Gratipay/).
 
   1. You are responsible for paying any third-party fees associated with your
      use of the Service, such as credit card and bank fees.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -42,7 +42,7 @@ these Terms.
 
   1. A Participant may establish a Project on the Service. The Participant who
      establishes a Project is its Owner. Projects may optionally have other
-Members. The Owner is a Member.
+Participants as Members.
 
   1. A Project may receive payments from Participants for Work provided by the
      Project. When you establish a Project on the Service, you agree that
@@ -64,11 +64,11 @@ not entitle you personally to receive any goods or services from the Project,
 unless the Project explicitly offers those things to Participants.
 
   1. By accepting a payment from a Participant, the Project forms an agreement
-     with that Participant to perform the Work described in its profile. The
-Service is a platform to facilitate this agreement. Gratipay is not a party to
-the agreement, and is not responsible to either the Project or the Participant
-if either party breaches the terms of the agreement (e.g. if the Project fails
-to provide the promised services).
+     with that Participant to perform the Work described in the Project's
+profile. The Service is a platform to facilitate this agreement. Gratipay is
+not a party to the agreement, and is not responsible to either the Project or
+the Participant if either party breaches the terms of the agreement (e.g. if
+the Project fails to provide the promised services).
 
   1. Gratipay is not obligated to provide refunds under any circumstance.
      Projects are responsible for producing the work they offer. Gratipay does
@@ -79,12 +79,19 @@ Projects will provide the work they promise.
 
   1. Projects can use the Service to distribute payments to Project Members.
 
-  1. When a Project makes a payment to you, it is a payment to fund the Work
-     you contribute to the Project.
+  1. When you receive a payment from a Project, it is a payment to fund the
+     Work you contribute to the Project.
+
+  1. By accepting a payment from a Project, the Member forms an agreement with
+     that Project to contribute to the Work described in the Project's profile.
+The Service is a platform to facilitate this agreement. Gratipay is not a party
+to the agreement, and is not responsible to either the Project or the Member if
+either party breaches the terms of the agreement (e.g. if the Member fails to
+provide the promised services).
 
   1. Gratipay does not determine how payments are allocated and is not
      responsible for how Projects internally distribute payments. The agreement
-between the Project Owner and other Members regarding the allocation of
+between the Project's Owner and its Members regarding the allocation of
 payments is solely between those parties.
 
 1. Additional Rules for Gratipay Projects
@@ -123,7 +130,7 @@ are responsible for compliance with all laws, as well as any taxes and
 withholding requirements, applicable to payments made to Project Members
 (whether through the Service or otherwise), including without limitation
 payroll tax, unemployment insurance, and worker compensation insurance
-payments.  Project Owners are also responsible for providing any required tax
+payments. Project Owners are also responsible for providing any required tax
 and other documentation to employees, independent contractors, tax authorities,
 or any other person.
 
@@ -351,7 +358,7 @@ SERVICE; (ii) ANY CONDUCT OR CONTENT OF ANY THIRD PARTY ON THE SERVICE,
 INCLUDING WITHOUT LIMITATION, ANY DEFAMATORY, OFFENSIVE OR ILLEGAL CONDUCT OF
 OTHER PARTICIPANTS OR THIRD PARTIES; (iii) ANY CONTENT OBTAINED FROM THE
 SERVICE; OR (iv) UNAUTHORIZED ACCESS, USE OR ALTERATION OF YOUR TRANSMISSIONS
-OR CONTENT.  IN NO EVENT SHALL THE AGGREGATE LIABILITY OF GRATIPAY OR ITS
+OR CONTENT. IN NO EVENT SHALL THE AGGREGATE LIABILITY OF GRATIPAY OR ITS
 AFFILIATES EXCEED THE GREATER OF ONE HUNDRED U.S. DOLLARS (U.S. $100.00) OR THE
 AMOUNT YOU PAID GRATIPAY, IF ANY, IN THE PAST SIX MONTHS FOR THE SERVICE GIVING
 RISE TO THE CLAIM.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -44,59 +44,25 @@ these Terms.
      establishes a Project is the "Project Owner". Projects may optionally have other
 Participants as "Project Members."
 
-  1. A Project may receive payments from Participants for Work provided by the
+  1. A Participant may give money to a Project. A Participant who gives money to a Project is a "Giver."
+
+1.  Obligations of Project Owners
+
+  1. A Project may receive payments from Givers for Work provided by the
      Project ("Project Work"). When you establish a Project on the Service, you agree that
 payments will be used exclusively to support the Project Work described in your
 Project's profile.
 
-  1. When you become a Project Member, you agree
-that payments to you by the Project are made exclusively because of your
-contribution ("Project Tasks") to the Project Work decribed in the Project's profile. A Project may make 
-payments to its Project Members for Project Tasks performed by the Project Members. 
+  1. Projects can use the Service to receive payments from Givers.
 
-1. Payments from Participants to Projects
-
-  1. Projects can use the Service to receive payments from Participants.
-
-  1. When you make a payment to a Project, it is a payment to fund the Project Work. 
-  You understand and acknowledge that your payment does
-not entitle you personally to receive any goods or services from the Project,
-unless the Project explicitly offers those things to Participants.
-
-  1. By accepting a payment from a Participant, the Project forms an agreement
-     with that Participant to perform the Project Work. 
+  1. By accepting a payment from a Giver, the Project forms an agreement
+     with that Giver to perform the Project Work. 
      The Service is a platform to facilitate this agreement. Gratipay is
 not a party to the agreement, and is not responsible to either the Project or
-the Participant if either party breaches the terms of the agreement (e.g. if
+the Giver if either party breaches the terms of the agreement (e.g. if
 the Project fails to provide the promised services).
 
-  1. Gratipay is not obligated to provide refunds under any circumstance.
-     Projects are responsible for producing the work they offer. Gratipay does
-not hold funds on behalf of Projects, and does not warrant or guarantee that
-Projects will provide the work they promise.
-
-1. Payments from Projects to Project Members
-
-  1. Projects can use the Service to distribute payments to Project Members.
-
-  1. When you receive a payment from a Project, it is a payment to fund the
-     Project Tasks you contribute to the Project.
-
-  1. By accepting a payment from a Project, the Project Member forms an agreement with
-     that Project to contribute to the Project Work described in the Project's profile.
-The Service is a platform to facilitate this agreement. Gratipay is not a party
-to the agreement, and is not responsible to either the Project or the Project Member if
-either party breaches the terms of the agreement (e.g. if the Project Member fails to
-provide the promised services).
-
-  1. Gratipay does not determine how payments are allocated and is not
-     responsible for how Projects internally distribute payments. The agreement
-between the Project's Owner and Project Members regarding the allocation of
-payments is solely between those parties.
-
-1. Additional Rules for Gratipay Projects
-
-  1. A Project can only begin receiving payments from Participants once the
+  1. A Project can only begin receiving payments from Givers once the
      Project Owner has provided a working withdrawal mechanism for receiving payments
 (e.g. bank account information).
 
@@ -113,11 +79,47 @@ opportunity to publicly evaluate and provide commentary about the Project.
 However, all decisions regarding whether to accept, reject, suspend, remove, or
 take any other action regarding a Project belong solely to Gratipay.
 
+1.  Obligations of Project Members
+
+  1. Projects can use the Service to distribute payments to Project Members.
+
+  1. When you receive a payment from a Project, it is a payment to fund the
+     Project Tasks you contribute to the Project.
+     
+       1. When you become a Project Member, you agree
+that payments to you by the Project are made exclusively because of your
+contribution ("Project Tasks") to the Project Work decribed in the Project's profile. A Project may make 
+payments to its Project Members for Project Tasks performed by the Project Members. 
+
+  1. By accepting a payment from a Project, the Project Member forms an agreement with
+     that Project to contribute to the Project Work described in the Project's profile.
+The Service is a platform to facilitate this agreement. Gratipay is not a party
+to the agreement, and is not responsible to either the Project or the Project Member if
+either party breaches the terms of the agreement (e.g. if the Project Member fails to
+provide the promised services).
+
+  1. Gratipay does not determine how payments are allocated and is not
+     responsible for how Projects internally distribute payments. The agreement
+between the Project's Owner and Project Members regarding the allocation of
+payments is solely between those parties.
+
+1.  Obligations of Givers
+
+  1. When you make a payment to a Project, it is a payment to fund the Project Work. 
+  You understand and acknowledge that your payment does
+not entitle you personally to receive any goods or services from the Project,
+unless the Project explicitly offers those things to Givers.
+
+  1. Gratipay is not obligated to provide refunds under any circumstance.
+     Projects are responsible for producing the work they offer. Gratipay does
+not hold funds on behalf of Projects, and does not warrant or guarantee that
+Projects will provide the work they promise.
+
 1. Fees and Taxes
 
-  1. Gratipay does not take any fee from payments made by Participants to
+  1. Gratipay does not take any fee from payments made by Givers to
      Projects, or by Projects to Project Members. Gratipay and the Service are funded
-through the Service itself, by voluntary payments from Gratipay Participants
+through the Service itself, by voluntary payments from Givers
 who wish to fund our own Work. To contribute to Gratipay, please [visit
 Gratipay's Project page](/Gratipay/).
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -37,6 +37,9 @@ these Terms.
 
 1. General Terms
 
+  1. The Service is a platform to facilitate payments for goods or services
+     ("Work").
+
   1. A Participant may establish a Project on the Service. The Participant who
      establishes a Project is the Project Owner.
 
@@ -53,12 +56,10 @@ these Terms.
 on the Service, you agree that payments will be used exclusively to support the
 Work described in your Project's profile.
 
-  1. By accepting a payment from a Giver, the Project Owner forms an agreement
-     with that Giver to provide the Project's Work. The Service is a platform
-to facilitate this agreement. Gratipay is not a party to the agreement, and is
-not responsible to either the Project Owner or the Giver if either party
-breaches the terms of the agreement (e.g. if the Project Owner fails to provide
-the promised goods or services).
+  1. Gratipay is not a party to any agreement between Project Owners and
+     Givers, and is not responsible to either the Project Owner or the Giver if
+either party breaches the terms of any such agreement (e.g. if the Project
+Owner fails to provide the promised goods or services).
 
   1. A Project Owner can only begin receiving payments from Givers once the
      Project Owner has provided a working withdrawal mechanism for receiving
@@ -82,12 +83,10 @@ take any other action regarding a Project belong solely to Gratipay.
      Project Owner are made exclusively because of your collaboration in the
 Work described in the Project's profile.
 
-  1. By becoming a Collaborator, the Collaborator forms an agreement with that
-     Project Owner to collaborate in the Work described in the Project's
-profile. The Service is a platform to facilitate this agreement. Gratipay is
-not a party to the agreement, and is not responsible to either the Project
-Owner or the Collaborator if either party breaches the terms of the agreement
-(e.g. if the Collaborator fails to provide the promised goods or services).
+  1. Gratipay is not a party to any agreement between Project Owners and
+     Collaborators, and is not responsible to either the Project Owner or the
+Collaborator if either party breaches the terms of any such agreement (e.g. if
+the Collaborator fails to provide the promised goods or services).
 
   1. Gratipay does not determine how payments are allocated and is not
      responsible for how Projects internally distribute payments. The agreement

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -41,8 +41,8 @@ these Terms.
      establishes a Project is the Project Owner. Projects may optionally have
 other Participants as Collaborators. The Project Owner is also a Collaborator.
 
-  1. A Participant may give payments to a Project. A Participant who gives payments
-     to a Project is a Giver.
+  1. A Participant may give payments to a Project. A Participant who gives
+     payments to a Project is a Giver.
      
   1. Projects and their Work must be consistent with Gratipay's [Brand
      Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
@@ -58,10 +58,10 @@ Use Policy.
 agree that payments will be used exclusively to support the Work described in
 your Project's profile.
 
-  1. By accepting a payment from a Giver, the Project Owner forms an agreement with
-     that Giver to provide the Project's Work. The Service is a platform to
-facilitate this agreement. Gratipay is not a party to the agreement, and is not
-responsible to either the Project or the Giver if either party breaches the
+  1. By accepting a payment from a Giver, the Project Owner forms an agreement
+     with that Giver to provide the Project's Work. The Service is a platform
+to facilitate this agreement. Gratipay is not a party to the agreement, and is
+not responsible to either the Project or the Giver if either party breaches the
 terms of the agreement (e.g. if the Project fails to provide the promised goods
 or services).
 
@@ -83,12 +83,12 @@ take any other action regarding a Project belong solely to Gratipay.
      Project are made exclusively because of your collaboration in the Work
 described in the Project's profile.
 
-  1. By becoming a Collaborator, the Collaborator forms an agreement
-     with that Project to collaborate in the Work described in the Project's
-profile. The Service is a platform to facilitate this agreement. Gratipay is
-not a party to the agreement, and is not responsible to either the Project or
-the Collaborator if either party breaches the terms of the agreement (e.g. if
-the Collaborator fails to provide the promised goods or services).
+  1. By becoming a Collaborator, the Collaborator forms an agreement with that
+     Project to collaborate in the Work described in the Project's profile. The
+Service is a platform to facilitate this agreement. Gratipay is not a party to
+the agreement, and is not responsible to either the Project or the Collaborator
+if either party breaches the terms of the agreement (e.g. if the Collaborator
+fails to provide the promised goods or services).
 
   1. Gratipay does not determine how payments are allocated and is not
      responsible for how Projects internally distribute payments. The agreement

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -53,8 +53,8 @@ these Terms.
 
   1. A Project Owner can use the Service to receive payments from Givers for
      Work provided by the Project's Collaborators. When you establish a Project
-on the Service, you agree that payments will be used exclusively to support the
-Work described in your Project's profile.
+on the Service, you agree that payments via the Project will be used
+exclusively to support the Work described in the Project's profile.
 
   1. Gratipay is not a party to any agreement between Project Owners and
      Givers, and is not responsible to either the Project Owner or the Giver if
@@ -89,17 +89,17 @@ Collaborator if either party breaches the terms of any such agreement (e.g. if
 the Collaborator fails to provide the promised goods or services).
 
   1. Gratipay does not determine how payments are allocated and is not
-     responsible for how Projects internally distribute payments. The agreement
-between the Project's Owner and Collaborators regarding the allocation of
+     responsible for how Project Owners distribute payments. The agreement
+between the Project's Owner and other Collaborators regarding the allocation of
 payments is solely between those parties.
 
 1. Terms for Givers
 
-  1. When you make a payment to a Project Owner, it is a payment to fund the
-     Work described in the Project's profile. You understand and acknowledge
-that your payment does not entitle you personally to receive any goods or
-services from the Project Owner, unless the Project Owner explicitly offers
-those things to Givers.
+  1. When you make a payment via a Project to a Project Owner, it is a payment
+     to fund the Work described in the Project's profile. You understand and
+acknowledge that your payment does not entitle you personally to receive any
+goods or services from the Project Owner, unless the Project Owner explicitly
+offers those things to Givers.
 
   1. Gratipay is not obligated to provide refunds under any circumstance.
      Project Owners are responsible for producing the Work they offer. Gratipay
@@ -234,15 +234,15 @@ agreement](https://www.braintreepayments.com/legal/bank-agreement-us).
 
 1. Nonprofits and Charities using Gratipay
 
-  1. If your Project is associated with a nonprofit organization, soliciting
-     payments on Gratipay may subject you to certain state laws regarding
-charitable solicitations, including various registration, reporting, and audit
-requirements. You are solely responsible for compliance with these and any
-other applicable law or regulation.
+  1. If you are a nonprofit organization, soliciting payments on Gratipay may
+     subject you to certain state laws regarding charitable solicitations,
+including various registration, reporting, and audit requirements. You are
+solely responsible for compliance with these and any other applicable law or
+regulation.
 
   1. Gratipay makes no representation or warranty regarding the tax-exempt
-     status of any Project, or the tax-deductible status of any payment made
-via the Service.
+     status of any Project Owner, or the tax-deductible status of any payment
+made via the Service.
 
 1. Copyright Policy
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -45,10 +45,6 @@ these Terms.
 
   1. A Participant may make payments to a Project Owner via a Project. A
      Participant who makes payments via a Project is a Giver.
-     
-  1. Projects and their Work must be consistent with Gratipay's [Brand
-     Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
-Use Policy.
 
   1. Gratipay reserves the right to reject, suspend, or remove a Project at any
      time, and for any reason.
@@ -204,6 +200,8 @@ disclosure policy](/about/security/).
     * Posting anyone's personal or confidential information, such as social
       security numbers, credit card numbers, street addresses, phone numbers,
 confidential ID numbers, or account passwords, without their permission.
+
+    * Aggressive trolling or activism.
 
     * Account hijacking, including any access to or use of another
       Participant's account without their permission.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -40,8 +40,8 @@ these Terms.
   1. The Service is a platform to facilitate payments for goods or services
      ("Work").
 
-  1. A Participant may establish a Project on the Service. The Participant who
-     establishes a Project is the Project Owner.
+  1. A Participant may establish a Project on the Service. A Participant who 
+     establishes a Project is also a Project Owner.
 
   1. Projects may optionally have other Participants as Collaborators. The
      Project Owner is also a Collaborator.
@@ -89,14 +89,14 @@ Collaborator if either party breaches the terms of any such agreement (e.g. if
 the Collaborator fails to provide the promised goods or services).
 
   1. Gratipay does not determine how payments are allocated and is not
-     responsible for how Project Owners distribute payments. The agreement
+     responsible for how Project Owners distribute payments. Any agreement
 between the Project's Owner and other Collaborators regarding the allocation of
 payments is solely between those parties.
 
 1. Terms for Givers
 
   1. When you make a payment via a Project to a Project Owner, it is a payment
-     to fund the Work described in the Project's profile. You understand and
+     to pay for the Work described in the Project's profile. You understand and
 acknowledge that your payment does not entitle you personally to receive any
 goods or services from the Project Owner, unless the Project Owner explicitly
 offers those things to Givers.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -69,7 +69,7 @@ will provide the work they promise.
      incoming payments among Team Members, according to the allocation set by
 the Owner and/or Members.
 
-  1. Gratipay does not determine how a Payouts are allocated and is not
+  1. Gratipay does not determine how Payouts are allocated and is not
      responsible for how Teams internally distribute payments. The agreement
 between Team Members and Owners regarding the allocation of Payouts is solely
 between those parties.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -41,31 +41,31 @@ these Terms.
      ("Work").
 
   1. A Participant may establish a Project on the Service. The Participant who
-     establishes a Project is its Owner. Projects may optionally have other
-Participants as Members.
+     establishes a Project is the "Project Owner". Projects may optionally have other
+Participants as "Project Members."
 
   1. A Project may receive payments from Participants for Work provided by the
-     Project. When you establish a Project on the Service, you agree that
-payments will be used exclusively to support the Work described in your
+     Project ("Project Work"). When you establish a Project on the Service, you agree that
+payments will be used exclusively to support the Project Work described in your
 Project's profile.
 
-  1. A Project may make payments to its Members for Work provided to the
-     Project by the Members. When you become a Member of a Project, you agree
+  1. When you become a Project Member, you agree
 that payments to you by the Project are made exclusively because of your
-contribution to the Work decribed in the Project's profile.
+contribution ("Project Tasks") to the Project Work decribed in the Project's profile. A Project may make 
+payments to its Project Members for Project Tasks performed by the Project Members. 
 
 1. Payments from Participants to Projects
 
   1. Projects can use the Service to receive payments from Participants.
 
-  1. When you make a payment to a Project, it is a payment to fund the Work the
-     Project provides. You understand and acknowledge that your payment does
+  1. When you make a payment to a Project, it is a payment to fund the Project Work. 
+  You understand and acknowledge that your payment does
 not entitle you personally to receive any goods or services from the Project,
 unless the Project explicitly offers those things to Participants.
 
   1. By accepting a payment from a Participant, the Project forms an agreement
-     with that Participant to perform the Work described in the Project's
-profile. The Service is a platform to facilitate this agreement. Gratipay is
+     with that Participant to perform the Project Work. 
+     The Service is a platform to facilitate this agreement. Gratipay is
 not a party to the agreement, and is not responsible to either the Project or
 the Participant if either party breaches the terms of the agreement (e.g. if
 the Project fails to provide the promised services).
@@ -75,32 +75,32 @@ the Project fails to provide the promised services).
 not hold funds on behalf of Projects, and does not warrant or guarantee that
 Projects will provide the work they promise.
 
-1. Payments from Projects to Members
+1. Payments from Projects to Project Members
 
   1. Projects can use the Service to distribute payments to Project Members.
 
   1. When you receive a payment from a Project, it is a payment to fund the
-     Work you contribute to the Project.
+     Project Tasks you contribute to the Project.
 
-  1. By accepting a payment from a Project, the Member forms an agreement with
-     that Project to contribute to the Work described in the Project's profile.
+  1. By accepting a payment from a Project, the Project Member forms an agreement with
+     that Project to contribute to the Project Work described in the Project's profile.
 The Service is a platform to facilitate this agreement. Gratipay is not a party
-to the agreement, and is not responsible to either the Project or the Member if
-either party breaches the terms of the agreement (e.g. if the Member fails to
+to the agreement, and is not responsible to either the Project or the Project Member if
+either party breaches the terms of the agreement (e.g. if the Project Member fails to
 provide the promised services).
 
   1. Gratipay does not determine how payments are allocated and is not
      responsible for how Projects internally distribute payments. The agreement
-between the Project's Owner and its Members regarding the allocation of
+between the Project's Owner and Project Members regarding the allocation of
 payments is solely between those parties.
 
 1. Additional Rules for Gratipay Projects
 
   1. A Project can only begin receiving payments from Participants once the
-     Owner has provided a working withdrawal mechanism for receiving payments
+     Project Owner has provided a working withdrawal mechanism for receiving payments
 (e.g. bank account information).
 
-  1. Projects and their Work must be consistent with Gratipay's [Brand
+  1. Projects and Project Work must be consistent with Gratipay's [Brand
      Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
 Use Policy.
 
@@ -116,7 +116,7 @@ take any other action regarding a Project belong solely to Gratipay.
 1. Fees and Taxes
 
   1. Gratipay does not take any fee from payments made by Participants to
-     Projects, or by Projects to Members. Gratipay and the Service are funded
+     Projects, or by Projects to Project Members. Gratipay and the Service are funded
 through the Service itself, by voluntary payments from Gratipay Participants
 who wish to fund our own Work. To contribute to Gratipay, please [visit
 Gratipay's Project page](/Gratipay/).

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -18,22 +18,22 @@ legal@gratipay.com
 
   1. When you register for the Service, you agree to provide Gratipay with
      complete and accurate registration information. You are responsible for
-    keeping your account information, including your contact and payment
-    information, up to date. Gratipay takes our Participants' privacy seriously. We
-    will only use or share your information and Content as described in our
-    [Privacy Policy](/about/policies/privacy), which is incorporated into these
-    Terms.
+keeping your account information, including your contact and payment
+information, up to date. Gratipay takes our Participants' privacy seriously. We
+will only use or share your information and Content as described in our
+[Privacy Policy](/about/policies/privacy), which is incorporated into these
+Terms.
 
   1. You are responsible for maintaining the security of your account
      information, including your authentication credentials. You agree to
-    notify Gratipay immediately of any actual or suspected loss, theft, or
-    unauthorized use of your credentials. Gratipay shall not be liable for any loss
-    or damage arising from your failure to keep your account secure.
+notify Gratipay immediately of any actual or suspected loss, theft, or
+unauthorized use of your credentials. Gratipay shall not be liable for any loss
+or damage arising from your failure to keep your account secure.
 
   1. You may only use the Service if you are 13 years old or older, and you
      represent to us that you are 13 or older. If you are under the age of 18,
-    your legal guardian must consent to your use and must agree to be bound by
-    these Terms.
+your legal guardian must consent to your use and must agree to be bound by
+these Terms.
 
 1. General Rules
 
@@ -41,68 +41,69 @@ legal@gratipay.com
      ("Work").
 
   1. A Participant may establish a Project on the Service. The Participant who
-     establishes a Project is the "Project Owner". Projects may optionally have other
-    Participants as "Project Members."
+     establishes a Project is the "Project Owner". Projects may optionally have
+other Participants as "Project Members."
 
-  1. A Participant may give money to a Project. A Participant who gives money to a Project is a "Giver."
+  1. A Participant may give money to a Project. A Participant who gives money
+     to a Project is a "Giver."
 
 1.  Obligations of Project Owners
 
-  1. A Project can use the Service to receive payments from Givers for Work provided by the
-     Project ("Project Work"). When you establish a Project on the Service, you agree that
-    payments will be used exclusively to support the Project Work described in your
-    Project's profile.
+  1. A Project can use the Service to receive payments from Givers for Work
+     provided by the Project ("Project Work"). When you establish a Project on
+the Service, you agree that payments will be used exclusively to support the
+Project Work described in your Project's profile.
 
-  1. By accepting a payment from a Giver, the Project forms an agreement
-     with that Giver to perform the Project Work. 
-     The Service is a platform to facilitate this agreement. Gratipay is
-    not a party to the agreement, and is not responsible to either the Project or
-    the Giver if either party breaches the terms of the agreement (e.g. if
-    the Project fails to provide the promised services).
+  1. By accepting a payment from a Giver, the Project forms an agreement with
+     that Giver to perform the Project Work.  The Service is a platform to
+facilitate this agreement. Gratipay is not a party to the agreement, and is not
+responsible to either the Project or the Giver if either party breaches the
+terms of the agreement (e.g. if the Project fails to provide the promised
+services).
 
-  1. A Project can only begin receiving payments from Givers once the
-     Project Owner has provided a working withdrawal mechanism for receiving payments
-    (e.g. bank account information).
+  1. A Project can only begin receiving payments from Givers once the Project
+     Owner has provided a working withdrawal mechanism for receiving payments
+(e.g. bank account information).
 
   1. Projects and Project Work must be consistent with Gratipay's [Brand
      Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
-    Use Policy. 
+Use Policy.
 
   1. Gratipay reserves the right to reject, suspend, or remove a Project at any
      time, and for any reason.
 
   1. Establishing a Project on Gratipay involves an application and approval
      process. As part of this process, the Gratipay community will have the
-     opportunity to publicly evaluate and provide commentary about the Project.
-     However, all decisions regarding whether to accept, reject, suspend, remove, or
-     take any other action regarding a Project belong solely to Gratipay.
+opportunity to publicly evaluate and provide commentary about the Project.
+However, all decisions regarding whether to accept, reject, suspend, remove, or
+take any other action regarding a Project belong solely to Gratipay.
 
 1.  Obligations of Project Members
 
   1. Projects can use the Service to distribute payments to Project Members.
 
-  1. When you become a Project Member, you agree that payments to you by the 
-  Project are made exclusively because of your contribution ("Project Tasks") 
-  to the Project Work decribed in the Project's profile. 
+  1. When you become a Project Member, you agree that payments to you by the
+     Project are made exclusively because of your contribution ("Project
+Tasks") to the Project Work decribed in the Project's profile.
 
-  1. By accepting a payment from a Project, the Project Member forms an agreement with
-     that Project to contribute to the Project Work described in the Project's profile.
-     The Service is a platform to facilitate this agreement. Gratipay is not a party
-     to the agreement, and is not responsible to either the Project or the Project Member if
-     either party breaches the terms of the agreement (e.g. if the Project Member fails to
-     provide the promised services).
+  1. By accepting a payment from a Project, the Project Member forms an
+     agreement with that Project to contribute to the Project Work described in
+the Project's profile.  The Service is a platform to facilitate this agreement.
+Gratipay is not a party to the agreement, and is not responsible to either the
+Project or the Project Member if either party breaches the terms of the
+agreement (e.g. if the Project Member fails to provide the promised services).
 
   1. Gratipay does not determine how payments are allocated and is not
      responsible for how Projects internally distribute payments. The agreement
-     between the Project's Owner and Project Members regarding the allocation of
-     payments is solely between those parties.
+between the Project's Owner and Project Members regarding the allocation of
+payments is solely between those parties.
 
 1.  Obligations of Givers
 
-  1. When you make a payment to a Project, it is a payment to fund the Project Work. 
-  You understand and acknowledge that your payment does
-not entitle you personally to receive any goods or services from the Project,
-unless the Project explicitly offers those things to Givers.
+  1. When you make a payment to a Project, it is a payment to fund the Project
+     Work.  You understand and acknowledge that your payment does not entitle
+you personally to receive any goods or services from the Project, unless the
+Project explicitly offers those things to Givers.
 
   1. Gratipay is not obligated to provide refunds under any circumstance.
      Projects are responsible for producing the work they offer. Gratipay does

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -48,26 +48,25 @@ its operations.**
   1. The Participant who establishes a Team is its Owner. Teams may optionally
      have other Members.
 
-  1. When you establish a Team on the Service to fund your **Open Work**, you agree
-     that payments will be used exclusively to support the **Open Work** described
-in your Team's profile.
+  1. When you establish a Team on the Service, you agree that payments will be 
+    used exclusively to support the work described in your Team's profile.
 
-  1. When you make a payment to a Team, it is a payment to fund the **Open Work**
+  1. When you make a payment to a Team, it is a payment to fund the work
      the Team provides. You understand and acknowledge that your payment does
 not entitle you personally to receive any goods or services from the Team,
 unless the Team explicitly offers those things to Participants.
 
   1. By accepting a payment from a Participant, a Team forms an agreement with
-     that Participant to perform the **Open Work described in its profile.** The
+     that Participant to perform the work described in its profile. The
 Service is a platform to facilitate this agreement. Gratipay is not a party to
 the agreement, and is not responsible to either the Team or the Participant if
 either party breaches the terms of the agreement (e.g. if the Team fails to
 provide the promised services).
 
   1. Gratipay is not obligated to provide refunds under any circumstance. Teams
-     are responsible for producing the **Open Work** they offer. Gratipay does not
+     are responsible for producing the work they offer. Gratipay does not
 hold funds on behalf of Teams, and does not warrant or guarantee that Teams
-will provide the **Open Work** they promise.
+will provide the work they promise.
 
 1. Take-What-You-Want Payout Rules
 
@@ -91,7 +90,7 @@ generates.**
      provided a working withdrawal mechanism for receiving payments (e.g. bank
 account information).
 
-  1. Teams and their **Open Work** must be consistent with Gratipay's [Brand
+  1. Teams and their work must be consistent with Gratipay's [Brand
      Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
 Use Policy.
 
@@ -119,7 +118,7 @@ page](/Gratipay/).
      your use of the Service. Team Owners, and not Gratipay, are responsible
 for compliance with all laws, as well as any taxes and withholding
 requirements, applicable to payouts made to Team Members (whether through the
-Take-What-You-Want Payout feature or otherwise), including without limitation **payroll** tax,
+Take-What-You-Want Payout feature or otherwise), including without limitation payroll tax,
 unemployment insurance, and worker compensation insurance payments. Team Owners
 are also responsible for providing any required tax and other documentation to
 employees, independent contractors, tax authorities, or any other person.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -38,60 +38,60 @@ these Terms.
 1. The Gratipay Model and General Rules
 
   1. The Service is a platform to enable Teams of Gratipay Participants to
-     receive payments to fund **Open Work**. Open Work means that the Team provides
+     receive payments to fund **Open Work. Open Work means that the Team provides
 a clear path for any individual to voluntarily begin contributing to the Team's
 work and to share in any revenue the Team generates. Some examples of Teams
 performing Open Work include an open source software project that pays
 contributors, or a hackerspace that pays individuals to teach classes or manage
-its operations.
+its operations.**
 
   1. The Participant who establishes a Team is its Owner. Teams may optionally
      have other Members.
 
-  1. When you establish a Team on the Service to fund your Open Work, you agree
-     that payments will be used exclusively to support the Open Work described
+  1. When you establish a Team on the Service to fund your **Open Work**, you agree
+     that payments will be used exclusively to support the **Open Work** described
 in your Team's profile.
 
-  1. When you make a payment to a Team, it is a payment to fund the Open Work
+  1. When you make a payment to a Team, it is a payment to fund the **Open Work**
      the Team provides. You understand and acknowledge that your payment does
 not entitle you personally to receive any goods or services from the Team,
 unless the Team explicitly offers those things to Participants.
 
   1. By accepting a payment from a Participant, a Team forms an agreement with
-     that Participant to perform the Open Work described in its profile. The
+     that Participant to perform the **Open Work described in its profile.** The
 Service is a platform to facilitate this agreement. Gratipay is not a party to
 the agreement, and is not responsible to either the Team or the Participant if
 either party breaches the terms of the agreement (e.g. if the Team fails to
 provide the promised services).
 
   1. Gratipay is not obligated to provide refunds under any circumstance. Teams
-     are responsible for producing the Open Work they offer. Gratipay does not
+     are responsible for producing the **Open Work** they offer. Gratipay does not
 hold funds on behalf of Teams, and does not warrant or guarantee that Teams
-will provide the Open Work they promise.
+will provide the **Open Work** they promise.
 
-1. Payroll Rules
+1. Take-What-You-Want Payout Rules
 
-  1. Teams can use the Service's Payroll feature to automatically divide
+  1. Teams can use the Service's Take-What-You-Want Payouts feature to automatically divide
      incoming payments among Team Members, according to the allocation set by
 the Owner and/or Members.
 
-  1. Gratipay does not determine how a Team's Payroll is allocated and is not
+  1. Gratipay does not determine how a Team's Take-What-You-Want Payouts are allocated and is not
      responsible for how Teams internally distribute payments. The agreement
-between Team Members and Owners regarding the allocation of payments is solely
+between Team Members and Owners regarding the allocation of payouts is solely
 between those parties.
 
 1. Rules for Gratipay Teams
 
-  1. Teams may accept payments on the Service only for Open Work, meaning that
+  1. Teams may accept payments on the Service only for **Open Work, meaning that
      they provide a clear path for any individual to voluntarily begin
 contributing to the Team's work, and to share in any revenue the Team
-generates.
+generates.**
 
   1. A Team can only begin receiving payments from Participants once it has
      provided a working withdrawal mechanism for receiving payments (e.g. bank
 account information).
 
-  1. Teams and their Open Work must be consistent with Gratipay's [Brand
+  1. Teams and their **Open Work** must be consistent with Gratipay's [Brand
      Guidelines](http://inside.gratipay.com/big-picture/brand/) and Acceptable
 Use Policy.
 
@@ -109,7 +109,7 @@ take any other action regarding a Team belong solely to Gratipay.
   1. Gratipay does not take any fee from payments made by Participants to
      Teams. Gratipay and the Service are funded through the Service itself, by
 voluntary contributions from Gratipay Participants and Teams who wish to fund
-our own Open Work. To contribute to Gratipay, please [visit Gratipay's Team
+our own **Open Work**. To contribute to Gratipay, please [visit Gratipay's Team
 page](/Gratipay/).
 
   1. You are responsible for paying any third-party fees associated with your
@@ -118,8 +118,8 @@ page](/Gratipay/).
   1. You are responsible for paying any taxes and withholdings associated with
      your use of the Service. Team Owners, and not Gratipay, are responsible
 for compliance with all laws, as well as any taxes and withholding
-requirements, applicable to payments made to Team Members (whether through the
-Payroll feature or otherwise), including without limitation payroll tax,
+requirements, applicable to payouts made to Team Members (whether through the
+Take-What-You-Want Payout feature or otherwise), including without limitation **payroll** tax,
 unemployment insurance, and worker compensation insurance payments. Team Owners
 are also responsible for providing any required tax and other documentation to
 employees, independent contractors, tax authorities, or any other person.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -39,7 +39,7 @@ these Terms.
 
   1. A Participant may establish a Project on the Service. The Participant who
      establishes a Project is the Project Owner. Projects may optionally have
-other Participants as Collaborators.
+other Participants as Collaborators. The Project Owner is also a Collaborator.
 
   1. A Participant may give payments to a Project. A Participant who gives payments
      to a Project is a Giver.
@@ -83,7 +83,7 @@ take any other action regarding a Project belong solely to Gratipay.
      Project are made exclusively because of your collaboration in the Work
 described in the Project's profile.
 
-  1. By accepting a payment from a Project, the Collaborator forms an agreement
+  1. By becoming a Collaborator, the Collaborator forms an agreement
      with that Project to collaborate in the Work described in the Project's
 profile. The Service is a platform to facilitate this agreement. Gratipay is
 not a party to the agreement, and is not responsible to either the Project or

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -46,9 +46,6 @@ these Terms.
   1. A Participant may make payments to a Project Owner via a Project. A
      Participant who makes payments via a Project is a Giver.
 
-  1. Gratipay reserves the right to reject, suspend, or remove a Project at any
-     time, and for any reason.
-
 1. Terms for Project Owners
 
   1. A Project Owner can use the Service to receive payments from Givers for
@@ -72,6 +69,9 @@ payments (e.g. bank account information).
 opportunity to publicly evaluate and provide commentary about the Project.
 However, all decisions regarding whether to accept, reject, suspend, remove, or
 take any other action regarding a Project belong solely to Gratipay.
+
+  1. Gratipay reserves the right to reject, suspend, or remove a Project at any
+     time, and for any reason.
 
 1. Terms for Collaborators
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -35,7 +35,7 @@ or damage arising from your failure to keep your account secure.
 your legal guardian must consent to your use and must agree to be bound by
 these Terms.
 
-1. General Rules
+1. General Terms
 
   1. A Participant may establish a Project on the Service. The Participant who
      establishes a Project is the Project Owner. Projects may optionally have

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -38,7 +38,7 @@ these Terms.
 1. The Gratipay Model and General Rules
 
   1. The Service is a platform to enable Teams of Gratipay Participants to
-     receive payments to fund Open Work. Open Work means that the Team provides
+     receive payments to fund **Open Work**. Open Work means that the Team provides
 a clear path for any individual to voluntarily begin contributing to the Team's
 work and to share in any revenue the Team generates. Some examples of Teams
 performing Open Work include an open source software project that pays

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -183,48 +183,48 @@ permissible, for example as fair use.
 
   1. The following conduct is prohibited on the Service:
 
-    * Illegal activities, including the promotion or solicitation of illegal
+    1. Illegal activities, including the promotion or solicitation of illegal
       acts.
 
-    * Malicious activity or content, such as the transmission of viruses,
-      malware, or any other malicious or destructive code, or content or
-activity intended to harm or disrupt the hardware, networks, or infrastructure
-of Gratipay or any third parties.
+    1. Malicious activity or content, such as the transmission of viruses,
+      malware, or any other malicious or destructive code, or content or activity 
+      intended to harm or disrupt the hardware, networks, or infrastructure of 
+      Gratipay or any third parties.
 
-    * Unauthorized access, including: accessing or attempting to access any
-      non-public interface, system, or functionality of the Service, or testing
-the Service for vulnerabilities, except as described in our [security
-disclosure policy](/about/security/).
+    1. Unauthorized access, including: accessing or attempting to access any
+      non-public interface, system, or functionality of the Service, or testing the 
+      Service for vulnerabilities, except as described in our 
+      [security disclosure policy](/about/security/).
 
-    * Abuse, including threats of violence or harassment of a Participant
+    1. Abuse, including threats of violence or harassment of a Participant
       through repeated unwanted contact.
 
-    * Posting anyone's personal or confidential information, such as social
-      security numbers, credit card numbers, street addresses, phone numbers,
-confidential ID numbers, or account passwords, without their permission.
+    1. Posting anyone's personal or confidential information, such as social
+      security numbers, credit card numbers, street addresses, phone numbers, 
+      confidential ID numbers, or account passwords, without their permission.
 
-    * Aggressive trolling or activism.
+    1. Aggressive trolling or activism.
 
-    * Account hijacking, including any access to or use of another
+    1. Account hijacking, including any access to or use of another
       Participant's account without their permission.
 
-    * Child exploitation, including any content or activity that exploits or
+    1. Child exploitation, including any content or activity that exploits or
       abuses children.
 
-    * Spam, including posting unsolicited promotional or commercial content in
-      comments, sending invitations for the purpose of advertising to the
-recipients, or posting content or links for the purpose of manipulating search
-or other algorithms.
+    1. Spam, including posting unsolicited promotional or commercial content in
+      comments, sending invitations for the purpose of advertising to the 
+      recipients, or posting content or links for the purpose of manipulating search 
+      or other algorithms.
 
-    * Intellectual property infringement, including the infringing use of third
-      party trademarks or the unauthorized and unlawful posting of copyrighted
-content. We respond to reports of copyright infringement as described in the
-Copyright Policy.
+    1. Intellectual property infringement, including the infringing use of third
+      party trademarks or the unauthorized and unlawful posting of copyrighted 
+      content. We respond to reports of copyright infringement as described in the 
+      Copyright Policy.
 
-    * Fraud or impersonation, including any use of the Service to impersonate
-      or deceive others. Contests or promotions that violate any applicable law
-or regulation, or that suggest in any way that Gratipay is involved in or
-responsible for the activity.
+    1. Fraud or impersonation, including any use of the Service to impersonate
+      or deceive others. Contests or promotions that violate any applicable law 
+      or regulation, or that suggest in any way that Gratipay is involved in or 
+      responsible for the activity.
 
 1. Gratipay's Service Providers
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -39,10 +39,9 @@ these Terms.
 
   1. The Service is a platform to facilitate payments for goods or services.
      The nature and scope of such goods or services (the "Work") is defined by
-each Project.
+Projects established by Participants on the Service.
 
-  1. A Participant may establish a Project on the Service. A Participant who
-     establishes a Project is also a Project Owner.
+  1. A Participant who establishes a Project is also a Project Owner.
 
   1. Projects may optionally have other Participants as Collaborators. The
      Project Owner is also a Collaborator.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -93,11 +93,12 @@ payments is solely between those parties.
 
 1. Terms for Givers
 
-  1. When you make a payment via a Project to a Project Owner, it is a payment
-     for the Work described in the Project's profile. You understand and
-acknowledge that your payment does not entitle you personally to receive any
-goods or services from the Project Owner, unless the Project Owner explicitly
-offers those things to Givers.
+  1. Givers can make payments to Project Owners because of the Project's Work
+     and for no other reason.
+
+  1. You understand and acknowledge that your payment does not entitle you
+     personally to receive any goods or services from the Project Owner, unless
+the Project Owner explicitly offers those things to Givers.
 
   1. Project Owners are the only party responsible to Givers for producing the
      Work their Project describes. Gratipay does not warrant or guarantee that

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -37,11 +37,11 @@ these Terms.
 
 1. General Terms
 
-  1. The Service is a platform to facilitate payments for goods or services. 
-       The nature and scope of such goods or services (the "Work") is defined 
-by each Project.
+  1. The Service is a platform to facilitate payments for goods or services.
+     The nature and scope of such goods or services (the "Work") is defined by
+each Project.
 
-  1. A Participant may establish a Project on the Service. A Participant who 
+  1. A Participant may establish a Project on the Service. A Participant who
      establishes a Project is also a Project Owner.
 
   1. Projects may optionally have other Participants as Collaborators. The
@@ -57,7 +57,8 @@ by each Project.
 on the Service, you agree that payments via the Project will be used
 exclusively to support the Work described in the Project's profile.
 
-  1. Project Owners may only make payments to a Collaborator for their contributions.
+  1. Project Owners may only make payments to a Collaborator for their
+     contributions.
 
   1. Gratipay is not a party to any agreement between Project Owners and
      Givers, and is not responsible to either the Project Owner or the Giver if
@@ -82,7 +83,7 @@ take any other action regarding a Project belong solely to Gratipay.
   1. Project Owners can use the Service to distribute payments to
      Collaborators.
 
-  1. Collaborators can receive payments from Project Owners because of their 
+  1. Collaborators can receive payments from Project Owners because of their
      collaboration in the Project's Work and for no other reason.
 
   1. Gratipay is not a party to any agreement between Project Owners and
@@ -103,11 +104,11 @@ acknowledge that your payment does not entitle you personally to receive any
 goods or services from the Project Owner, unless the Project Owner explicitly
 offers those things to Givers.
 
-  1. Project Owners are the only party responsible to Givers for producing the 
-     Work their Project describes. Gratipay is not obligated to provide refunds 
-to Givers or produce work under any circumstance. Gratipay does not hold funds 
-on behalf of Project Owners, and does not warrant or guarantee that Project Owners 
-will provide the Work they promise.
+  1. Project Owners are the only party responsible to Givers for producing the
+     Work their Project describes. Gratipay is not obligated to provide refunds
+to Givers or produce work under any circumstance. Gratipay does not hold funds
+on behalf of Project Owners, and does not warrant or guarantee that Project
+Owners will provide the Work they promise.
 
 1. Fees and Taxes
 
@@ -184,47 +185,47 @@ permissible, for example as fair use.
   1. The following conduct is prohibited on the Service:
 
     1. Illegal activities, including the promotion or solicitation of illegal
-      acts.
+       acts.
 
     1. Malicious activity or content, such as the transmission of viruses,
-      malware, or any other malicious or destructive code, or content or activity 
-      intended to harm or disrupt the hardware, networks, or infrastructure of 
-      Gratipay or any third parties.
+       malware, or any other malicious or destructive code, or content or
+activity intended to harm or disrupt the hardware, networks, or infrastructure
+of Gratipay or any third parties.
 
     1. Unauthorized access, including: accessing or attempting to access any
-      non-public interface, system, or functionality of the Service, or testing the 
-      Service for vulnerabilities, except as described in our 
-      [security disclosure policy](/about/security/).
+       non-public interface, system, or functionality of the Service, or
+testing the Service for vulnerabilities, except as described in our [security
+disclosure policy](/about/security/).
 
     1. Abuse, including threats of violence or harassment of a Participant
-      through repeated unwanted contact.
+       through repeated unwanted contact.
 
     1. Posting anyone's personal or confidential information, such as social
-      security numbers, credit card numbers, street addresses, phone numbers, 
-      confidential ID numbers, or account passwords, without their permission.
+       security numbers, credit card numbers, street addresses, phone numbers,
+confidential ID numbers, or account passwords, without their permission.
 
     1. Aggressive trolling or activism.
 
     1. Account hijacking, including any access to or use of another
-      Participant's account without their permission.
+       Participant's account without their permission.
 
     1. Child exploitation, including any content or activity that exploits or
-      abuses children.
+       abuses children.
 
     1. Spam, including posting unsolicited promotional or commercial content in
-      comments, sending invitations for the purpose of advertising to the 
-      recipients, or posting content or links for the purpose of manipulating search 
-      or other algorithms.
+       comments, sending invitations for the purpose of advertising to the
+recipients, or posting content or links for the purpose of manipulating search
+or other algorithms.
 
-    1. Intellectual property infringement, including the infringing use of third
-      party trademarks or the unauthorized and unlawful posting of copyrighted 
-      content. We respond to reports of copyright infringement as described in the 
-      Copyright Policy.
+    1. Intellectual property infringement, including the infringing use of
+       third party trademarks or the unauthorized and unlawful posting of
+copyrighted content. We respond to reports of copyright infringement as
+described in the Copyright Policy.
 
     1. Fraud or impersonation, including any use of the Service to impersonate
-      or deceive others. Contests or promotions that violate any applicable law 
-      or regulation, or that suggest in any way that Gratipay is involved in or 
-      responsible for the activity.
+       or deceive others. Contests or promotions that violate any applicable
+law or regulation, or that suggest in any way that Gratipay is involved in or
+responsible for the activity.
 
 1. Gratipay's Service Providers
 
@@ -238,9 +239,9 @@ agreement](https://www.braintreepayments.com/legal/bank-agreement-us).
 1. Nonprofits and Charities using Gratipay
 
   1. If you are a nonprofit organization, soliciting payments on Gratipay may
-     subject you to local laws regarding charitable solicitations,
-including various registration, reporting, and audit requirements. You are
-solely responsible for compliance with these and any other applicable law or
+     subject you to local laws regarding charitable solicitations, including
+various registration, reporting, and audit requirements. You are solely
+responsible for compliance with these and any other applicable law or
 regulation.
 
   1. Gratipay makes no representation or warranty regarding the tax-exempt

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -56,8 +56,8 @@ Projects established on the Service.
 on the Service, you agree that payments via the Project will be used
 exclusively to support the Work described in the Project's profile.
 
-  1. Project Owners can make payments to Collaborators because of their
-     collaboration in the Project's Work and for no other reason.
+  1. Project Owners may only make payments to Collaborators for their
+     collaboration in the Project's Work.
 
   1. Gratipay is not a party to any agreement between Project Owners and
      Givers, and is not responsible to either the Project Owner or the Giver if
@@ -78,8 +78,8 @@ take any other action regarding a Project belong solely to Gratipay.
   1. Project Owners can use the Service to distribute payments to
      Collaborators.
 
-  1. Collaborators can receive payments from Project Owners because of their
-     collaboration in the Project's Work and for no other reason.
+  1. Collaborators may only receive payments from Project Owners for their
+     collaboration in the Project's Work.
 
   1. Gratipay is not a party to any agreement between Project Owners and
      Collaborators, and is not responsible to either the Project Owner or the
@@ -93,8 +93,7 @@ payments is solely between those parties.
 
 1. Terms for Givers
 
-  1. Givers can make payments to Project Owners because of the Project's Work
-     and for no other reason.
+  1. Givers may only make payments to Project Owners for the Project's Work.
 
   1. You understand and acknowledge that your payment does not entitle you
      personally to receive any goods or services from the Project Owner, unless

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -99,7 +99,7 @@ payments is solely between those parties.
 1. Terms for Givers
 
   1. When you make a payment via a Project to a Project Owner, it is a payment
-     to pay for the Work described in the Project's profile. You understand and
+     for the Work described in the Project's profile. You understand and
 acknowledge that your payment does not entitle you personally to receive any
 goods or services from the Project Owner, unless the Project Owner explicitly
 offers those things to Givers.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -57,8 +57,8 @@ each Project.
 on the Service, you agree that payments via the Project will be used
 exclusively to support the Work described in the Project's profile.
 
-  1. Project Owners may only make payments to a Collaborator for their
-     contributions.
+  1. Project Owners can make payments to Collaborators because of their
+     collaboration in the Project's Work and for no other reason.
 
   1. Gratipay is not a party to any agreement between Project Owners and
      Givers, and is not responsible to either the Project Owner or the Giver if

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -65,10 +65,6 @@ exclusively to support the Work described in the Project's profile.
 either party breaches the terms of any such agreement (e.g. if the Project
 Owner fails to provide the promised goods or services).
 
-  1. A Project Owner can only begin receiving payments from Givers once the
-     Project Owner has provided a working withdrawal mechanism for receiving
-payments (e.g. bank account information).
-
   1. Establishing a Project on Gratipay involves an application and approval
      process. As part of this process, the Gratipay community will have the
 opportunity to publicly evaluate and provide commentary about the Project.
@@ -105,10 +101,9 @@ goods or services from the Project Owner, unless the Project Owner explicitly
 offers those things to Givers.
 
   1. Project Owners are the only party responsible to Givers for producing the
-     Work their Project describes. Gratipay is not obligated to provide refunds
-to Givers or produce work under any circumstance. Gratipay does not hold funds
-on behalf of Project Owners, and does not warrant or guarantee that Project
-Owners will provide the Work they promise.
+     Work their Project describes. Gratipay does not warrant or guarantee that
+Project Owners will provide the Work they promise, and Gratipay is not
+obligated to provide refunds to Givers or produce work under any circumstance.
 
 1. Fees and Taxes
 

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -110,8 +110,8 @@ obligated to provide refunds to Givers or produce work under any circumstance.
   1. Gratipay does not take any fee from payments made by Givers to Project
      Owners, or by Project Owners to Collaborators. Gratipay and the Service
 are funded through the Service itself, by voluntary payments from Givers who
-wish to fund our own Work. To contribute to Gratipay, please [visit Gratipay's
-Project page](/Gratipay/).
+wish to fund our own Work. To contribute to Gratipay, please visit Gratipay's
+[Project page for the Service](/Gratipay/).
 
   1. You are responsible for paying any third-party fees associated with your
      use of the Service, such as credit card and bank fees.

--- a/www/about/policies/terms-of-service.md
+++ b/www/about/policies/terms-of-service.md
@@ -39,7 +39,7 @@ these Terms.
 
   1. The Service is a platform to facilitate payments for goods or services.
      The nature and scope of such goods or services (the "Work") is defined by
-Projects established by Participants on the Service.
+Projects established on the Service.
 
   1. A Participant who establishes a Project is also a Project Owner.
 


### PR DESCRIPTION
https://github.com/gratipay/inside.gratipay.com/issues/432#issuecomment-243522286

> I've started a [private ticket](https://github.com/gratipay/legal-tor-ekeland/issues/31) with our [lawyer](https://github.com/copiesofcopies) about revising our Terms of Service to relax our open work requirement. In the interest of time/money, I think the way to proceed is **take a stab at revising them ourselves**, and then bring our revision to him for review.

Stub out a PR for changes.

Related milestones:
- IG: https://github.com/gratipay/inside.gratipay.com/milestone/9
- G: https://github.com/gratipay/gratipay.com/milestone/22
### Todo
- [x] come up with an alias for Participants acting as contributors, so that we're never using "Participant" in a context-dependent way
  - Tried to address in https://github.com/gratipay/gratipay.com/pull/4117/commits/78edd7983ec2ca316db9b5fd0cb5212e763d8822 by creating "Giver"
- [x] more clearly describe the differences between these various roles up from (and clarify that each is a Participant interacting with the platform in a different way)
  - Tried to address in https://github.com/gratipay/gratipay.com/pull/4117/commits/78edd7983ec2ca316db9b5fd0cb5212e763d8822
- [x] revise the individual sections (e.g. the new 3-5) such that each is limited to describing the obligations of one role. So one section for Owners, one for Participant-contributors, and one for Members
  - Tried to address in https://github.com/gratipay/gratipay.com/pull/4117/commits/78edd7983ec2ca316db9b5fd0cb5212e763d8822
- [x] rename "Owners" and "Members" to "Project Owners" and "Project Members." "Members" in particular is ambiguous -- since "members," "participants," and "users" could all potentially be used interchangeably in common speech, people may get confused trying to keep them straight when reading through the terms.
  - Tried to address in  https://github.com/gratipay/gratipay.com/pull/4117/commits/01e8cb2aa068706354023a7d93e0d74a7f7f8e2e
- [x] Probably use different language for the "Work" performed by the project and the work performed by Members for Projects 
  - Tried to address in  https://github.com/gratipay/gratipay.com/pull/4117/commits/01e8cb2aa068706354023a7d93e0d74a7f7f8e2e
- [x] Run changes by @tieguy.
- [ ] Propagate final version to `terms-of-service.spt`.
- [ ] Email new terms and post as a news item. (https://github.com/gratipay/gratipay.com/pull/4117#issuecomment-262336157)
