### PR TITLE
Add a package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "Gratipay",
+    "dependencies": {"marky-markdown":"latest"}
+}


### PR DESCRIPTION
Heroku refuses to install the node buildpack without this. Might as well see about installing marky-markdown from here.