### PR TITLE
Rename 'Routes' to 'Payments'

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -119,7 +119,7 @@
                , ('/giving/',    _('Giving'),    True,   False)
                , ('/history/',   _('History'),   True,   False)
                , ('/emails/',    _('Emails'),    True,   False)
-               , ('/routes/',    _('Routes'),    True,   False)
+               , ('/routes/',    _('Payments'),  True,   False)
                , ('/settings/',  _('Settings'),  True,   False)
                , ('/events/',    _('Events'),    False,  False)
                 ] %}


### PR DESCRIPTION
Fixes https://github.com/gratipay/gratipay.com/issues/3906. 

Intentionally kept this simple - I've only modified the left-nav text, the route URL (`/~user/routes`) and headings ('Payment Routes') are untouched.

**After:**

<img width="625" alt="screen shot 2016-10-30 at 1 06 53 am" src="https://cloud.githubusercontent.com/assets/3893573/19832278/45bb3b50-9e3d-11e6-9500-7db6fe2c2724.png">

**Before:**

<img width="631" alt="screen shot 2016-10-30 at 1 07 13 am" src="https://cloud.githubusercontent.com/assets/3893573/19832279/45c775aa-9e3d-11e6-9727-2ddce2a55b71.png">
