### PR TITLE
update the "★ announcement ★" link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -74,11 +74,10 @@
         <table id="notice">
             <tr>
                 <td>&#x2605;</td>
-                <td>{{ _( "{nowrap}Our new {a}Terms of Service{_a}{_nowrap} {nowrap}make it {a2}easier to get funded on Gratipay{_a}{_nowrap}."
+                <td>{{ _( "{nowrap}We have {a}integrated npm{_a} into Gratipay.{_nowrap}{_nowrap}"
                         , nowrap='<span class="nowrap">'|safe
                         , _nowrap='</span>'|safe
-                        , a='<a href="/about/policies/terms-of-service">'|safe
-                        , a2='<a href="https://gratipay.news/from-teams-to-projects-45c46718507b">'|safe
+                        , a='<a href="https://gratipay.news/integrating-npm-39333109419d">'|safe
                         , _a='</a>'|safe
                          ) }}</td>
                 <td>&#x2605;</td>

--- a/tests/py/test_notifications.py
+++ b/tests/py/test_notifications.py
@@ -27,4 +27,4 @@ class TestNotifications(Harness):
         assert alice.notifications == ["abcd", "bcde"]
 
     def test_blog_announcement(self):
-        assert 'projects-45c46718507b">easier' in self.client.GET('/').body
+        assert 'integrating-npm-39333109419d">integrated' in self.client.GET('/').body


### PR DESCRIPTION
This should take care of [update the "★ announcement ★" link](https://github.com/gratipay/gratipay.com/issues/4148#issue-184259778)

**NB:** I may need to change the actually link address if @whit537/ @aandis changes the path of the search page over time. 
