### PR TITLE
Wrap marky-markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
  - if [ "${TRAVIS_BRANCH}" = "master" -a "${TRAVIS_PULL_REQUEST}" = "false" ]; then rm -rf env; fi
  - touch requirements.txt package.json
  - make env
+ - npm install -g marky-markdown
 before_script:
  - echo "DATABASE_URL=dbname=gratipay" | tee -a tests/local.env local.env
  - psql -U postgres -c 'CREATE DATABASE "gratipay";'

--- a/gratipay/utils/markdown.py
+++ b/gratipay/utils/markdown.py
@@ -15,6 +15,5 @@ def render(markdown):
 def marky(markdown):
     """Process markdown the same way npm does.
     """
-    echo = Popen(("echo", markdown), stdout=PIPE)
-    marky = Popen(("marky-markdown", "/dev/stdin"), stdin=echo.stdout, stdout=PIPE)
-    return Markup(marky.communicate()[0])
+    marky = Popen(("marky-markdown", "/dev/stdin"), stdin=PIPE, stdout=PIPE)
+    return Markup(marky.communicate(markdown)[0])

--- a/gratipay/utils/markdown.py
+++ b/gratipay/utils/markdown.py
@@ -1,5 +1,8 @@
+import subprocess
+
 from markupsafe import Markup
 import misaka as m  # http://misaka.61924.nl/
+
 
 def render(markdown):
     return Markup(m.html(
@@ -7,3 +10,9 @@ def render(markdown):
         extensions=m.EXT_AUTOLINK | m.EXT_STRIKETHROUGH | m.EXT_NO_INTRA_EMPHASIS,
         render_flags=m.HTML_SKIP_HTML | m.HTML_TOC | m.HTML_SMARTYPANTS | m.HTML_SAFELINK
     ))
+
+
+def marky(markdown):
+    """Process markdown the same way npm does.
+    """
+    return subprocess.call()

--- a/gratipay/utils/markdown.py
+++ b/gratipay/utils/markdown.py
@@ -1,4 +1,4 @@
-import subprocess
+from subprocess import Popen, PIPE
 
 from markupsafe import Markup
 import misaka as m  # http://misaka.61924.nl/
@@ -15,4 +15,6 @@ def render(markdown):
 def marky(markdown):
     """Process markdown the same way npm does.
     """
-    return subprocess.call()
+    echo = Popen(("echo", markdown), stdout=PIPE)
+    marky = Popen(("marky-markdown", "/dev/stdin"), stdin=echo.stdout, stdout=PIPE)
+    return marky.communicate()[0]

--- a/gratipay/utils/markdown.py
+++ b/gratipay/utils/markdown.py
@@ -17,4 +17,4 @@ def marky(markdown):
     """
     echo = Popen(("echo", markdown), stdout=PIPE)
     marky = Popen(("marky-markdown", "/dev/stdin"), stdin=echo.stdout, stdout=PIPE)
-    return marky.communicate()[0]
+    return Markup(marky.communicate()[0])

--- a/tests/py/test_markdown.py
+++ b/tests/py/test_markdown.py
@@ -1,0 +1,12 @@
+from gratipay.testing import Harness
+from gratipay.utils import markdown
+
+from HTMLParser import HTMLParser
+
+class TestMarkdown(Harness):
+
+    def test_marky_works(self):
+        md = "**Hello World!**"
+        actual = HTMLParser().unescape(markdown.marky(md)).strip()
+        expected = '<p><strong>Hello World!</strong></p>'
+        assert actual == expected


### PR DESCRIPTION
[marky-markdown](https://github.com/npm/marky-markdown#command-line-usage) is the markdown parser that npm uses. We should use it with npm package readmes. There's a [CLI](https://github.com/npm/marky-markdown#command-line-usage) that we should be able to wrap. It doesn't take `stdin` but we can work around that using `/dev/stdin` like so:

```
marky-markdown /dev/stdin
```