### PR TITLE
Implement Content-Security-Policy (CSP)

### DIFF
--- a/gratipay/security/__init__.py
+++ b/gratipay/security/__init__.py
@@ -40,3 +40,9 @@ def add_headers_to_response(response):
     # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
     if 'X-XSS-Protection' not in response.headers:
         response.headers['X-XSS-Protection'] = '1; mode=block'
+
+    # CSP - https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+    # Allow resources from gratipay.com & all gratipay subdomains.
+    # Allow fonts from cloud.typography.com.
+    if 'content-security-policy' not in response.headers:
+        response.headers['content-security-policy'] = 'default-src \'self\' *.gratipay.com; font-src cloud.typography.com;'

--- a/gratipay/security/__init__.py
+++ b/gratipay/security/__init__.py
@@ -45,3 +45,11 @@ def add_headers_to_response(response):
     # Allow resources from gratipay.com & all gratipay subdomains.
     # Allow fonts from cloud.typography.com.
     if 'content-security-policy' not in response.headers:
+        response.headers['content-security-policy'] = ( 'default-src \'self\';' 
+                                                        'script-src assets.gratipay.com;'
+                                                        'style-src assets.gratipay.com;'
+                                                        'img-src *;'
+                                                        'font-src cloud.typography.com;' 
+                                                        'upgrade-insecure-requests;'
+                                                        'block-all-mixed-content;'
+                                                        'reflected-xss block;')

--- a/gratipay/security/__init__.py
+++ b/gratipay/security/__init__.py
@@ -45,4 +45,3 @@ def add_headers_to_response(response):
     # Allow resources from gratipay.com & all gratipay subdomains.
     # Allow fonts from cloud.typography.com.
     if 'content-security-policy' not in response.headers:
-        response.headers['content-security-policy'] = 'default-src \'self\' *.gratipay.com; font-src cloud.typography.com;'

--- a/tests/py/test_security.py
+++ b/tests/py/test_security.py
@@ -55,14 +55,15 @@ class TestSecurity(Harness):
 
     def test_ahtr__csp(self):
         headers = self.client.GET('/about/').headers
-        assert headers['content-security-policy'] = ( 'default-src \'self\';' 
-                                                        'script-src assets.gratipay.com;'
-                                                        'style-src assets.gratipay.com;'
-                                                        'img-src *;'
-                                                        'font-src cloud.typography.com;' 
-                                                        'upgrade-insecure-requests;'
-                                                        'block-all-mixed-content;'
-                                                        'reflected-xss block;')
+        policy = ('default-src \'self\';' 
+                    'script-src assets.gratipay.com;'
+                    'style-src assets.gratipay.com;'
+                    'img-src *;'
+                    'font-src cloud.typography.com;' 
+                    'upgrade-insecure-requests;'
+                    'block-all-mixed-content;'
+                    'reflected-xss block;')
+        assert headers['content-security-policy'] == policy
 
 
     # ep - EncryptingPacker

--- a/tests/py/test_security.py
+++ b/tests/py/test_security.py
@@ -53,6 +53,17 @@ class TestSecurity(Harness):
         headers = self.client.GET('/about/').headers
         assert headers['X-XSS-Protection'] == '1; mode=block'
 
+    def test_ahtr__csp(self):
+        headers = self.client.GET('/about/').headers
+        assert headers['content-security-policy'] = ( 'default-src \'self\';' 
+                                                        'script-src assets.gratipay.com;'
+                                                        'style-src assets.gratipay.com;'
+                                                        'img-src *;'
+                                                        'font-src cloud.typography.com;' 
+                                                        'upgrade-insecure-requests;'
+                                                        'block-all-mixed-content;'
+                                                        'reflected-xss block;')
+
 
     # ep - EncryptingPacker
 


### PR DESCRIPTION
This solves the following report: https://hackerone.com/reports/90777

This policy allows:
- Resources from gratipay.com & all gratipay subdomains.
- Fonts from cloud.typography.com.

If you like we could allow GIFs from, for example, [giphy.com](https://giphy.com/). That way users can at least embed GIFs.

Concerning [report-uri.io](https://report-uri.io/), you will need to sign up for that and if you have any issues feel free to contact me.