### PR TITLE
Fix CSRF annoyance

### DIFF
--- a/tests/py/test_hooks.py
+++ b/tests/py/test_hooks.py
@@ -114,23 +114,3 @@ class Tests2(Harness):
         r = self.client.GET('/about/')
         assert r.headers['Cache-Control'] == 'no-cache'
         assert 'Vary' not in r.headers
-
-    def test_no_csrf_cookie(self):
-        r = self.client.POST('/', csrf_token=False, raise_immediately=False)
-        assert r.code == 403
-        assert "Bad CSRF cookie" in r.body
-        assert b'csrf_token' in r.headers.cookie
-
-    def test_bad_csrf_cookie(self):
-        r = self.client.POST('/', csrf_token=b'bad_token', raise_immediately=False)
-        assert r.code == 403
-        assert "Bad CSRF cookie" in r.body
-        assert r.headers.cookie[b'csrf_token'].value != 'bad_token'
-
-    def test_csrf_cookie_set_for_most_requests(self):
-        r = self.client.GET('/about/')
-        assert b'csrf_token' in r.headers.cookie
-
-    def test_no_csrf_cookie_set_for_assets(self):
-        r = self.client.GET('/assets/gratipay.css')
-        assert b'csrf_token' not in r.headers.cookie

--- a/tests/py/test_hooks.py
+++ b/tests/py/test_hooks.py
@@ -5,7 +5,6 @@ from base64 import b64encode
 from aspen.http.request import Request
 from aspen.http.response import Response
 
-from gratipay.security import csrf
 from gratipay.security.user import SESSION
 from gratipay.testing import Harness
 
@@ -135,19 +134,3 @@ class Tests2(Harness):
     def test_no_csrf_cookie_set_for_assets(self):
         r = self.client.GET('/assets/gratipay.css')
         assert b'csrf_token' not in r.headers.cookie
-
-    def test_sanitize_token_passes_through_good_token(self):
-        token = 'ddddeeeeaaaaddddbbbbeeeeeeeeffff'
-        assert csrf._sanitize_token(token) == token
-
-    def test_sanitize_token_rejects_overlong_token(self):
-        token = 'ddddeeeeaaaaddddbbbbeeeeeeeefffff'
-        assert csrf._sanitize_token(token) is None
-
-    def test_sanitize_token_rejects_underlong_token(self):
-        token = 'ddddeeeeaaaaddddbbbbeeeeeeeefff'
-        assert csrf._sanitize_token(token) is None
-
-    def test_sanitize_token_rejects_goofy_token(self):
-        token = 'ddddeeeeaaaadddd bbbbeeeeeeeefff'
-        assert csrf._sanitize_token(token) is None

--- a/tests/py/test_security_csrf.py
+++ b/tests/py/test_security_csrf.py
@@ -6,18 +6,43 @@ from gratipay.security import csrf
 
 class Tests(object):
 
-    def test_sanitize_token_passes_through_good_token(self):
+    # st - _sanitize_token
+
+    def test_st_passes_through_good_token(self):
         token = 'ddddeeeeaaaaddddbbbbeeeeeeeeffff'
         assert csrf._sanitize_token(token) == token
 
-    def test_sanitize_token_rejects_overlong_token(self):
+    def test_st_rejects_overlong_token(self):
         token = 'ddddeeeeaaaaddddbbbbeeeeeeeefffff'
         assert csrf._sanitize_token(token) is None
 
-    def test_sanitize_token_rejects_underlong_token(self):
+    def test_st_rejects_underlong_token(self):
         token = 'ddddeeeeaaaaddddbbbbeeeeeeeefff'
         assert csrf._sanitize_token(token) is None
 
-    def test_sanitize_token_rejects_goofy_token(self):
+    def test_st_rejects_goofy_token(self):
         token = 'ddddeeeeaaaadddd bbbbeeeeeeeefff'
         assert csrf._sanitize_token(token) is None
+
+
+    # integration tests
+
+    def test_no_csrf_cookie_gives_403(self):
+        r = self.client.POST('/', csrf_token=False, raise_immediately=False)
+        assert r.code == 403
+        assert "Bad CSRF cookie" in r.body
+        assert b'csrf_token' in r.headers.cookie
+
+    def test_bad_csrf_cookie_gives_403(self):
+        r = self.client.POST('/', csrf_token=b'bad_token', raise_immediately=False)
+        assert r.code == 403
+        assert "Bad CSRF cookie" in r.body
+        assert r.headers.cookie[b'csrf_token'].value != 'bad_token'
+
+    def test_csrf_cookie_set_for_most_requests(self):
+        r = self.client.GET('/about/')
+        assert b'csrf_token' in r.headers.cookie
+
+    def test_no_csrf_cookie_set_for_assets(self):
+        r = self.client.GET('/assets/gratipay.css')
+        assert b'csrf_token' not in r.headers.cookie

--- a/tests/py/test_security_csrf.py
+++ b/tests/py/test_security_csrf.py
@@ -2,9 +2,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from gratipay.security import csrf
+from gratipay.testing import Harness
 
 
-class Tests(object):
+class Tests(Harness):
 
     # st - _sanitize_token
 

--- a/tests/py/test_security_csrf.py
+++ b/tests/py/test_security_csrf.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from gratipay.security import csrf
+
+
+class Tests(object):
+
+    def test_sanitize_token_passes_through_good_token(self):
+        token = 'ddddeeeeaaaaddddbbbbeeeeeeeeffff'
+        assert csrf._sanitize_token(token) == token
+
+    def test_sanitize_token_rejects_overlong_token(self):
+        token = 'ddddeeeeaaaaddddbbbbeeeeeeeefffff'
+        assert csrf._sanitize_token(token) is None
+
+    def test_sanitize_token_rejects_underlong_token(self):
+        token = 'ddddeeeeaaaaddddbbbbeeeeeeeefff'
+        assert csrf._sanitize_token(token) is None
+
+    def test_sanitize_token_rejects_goofy_token(self):
+        token = 'ddddeeeeaaaadddd bbbbeeeeeeeefff'
+        assert csrf._sanitize_token(token) is None


### PR DESCRIPTION
Redux of #4184 (I couldn't help but close it in the course of https://github.com/gratipay/inside.gratipay.com/issues/884#issuecomment-260035697).

--------------------

We're getting [a ridiculous number](https://sentry.io/gratipay/gratipay-com/issues/79907897/) of `TypeError`s from trying to `constant_time_compare` one or two `None`s. Sup with that?