### PR TITLE
Install self in requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ env: requirements.txt requirements.dev.txt setup.py
 				./env/
 	$(pip) install --no-index -r requirements.txt
 	$(pip) install --no-index -r requirements.dev.txt
-	$(pip) install -e ./
 	touch env
 
 clean:

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,5 @@
   ./vendor/idna-2.1.tar.gz
   ./vendor/ipaddress-1.0.16.tar.gz
 ./vendor/cryptography-1.3.2.tar.gz
+
+-e .


### PR DESCRIPTION
Heroku doesn't run `make env`, they simply `pip install -r requirements.txt`. We want ourself installed in the virtualenv in order to be able to run scripts.