### PR TITLE
Add tests for payday behavior when balance is negative

### DIFF
--- a/gratipay/testing/billing.py
+++ b/gratipay/testing/billing.py
@@ -49,6 +49,14 @@ class BillingHarness(Harness, PaydayMixin):
                                            claimed_time='now', email_address='abcd@gmail.com')
         self.homer_route = ExchangeRoute.insert(self.homer, 'paypal', 'abcd@gmail.com')
 
+        # A customer with both Braintree and Paypal attached.
+        self.marge = self.make_participant('marge', is_suspicious=False, verified_in='US',
+                                           claimed_time='now', email_address='marge@example.com')
+        self.marge_paypal_route = ExchangeRoute.insert(self.marge, 'paypal', 'marge@example.com')
+        self.marge_braintree_route = ExchangeRoute.insert(self.marge, 'braintree-cc',
+                                                                               self.marge_cc_token)
+        self.marge_route = self.marge_paypal_route  # so hacky
+
 
     @classmethod
     def tearDownClass(cls):
@@ -66,9 +74,11 @@ def install_fixture():
         cls = BillingHarness
         cls.roman_bt_id = braintree.Customer.create().customer.id
         cls.obama_bt_id = braintree.Customer.create().customer.id
+        cls.marge_bt_id = braintree.Customer.create().customer.id
         cls.bt_card = braintree.PaymentMethod.create({
             "customer_id": cls.obama_bt_id,
             "payment_method_nonce": Nonces.Transactable
         }).payment_method
         cls.obama_cc_token = cls.bt_card.token
+        cls.marge_cc_token = cls.bt_card.token
         cls._fixture_installed = True

--- a/tests/py/fixtures/BillingHarness.yml
+++ b/tests/py/fixtures/BillingHarness.yml
@@ -7,17 +7,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAG3ak1UAA5SRQVODMBCF7/0VmdwjSS3WdgK9+QvqxdvKLpBKApMEC/9eip3WGfTg8b0vb/fN
-        Rh8G27BP8sG0LuPqQXJGrmjRuCrjr8cX8cwP+UoXfYitJZ+vGNMG88dUPslUbnQyiYs3saIGF8Wk
-        T7vqjOUJP4bR1lh5nfykl9el8SEKB5aYM03Go++JJzNq4C9StLYDNy58smCahdvVrVvOKGFYeGd6
-        Dyb+ss8TREIBkcWxo4zjJKOxxPO1VKmQWyHVUa33arvf7N50cg/M+b7D/+Xvge/9881FaajBcKuE
-        JooCPIbrUPAexmtjQPQUAi3Y1O32gV8AAAD//wMA0gM70fMBAAA=
+        H4sIADEkXVgAA5SRwW6DMBBE7/kKy3cXDE1EI0Nu/YL00tuWXcAJNsg2Dfx9CY2SSrSHHmeeZ3e0
+        VofRtOyTnNedzbl8ijkjW3aobZ3zt+OryPih2Khy8KEz5IoNY0pjkWZbud1lsYpmcfVmVjZgg5j1
+        6aW+YHXC8ziZBmunop/0+rrSzgdhwRCzus15cAPxaEEt/EXKzvRgp5VPBnS7cvums+sZFYwr70If
+        Xodf9jmCQCggsDD1lHOcZdCGeJHEcidkIpL0KNO9zPbP8l1Fj8CSH3r8X/4R+N6/3FxUmlr090qo
+        gyjBob8NBedgujUGREfe04rN3e4f+AUAAP//AwDXp0nO8wEAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"c0a8976b346e51bb42e6128bb3fac612"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"7b9952b7a514e3b17556f0ba2227e1df"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
@@ -29,47 +29,69 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAG/ak1UAA5SRwW6DMBBE7/kKy3cXTEBpI0Nu/YL00tuWXcApNsg2Cfx9CY2SSrSHHmeeZ3e0
-        VofRtOxMzuvO5lw+xZyRLTvUts752/FVPPNDsVHl4ENnyBUbxpTGQso03WZJqqJZXL2ZlQ3YIGZ9
-        eqkvWJ3wc5xMg7VT0U96fV1p54OwYIhZ3eY8uIF4tKAW/iJlZ3qw08onA7pduX3T2fWMCsaVd6EP
-        r8Mv+xxBIBQQWJh6yjnOMmhDvEhimYl4J2J5lMle7vaZfFfRI7Dkhx7/l38EvvcvNxeVphb9vRLq
-        IEpw6G9DwTmYbo0B0ZH3tGJzt/sHfgEAAP//AwBna82J8wEAAA==
+        H4sIADIkXVgAA5SRsXKDMBBEe3+FRr0CwnaCPQJ3+QKnSXfhDpCNBCOJGP4+mHjszJAUKXef9m7n
+        pA6DadgnOa9bm3H5FHNGtmhR2yrjb8dXkfJDvlJF70NryOUrxpTGPI23u832JVbRJK7exIoabBCT
+        Pu2qC5YnPA+jqbFyKvpJr69L7XwQFgwxq5uMB9cTj2bUwF+kaE0Hdlz4ZEA3C7erW7ucUcKw8C70
+        4XX4ZZ8jCIQCAgtjRxnHSQZtiOdJLJ+FTESyPsr1Xqb7TfKuokdgzvcd/i//CHzvn28uSk0N+nsl
+        1EEU4NDfhoJzMN4aA6Ij72nBpm73D/wCAAD//wMA81w3GvMBAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"b179a0644dabf894a946a41b7ca3b25f"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"84f36ea9e1bf49631cd410ba08de4ff5"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '<payment_method><customer_id>11443524</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
+    body: <customer></customer>
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers
+  response:
+    body:
+      string: !!binary |
+        H4sIADMkXVgAA5SRwW6DMBBE7/kKy3cXDFFDI0Nu/YL00tuWXcAJNsg2Dfx9CY2SSrSHHmeeZ3e0
+        VofRtOyTnNedzbl8ijkjW3aobZ3zt+OryPih2Khy8KEz5IoNY0pjkca7TG7lTkWzuHozKxuwQcz6
+        9FJfsDrheZxMg7VT0U96fV1p54OwYIhZ3eY8uIF4tKAW/iJlZ3qw08onA7pduX3T2fWMCsaVd6EP
+        r8Mv+xxBIBQQWJh6yjnOMmhDvEhi+SxkIpL0KNO9zPbb9F1Fj8CSH3r8X/4R+N6/3FxUmlr090qo
+        gyjBob8NBedgujUGREfe04rN3e4f+AUAAP//AwDkssF28wEAAA==
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"d5473b014386f809214bb4fdf53d5057"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode <payment_method><customer_id>80594570</customer_id><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>
     headers: {}
     method: POST
     uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods
   response:
     body:
       string: !!binary |
-        H4sIAHHak1UAA6xVTXPaMBC98ysY34U/MAnJGGV66bGXJj30kpGlNdYgS44kk/DvuzIGHAJpO+2N
-        ffu0H89Ponh4a9R0C9ZJo1dROkuiKWhuhNTrVfT0+JUsowc6KbgFIT3hzAo6mU6LUiqFFMKEsOBc
-        wBCVguavRSzFEPPOedOAJYikaZ7PF1lexGN0z6ukdZ5o1sBUS7WKvO0gioekYtdz3DQt07sLGect
-        gD/Md4EAbx60APEJRRnOlPSXyltYo2AXEq1xnimCCgK9y9PktojH0GHsTnu76yHCVFuz7OJy56z5
-        71i6Q10l/4R2TUgLzAcx/NTvWlhFAkMvG4holqQLktySJH1Ms/v09n6R/cSPeDwwVOha8XcVTgd6
-        R8UXLIU20zRP0my5DHndY8GDJLSgP6RjOMkxPmRrowTa69KqwTEoEZdM0Se90eZVY4UTNhlJZSoi
-        neuY5kCfvn8JvI+Jyb+L92fX5MQKtvToPhxqxDqigSuglP604D7cJyrWqcOcpTEKmI5oECjQ+uSe
-        2FkUnKDPOxVmHRU7z0z629RK2/cnjdG+pmlWxB/AM+YOmEWFsuQdtUePTBDns1ZMORhODN1rYMrX
-        +OnhNOYICxTZsDWQzipae9+6+zhmzoF3s9IyqcNjscZlXtluhm6IW7ZrQPvnBnxtxLMyaxNv0W2z
-        Vq8fQG+lNToQVo5pUZo3fPOO9ftuaI/g5ZLpzWmkd+jk8LTlNF0u0yIegoBje2vUyKEHoE9aaBl6
-        4ptBfPgdcNeVjlvZBhHdIBqzlu0G53uzAU3LTd2+NEW8jwLeafnS9U9H2ZsN15KVBEvzOV/maSU4
-        n/N5dXMzv1lUsEiTOYcllByv5NWjk//wIGxBN4Y4sbligGN+YFtsvb8CH7bvb9zp/+sXAAAA//8D
-        AM/WZvz1BgAA
+        H4sIADMkXVgAA6xVwXLaMBC98xWM78I2BuJkjHLrsZcmPfTSkaU1aJAlV5JJ3K/vyhhMCKTttDf2
+        7ZN29/mtKB5fazXdg3XS6HWUzpJoCpobIfVmHT0/fSJ59EgnBbcgpCecWUEn02lRSqWQQpgQFpwL
+        GKJS0JeuiKUYYt46b2qwBJE8Wd4vlndJEZ+jB14lrfNEsxqmWqp15G0LUTwkFbud46ZumO6uZJy3
+        AP7Y3xUCvHrQAsQHFGU4U9Jfu97CBgW7kmiM80wRVBDo/SJN7or4HDq23Wpvux4iTDVbNr863CUr
+        +x1Lt6ir5B/Qbglpgfkghp/6roF1JDD0soaIzpN0RdI5mWdPafaQ5g+L7Bt+xNOB4Ya2EX93w3ig
+        d1R8xVJoM00XSTrP85DXPRY8SEIJ+lU6hp2c4mN2a5RAe10bNTgGJeKSKfqsd9q8aLxhxCZnUpmK
+        SOdapjnQQHqPTv5duT/bkZEVPOnRevT5yxnrhAaugFL6cbpDeEhUrFXHPktjFDAd0aBOoPXJA7G1
+        qDZBk7cq9Hp22WVm0q9SI21fn9RG+y1N50X8DrxgdsAsKjRP3lB79MQEcdlrxZSD4cRQfQtM+S1+
+        dxjbPMMCRdZsA6S1im69b9xDHDPnwLtZaZnU4aXY4DAvrJuhFeKGdTVo/70GvzXiuzIbE+/RarNG
+        bx5B76U1OhDWjmlRmld88E7399XQHsHIJdO7saU36OT4ri1omudpEQ9BwLG8NerMnkegT1poGHri
+        s0F8+H3AjWi5D3YZz41YoLi2dNzKJujsBl2ZtawbNsObHWi6ubv/6UURH6KAt1r+aPunpez9iJPL
+        SoKli4zni7QSnGc8q1arbLWsYJkmGYccSo4re/Po5D88GHvQtSFO7G545JQf2BZLH7bk3fT9Uo7/
+        b78AAAD//wMAqqbEHRUHAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"d5c1968be63e8a7a1e806856b74d2680"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"ace15502c1bb936f03ac2b64d61de009"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}

--- a/tests/py/fixtures/TestNegativeBalances.yml
+++ b/tests/py/fixtures/TestNegativeBalances.yml
@@ -1,0 +1,387 @@
+interactions:
+- request:
+    body: !!python/unicode <transaction><payment_method_token>g79ztd</payment_method_token><amount>10.61</amount><customer_id></customer_id><type>sale</type><options><submit_for_settlement
+      type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
+      type="integer">4</participant_id></custom_fields></transaction>
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+  response:
+    body:
+      string: !!binary |
+        H4sIAKsmXVgAA9xYS2/jNhC+768IfGdk+RUnULQosChQoNvLbgq0lwVFjSwmEqmSlGPn13coSrIU
+        UUl6KFD0Zs18HHIenPno6POpLK6OoDSX4n4RXi8XVyCYTLk43C8evv9M9ovP8afIKCo0ZQZR8aer
+        q4in8S7T+61ihyjADyvThppax7Q2uVT8BdIoaEVWa84VxJoWEAXNTytjtVK425lwLQluCvHDty9R
+        MBVbMC1lLUwcLq93YRS0X1ZRgmI5FYZQxqyQ4Hm0SW6fNjcvL8njSu22j1HgQzWnrhPi0V0JXtwv
+        jKphEbhdqDagPgSVKkWkR8EUUAMpoebKxuB+keKn4SUs4tUy3JFwRVbr7+H6bnV7F27/xEj0C5r1
+        dZX+s/WXBW28tZHogf1wSdwvt7eb7c2ySyJKM660IYKW8Pr8qCzovI7JsqLi7NFASXnhkT9Dornx
+        2apyKXzyjJ4mUQ2GbkUJLwos3ouLz+d/1zltFADWQ5oq0Nrn/cmASG0WZiGFZLTgxmdewQEvnS9E
+        Em9X4e7H7SZc3kTBUNQdG2tUnee9cmq7gtCiyunqQ6j1eyhRYz44m+ZqkB50LatF6rsovUa3hU6V
+        oueREuM5aEo+IxVVhmM4NBhTQAl4WccrfMYv3es98wOzCTUs92JyXlXDavSV9P+yJN8okP9MLQ6z
+        0/ZGknEoUt35YyuI8Yq6cbHBGzaWDNrPYGVEj5qAUlIRDG4lhQZvTBrcIGZjdPwVp9ybgM7EON2v
+        QL84K29iGv+Px+nKqdBCDzhTnukZNY/grgeOKT2tiKhSkuFuGIfuWtEG3lj68uvX3R84o94Eja2M
+        jxIul8vh8ulBPTqDpR//VKHmaAnKHKIJbZpyexIM/hQ28fUoObMJyjDxuAKLLgE1jUht6QPu4jjC
+        DMrQE3EEx6uCE5RVRwESKQugYhFntNCWXPWAjnKgF4RR1Y1AI59AxIeb2xeDAXBfTpNwEW+W4Wq/
+        t31aDFvQJg73e6Rd7Ud7y9Aoacjc71xTrJb+u+syFVcumaUUJo/DVRRMhBPsGahCPrNajsCNtN23
+        nffE9qiGkj58u7CAi/RyylwWTbj9nYeX9ACkVkWcG1PpuyCgGru7vk4U5cJenLbir7HlYgs426b/
+        owSs1vRHIQ8yOKL/15U4fAZx5EoKC7jXVKSJPCH76O23bUVBRbF7/CZtAbrfTpMDLUyOJ0YmLJ6E
+        fBZRMJA5UAoJNxe9+2xVtcLEYRUe6sISvwHqtaafIZbR4pi8QAeyrg2elSwGiE7Qhk/rGrsoTkHx
+        dMGMpOOuLDNitVQwiO12U2kXJ5nWrGm0l60vMgeqBf+rhvYmoRgjz7EVq3izZvtNmKWMrdk62+3W
+        u20G23C5ZrCHhGGNzy51lo8gSkl0+jRz03p9OwbGN619DpGcY1mq84hq9GO6QQAaahNoryfSeVSU
+        1Qcpfo/vLbz5DmsQc08pF1CNEVAy56aidfGEV7aR9OcbsCItsZ1BTCuO55jKnZfBazd7SRsa1xgL
+        6mdZdaKZ4tUsCxvo+zbWUExS4dSXKUGiQ2wQPRf/FRKPpYwXi0d+tY+dDgQHgYdCplw3Ne3VgbMi
+        uyKbaUlz7x9sItOzjY0iPbMPaPRrpm57vRsQ+JoVMLWKOT/aiZYBzM0iu618Ji6bEy2GIamVdgw5
+        BYNPwI5XjVX+3AzotX/7MWbyn8EH4XCyAcD2rPzHsE8NrFSkdj6DNWMe9owZmfHdel7VBnyl0c4V
+        wgVytdo9V+wsdX3lh+0rUTAHGrOdgaNjUjQkPLOg9201FOk9Wz2PMjlOUILXy9Yd4NEzOY7YqHnE
+        n/4GAAD//wMA0MsZVJQSAAA=
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"3451697fb82f46f2c16d160323fee871"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode <transaction><payment_method_token>g79ztd</payment_method_token><amount>20.91</amount><customer_id>80594570</customer_id><type>sale</type><options><submit_for_settlement
+      type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
+      type="integer">2</participant_id></custom_fields></transaction>
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+  response:
+    body:
+      string: !!binary |
+        H4sIAKwmXVgAA9xYS2/jNhC+51cEvjOy/Iq9ULQoUBTtoQWKbBZoLwuKGltcS6SWpBw7v75DUZKl
+        iEpyKVD0Zs18HHKG8/jo6PO5yG9PoDSX4mEW3s1ntyCYTLk4PMyevvxCtrPP8U1kFBWaMoOo+Ob2
+        NuJpvFqc00v54xgF+GFl2lBT6ZhWJpOKv0AaBY3Ias2lhFjTHKKg/mllrFIKd7sQriXBTSF+evw5
+        CsZiC6aFrISJF/O7XRgFzZdVFKBYRoUhlDErJHgebZLdcXX/8pJ8X6jN+nsU+FD1qauEeHS3gucP
+        M6MqmAVuF6oNqA9BpUoR6VEwBdRASqi5tTF4mKX4aXgBM3Qr3JBwQRbLL+Hy02L3KVz/jZHoFtTr
+        qzL9+PoNrr8uaOKtjUQP7Ie7xO18vVut7+ftJaJ0z5U2RNACXp8flTmd1jFZlFRcPBooKM898mdI
+        NDc+W2UmhU++p+dRVIO+W1HC8xyT9+ri8+XfdU4bBYD5kKYKtPZ5fzYgUnsLk5BcMppz4zOv4IBF
+        5wuRxOrKXX3sVuH8Pgr6ovbYmKPqMu2VU9sVhOZlRhcfQi3fQ4kK74Oz8V31rgdd21ci9RVKp9FN
+        olOl6GWgxHj2mpLPSEmV4RgODcbkUAAW63CFz/i1e71nvmc2oYZlXkzGy7Kfjb6U/l+m5BsJ8p/J
+        xf7tNL2R7DnkqW79sRnEeEnduFhghQ0lvfbTWxnRkyaglFQEg1tKocEbkxrXi9kQHf+OU+5NQGti
+        eN2vQL85K29iav9Pp/HKsdBCDzhTnukFNd/BlQeOKT3OiKhUkuFuGIe2rGgNry39tXn8df0nhvQt
+        0NDK8CjhfD7vLx8f1KMzmPrxTyVqTpagTCHq0KYptyfB4I9hI19PkjN7QXu8eFyBSZeAGkeksvQB
+        d3EcYQJl6Jk4guNVwRmKsqUAiZQ5UDGL9zTXllx1gJZyoBeEUdWOQCOPIOLD/e7FYADcl9MkXMSr
+        ebjYbm2fFv0WtIrD7RZpV/PRVBkaJTWZ+8o1xWzpvtsuU3LlLrOQwmRxiBU0Eo6wF6AK+cxiPgDX
+        0mbfZt4T26NqSvr0eGUBV+n1lJnM63D7Ow8v6AFIpfI4M6bUn4KAauzu+i5RlAtbOE3G32HLxRZw
+        sU3/WwGYrem3XB5kcEL/70px+AzixJUUFvCgqUgTeUb20dlv2oqCkmL3+EPaBHS/nSYDmpsMT4xM
+        WByFfBZR0JM5UAoJN1e9+2xUlcKLwyw8VLklfj3Ua003QyyjxTF5hfZkbRu8KJn3EK2gCZ/WFXZR
+        nILieMUMpMOuLPfEaqlgENvtxtI2TjKtWN1or1tfZQ5UCf6jgqaSUIyR59iKVbxasu0q3KeMLdly
+        v9ksN+s9rMP5ksEWEoY5PrnUWT6BKCTR6XGi0jp9MwaGldY8h0jGMS3VZUA1ujFdIwANNRdoyxPp
+        PCqK8oMUv8N3Ft58h9WIqaeUC6jGCCiZcVPSKj9iydaS7nw9VqQltjOIacnxHGO58zJ47WYnaULj
+        GmNO/SyrSjRTvJxkYT1918ZqiklKnPoyJUh0iA2ip/BfIfFYynixeORX+9jpQHAQeChkynWd014d
+        OCuyTbKJljT1/sEmMj7b0CjSM/uARr8m8rbTuwGBr1kBY6t45yc70fYAU7PIbiufibvNkRbDkFRK
+        O4acgsEnYMurhir/3fTotX/7IWb0n8EH4XC2AcD2rPzHsE8NzFSkdj6DFWMe9ow3MuG79bysDPhS
+        o5krhAvkapV7rthZ6vrKN9tXomAKNGQ7PUeHpKhPeCZB79uqKdJ7tjoeZTKcoATLy+Yd4NH3chix
+        QfOIb/4BAAD//wMAgM3Yt5QSAAA=
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"14a1aef85001740ce165d85d9d8c899b"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 201, message: Created}
+- request:
+    body: <transaction><amount>20.91</amount></transaction>
+    headers: {}
+    method: PUT
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/42xdypqk/submit_for_settlement
+  response:
+    body:
+      string: !!binary |
+        H4sIAK0mXVgAA9xYS2/jNhC+768IfGdk+RVnoWhRoCjaQwsU2y3QXgKKGllcS6SWpBw7v75DUZKl
+        iEoCFAUWvVkzH4ec4Tw+Ovp0LoubEyjNpXhYhLfLxQ0IJlMuDg+LL3/8RPaLT/GHyCgqNGUGUfGH
+        m5uIp/FmdU4v1bdjFOCHlWlDTa1jXSclNwbSx0yqRw3GFFCCMFHQAizWXCqINS0gCpqfVsZqpXDv
+        C+FaEjwCxF8+/xgFU7EF01LWwsSr5e19GAXtl1WUoFhOhSGUMSskeDptkvvj5u75Ofm6Urvt1yjw
+        oRof6oR4dDeCFw8Lo2pYBG4Xqg2od0GlShHpUTAFFMNEqLmxMXhYpPhpeAkLdCvckXBFVus/wvXH
+        1f3HcPs3RqJf0Kyvq/T96+9w/XVBG29tJHpgP9yV7pfb+832btldKUozrrQhgpbw8vyoLOi8jsmy
+        ouLi0UBJeeGRP0GiufHZqnIpfPKMnidRDYZuRQkvCkzlq4tPl//WOW0UAOZDmirQ2uf92YBI7S3M
+        QgrJaMGNz7yCA5agL0QSq6tw9XG/CZd3UTAUdcfGHFWXea+c2q4gtKhyunoXav0WStR4H5xN72pw
+        PehaVovUVyi9RreJTpWil5ES4zloUT4jFVWGYziuDenFCp9xWptcKv78tvmB2YQalnsxOa+qYTb6
+        Uvp/mZKvJMh3k4vD22l7I8k4FKnu/LEZxHhF3bhYYYWNJYP2M1gZ0ZMmoJRUBINbSaHBG5MGN4jZ
+        GB3/ilPuVUBnYnzdL0C/OCuvYhr/T6fpyqnQQg84U57oBTVfwZUHjik9zYioUpLhbhiHrqxoA28s
+        /bX7/PP2dwzpa6CxlfFRwuVyOVw+PahHZzD14x8q1Jwg9a5uEE1o05Tbk2Dwp7CJryfJmb2gDC8e
+        V2DSJaCmEaktfcBdHEeYQRl6Jo7geFVwhrLqKEAiZQFULOKMFtqSqx7QUQ70gjCquhFo5BFEfLi7
+        fzYYAPflNAkX8WYZrvZ726fFsAVt4nC/R9rVfrRVhkZJQ+b+5JpitvTfXZepuHKXWUph8jjECpoI
+        J9gLUIV8ZrUcgRtpu28774ntUQ1B/fL5ygKu0uspc1k04fZ3Hl7SA5BaFXFuTKU/BgHV2N31baIo
+        F7Zw2oy/xZaLLeBim/5jCZit6WMhDzI4of+3lTh8AnHiSgoLeNBUpIk8I/vo7bdtRUFFsXv8Jm0C
+        ut9OkwMtTI4nRiYsjkI+iSgYyBwohYSbq959tqpa4cVhFh7qwhK/Aeqlpp8hltHimLxCB7KuDV6U
+        LAaITtCGT+sauyhOQXG8YkbScVeWGbFaKhjEdruptIuTTGvWNNrr1leZA9WCf6uhrSQUY+Q5tmIV
+        b9ZsvwmzlLE1W2e73Xq3zWAbLtcM9pAwzPHZpc7yCUQpiU6PM5XW69sxMK609nFEco5pqS4jqtGP
+        6QYBaKi9QFueSOdRUVbvoPg7pPg9vrfQPrquTGb4DmsQc08pF1CNEVAy56aidXHEkm0k/fkGrEhL
+        bGcQ04rjOaZy52UwdfPfe373mufveY9+B3HoJW2KuAFRUD/brBPNFK9m2ehA37fzhmqTCtmPTAkS
+        PmJD6mmAL5B4LGW8WDzyi33slCQ4ED1UOuW6qW2vDpwV2RXbTGueewdiM52ebWwUaar9IwH9mqnf
+        Xu8GJb7qBUyt4p2f7GTPAOZmst1WPhF3mxMthiGplXYvhRQMPoU7fjlW+e9m8Mzwbz/GTP47eScc
+        zjYAOKaU/xj2yYWZihTXZ7BmzPOKwBuZ8d16XtUGfKnRzlfCBXLW2j3bLKdw/fXR9tcomAONWd/A
+        0TE5HBK/WdDbthqq+Jatnk+aHJkEwfKyeQd49EyOIzZqHvGHfwAAAP//AwDV5UqiqhMAAA==
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"9fb20ebdb99b72e0d4547bf3731eb426"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: PUT
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/6fs85rcg/void
+  response:
+    body:
+      string: !!binary |
+        H4sIAK4mXVgAA9xYS2/jNhC+768IfGdk+RVnoSgosChQoNvLPoD2sqCokcVEIlWScuz8+g5FSZYi
+        KglQFFj0Zs18HHKG8/jo6P5UFldHUJpLcbcIr5eLKxBMplwc7hbfvv5K9ov7+ENkFBWaMoOo+MPV
+        VcTTeJfp/VaxQxTgh5VpQ02t46PkKaRR0H5ajTlXEGtaQBQ0P62M1UrhTmfCtSS4IcTfvnyKgqnY
+        gmkpa2HicHm9C6Og/bKKEhTLqTCEMmaFBM+iTXL7uLl5fk4eVmq3fYgCH6o5cZ0Qj+5K8OJuYVQN
+        i8DtQrUB9S6oVCkiPQqmgBpICTVXNgZ3ixQ/DS9hEa+W4Y6EK7Jafw3XH1e3H8PtXxiJfkGzvq7S
+        96+/wfWXBW28tZHogf1wF7hfbm8325tld4EozbjShghawsvzo7Kg8zomy4qKs0cDJeWFR/4EiebG
+        Z6vKpfDJM3qaRDUYuhUlvCgwcS8uPp3/W+e0UQCYD2mqQGuf9ycDIrW3MAspJKMFNz7zCg5YcL4Q
+        SayuwtXH7SZc3kTBUNQdG3NUnee9cmq7gtCiyunqXaj1WyhR431wNr2rwfWga1ktUl+h9BrdJjpV
+        ip5HSoznoCH5jFRUGY7h0GBMASVgsY5X+IzT2uRS8ee3zQ/MJtSw3IvJeVUNs9GX0v/LlHwlQX6a
+        XBzeTtsbScahSHXnj80gxivqxsUGK2wsGbSfwcqIHjUBpaQiGNxKCg3emDS4QczG6PgzTrlXAZ2J
+        8XW/AP3mrLyKafw/Hqcrp0ILPeBMeaJn1DyAKw8cU3qaEVGlJMPdMA5dWdEG3lj69Pvn3Z84o14F
+        ja2MjxIul8vh8ulBPTqDqR//UqHmaAnKHKIJbZpyexIM/hQ28RUpD7MXlOHF4wpMugTUNCK1pQ+4
+        i+MIMyhDT8QRHK8KTlBWHQVIpCyAikWc0UJbctUDOsqBXhBGVTcCjXwEER9ubp8NBsB9OU3CRbxZ
+        hqv93vZpMWxBmzjc75F2tR9tlaFR0pC571xTzJb+u+syFVfuMkspTB6HqyiYCCfYM1CFfGa1HIEb
+        abtvO++J7VENHf325cICLtLLKXNZNOH2dx5e0gOQWhVxbkylPwYB1djd9XWiKBe2cNqMv8aWiy3g
+        bJv+jxIwW9MfhTzI4Ij+X1ficA/iyJUUFnCnqUgTeUL20dtv24qCimL3+EPaBHS/nSYHWpgcT4xM
+        WDwK+SSiYCBzoBQSbi5699mqaoUXh1l4qAtL/Aaol5p+hlhGi2PyAh3IujZ4VrIYIDpBGz6ta+yi
+        OAXF4wUzko67ssyI1VLBILbbTaVdnGRas6bRXra+yByoFvzvGtpKQjFGnmMrVvFmzfabMEsZW7N1
+        ttutd9sMtuFyzWAPCcMcn13qLB9BlJLo9HGm0np9OwbGldY+hUjOMS3VeUQ1+jHdIAANtRdoyxPp
+        PCrK6p1PhB7fW2gfXRcmM3yHNYi5p5QLqMYIKJlzU9G6eMSSbST9+QasSEtsZxDTiuM5pnLnZTB1
+        8997fvOa59PX50/gdS9pE8KNg4L6uWWdaKZ4Ncs9B/q+eTfEmlTIdWRKkN4RG0BPu3uBxGMp48Xi
+        kV/sY2ciwfHnIc4p100le3XgrMiutGYa8dyrD1vn9Gxjo0hK7d8G6NdMtfZ6NxbxDS9gahXv/Gjn
+        eAYwN4HttvKJuNucaDEMSa20exekYPDh27HJscp/N4NHhX/7MWbyT8k74XCyAcChpPzHsA8szFQk
+        tD6DNWOeNwPeyIzv1vOqNuBLjXaaEi6QodbukWYZhOumP2w3jYI50JjjDRwdU8EhzZsFvW2rIYZv
+        2erZo8mRNxAsL5t3gEfP5Dhio+YRf/gHAAD//wMAMxRjR4YTAAA=
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"e41281c064e4f749d94b62e592acf907"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode <transaction><payment_method_token>g79ztd</payment_method_token><amount>20.91</amount><customer_id>80594570</customer_id><type>sale</type><options><submit_for_settlement
+      type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
+      type="integer">2</participant_id></custom_fields></transaction>
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+  response:
+    body:
+      string: !!binary |
+        H4sIAK8mXVgAA9xYTW/jNhC951cEvjOybCexA0VBgWKBHrZosZtF0UtAUWOLsUSqJOXY+fUdipIs
+        RVSSHgoUvVkzj0POcD4eHT0ci/zyAEpzKe5n4dV8dgmCyZSL3f3s8fsXsp49xBeRUVRoygyi4ovL
+        y4incbLZvewPJY0C/LAybaipdEwrk0nFXyGNgkZkteZUQqxpDlFQ/7QyVimFu50I15LgphA/fvs5
+        CsZiC6aFrISJF/OrTRgFzZdVFKBYRoUhlDErJHgebZLNfnX7+po8L9TN9XMU+FD1qauEeHSXguf3
+        M6MqmAVuF6oNqE9BpUoR6VEwBdRASqi5tDG4n6X4aXgBM3QrvCHhgiyW38Pl3WJzF27+xEh0C+r1
+        VZn+s/XnBU28tZHogf1wl7ieX29W17fz9hJRuuVKGyJoAW/Pj8qcTuuYLEoqTh4NFJTnHvkLJJob
+        n60yk8In39LjKKpB360o4XmOyXt28eX07zqnjQLAfEhTBVr7vD8aEKm9hUlILhnNufGZV7DDovOF
+        SGJ15a4+NqtwfhsFfVF7bMxRdZr2yqntCkLzMqOLT6GWH6FEhffB2fiueteDrm0rkfoKpdPoJtGp
+        UvQ0UGI8e03JZ6SkynAMhwZjcigAi3W4wmf83L0+Mt8zm1DDMi8m42XZz0ZfSv8vU/KdBPnP5GL/
+        dpreSLYc8lS3/tgMYrykblwssMKGkl776a2M6EETUEoqgsEtpdDgjUmN68VsiI6/4pR7F9CaGF73
+        G9Avzsq7mNr/w2G8ciy00B3OlBd6Qs0zuPLAMaXHGRGVSjLcDePQlhWt4bWlPxa/f/n6G4b0PdDQ
+        yvAo4Xw+7y8fH9SjM5j68U8lag6WoEwh6tCmKbcnweCPYSNfD5Ize0FbvHhcgUmXgBpHpLL0AXdx
+        HGECZeiROILjVcERirKlAImUOVAxi7c015ZcdYCWcqAXhFHVjkAj9yDi3e3m1WAA3JfTJFzEq3m4
+        WK9tnxb9FrSKw/UaaVfz0VQZGiU1mfvBNfLA83fbZUqu3GUWUpgsDrGCRsIR9gRUIZ9ZzAfgWtrs
+        28x7YntUTUkfv51ZwFl6PmUm8zrc/s7DC7oDUqk8zowp9V0QUI3dXV8linJhC6fJ+CtsudgCTrbp
+        PxWA2Zo+5XIngwP6f1WK3QOIA1dSWMC9piJN5BHZR2e/aSsKSord41dpE9D9dpoMaG4yPDEyYbEX
+        8kVEQU/mQCkk3Jz17rNRVQovDrNwV+WW+PVQbzXdDLGMFsfkGdqTtW3wpGTeQ7SCJnxaV9hFcQqK
+        /RkzkA67stwSq6WCQWy3G0vbOMm0YnWjPW99ljlQJfhfFTSVhGKMPMdWrOLVkq1X4TZlbMmW25ub
+        5c31Fq7D+ZLBGhKGOT651Fk+gCgk0el+otI6fTMGhpXWPIdIxjEt1WlANboxXSMADTUXaMsT6Twq
+        ivKTFL/DdxbefYfViKmnlAuoxggomXFT0irfY8nWku58PVakJbYziGnJ8RxjufMyeOtmJ2lC4xpj
+        Tv0sq0o0U7ycZGE9fdfGaopJSpz6MiVIdIgNoqfw3yDxWMp4sXjkN/vY6UBwEHgoZMp1ndNeHTgr
+        sk2yiZY09f7BJjI+29Ao0jP7gEa/JvK207sBga9ZAWOreOcHO9G2AFOzyG4rX4i7zZEWw5BUSjuG
+        nILBJ2DLq4Yq/9306LV/+yFm9J/BJ+FwtAHA9qz8x7BPDcxUpHY+gxVjHvaMNzLhu/W8rAz4UqOZ
+        K4QL5GqVe67YWer6ypPtK1EwBRqynZ6jQ1LUJzyToI9t1RTpI1sdjzIZTlCC5WXzDvDoWzmM2KB5
+        xBd/AwAA//8DAOuN7PGUEgAA
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"73ece7609f13be9f2101acf8363a60a0"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 201, message: Created}
+- request:
+    body: <transaction><amount>20.91</amount></transaction>
+    headers: {}
+    method: PUT
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/b9gwkvpa/submit_for_settlement
+  response:
+    body:
+      string: !!binary |
+        H4sIAK8mXVgAA9xYS2/jNhC+768IfGdk2U5iLxQtChQL9LBFi32g6CWgqLHFtUSqJOXY+fUdinpG
+        VJIeFlj0Zs18HHKG8/jo6MO5yK9OoDSX4n4RXi8XVyCYTLk43C++fvlItosP8bvIKCo0ZQZR8bur
+        q4incbI7PB5PJY0C/LAybaipdKyrpODGQPqwl+pBgzE5FCBMFDQAizWXEmJNc4iC+qeVsUop3PtC
+        uJYEjwDx18+/RsFUbMG0kJUw8Wp5vQujoPmyigIUy6gwhDJmhQRPp02yO27unp6S7yt1e/M9Cnyo
+        2ocqIR7dleD5/cKoChaB24VqA+pNUKlSRHoUTAHFMBFqrmwM7hcpfhpewALdCm9JuCKr9Zdw/X61
+        ex/u/sZIdAvq9VWZ/rf1/YIm3tpI9MB+uCvdLm92m5u7ZXulKN1zpQ0RtIDn50dlTud1TBYlFReP
+        BgrKc4/8ERLNjc9WmUnhk+/peRLVYOhWlPA8x1TuXXy8/FjntFEAmA9pqkBrn/dnAyK1tzALySWj
+        OTc+8woOWIK+EEmsrtzVx24TLu+iYChqj405qi7zXjm1XUFoXmZ09SbU+jWUqPA+OJve1eB60LV9
+        JVJfoXQa3SQ6VYpeRkqM56BF+YyUVBmO4egb0rMVPuO0MplU/Ol18wOzCTUs82IyXpbDbPSl9P8y
+        JV9IkJ8mF4e30/RGsueQp7r1x2YQ4yV142KFFTaWDNrPYGVET5qAUlIRDG4phQZvTGrcIGZjdPwJ
+        p9yLgNbE+LqfgX5zVl7E1P6fTtOVU6GFHnCmPNILar6DKw8cU3qaEVGpJMPdMA5tWdEaXlv6a/Xn
+        x09/YEhfAo2tjI8SLpfL4fLpQT06g6kf/1Ki5gSpd3WNqEObptyeBIM/hU18PUnO7AXt8eJxBSZd
+        AmoakcrSB9zFcYQZlKFn4giOVwVnKMqWAiRS5kDFIt7TXFty1QFayoFeEEZVOwKNPIKID3e7J4MB
+        cF9Ok3ARb5bharu1fVoMW9AmDrdbpF3NR1NlaJTUZO4b18gK+++2y5RcucsspDBZHGIFTYQT7AWo
+        Qj6zWo7AtbTZt5n3xPaomqB+/dyzgF7anzKTeR1uf+fhBT0AqVQeZ8aU+n0QUI3dXV8ninJhC6fJ
+        +GtsudgCLrbpPxSA2Zo+5PIggxP6f12KwwcQJ66ksIB7TUWayDOyj85+01YUlBS7x+/SJqD77TQZ
+        0NxkeGJkwuIo5KOIgoHMgVJIuOn17rNRVQovDrPwUOWW+A1QzzXdDLGMFsdkDx3I2jZ4UTIfIFpB
+        Ez6tK+yiOAXFsceMpOOuLPfEaqlgENvtptI2TjKtWN1o+617mQNVgv9TQVNJKMbIc2zFKt6s2XYT
+        7lPG1my9v71d397s4SZcrhlsIWGY47NLneUTiEISnR5nKq3TN2NgXGnN44hkHNNSXUZUoxvTNQLQ
+        UHOBtjyRzqOiKN9I8Tt8Z6F5dPVMZvgOqxFzTykXUI0RUDLjpqRVfsSSrSXd+QasSEtsZxDTkuM5
+        pnLnZTB18wd7/pb36E8Qh07SpIgbEDn1s80q0UzxcpaNDvRdO6+pNimR/ciUIOEjNqSeBvgMicdS
+        xovFIz/bx05JggPRQ6VTruva9urAWZFtsc205rl3IDbT6dnGRpGm2j8S0K+Z+u30blDiq17A1Cre
+        +clO9j3A3Ey228pH4m5zosUwJJXS7qWQgsGncMsvxyr/3QyeGf7tx5jJfydvhMPZBgDHlPIfwz65
+        MFOR4voMVox5XhF4IzO+W8/LyoAvNZr5SrhAzlq5Z5vlFK6/Ptj+GgVzoDHrGzg6JodD4jcLet1W
+        TRVfs9XxSZMhkyBYXjbvAI++l+OIjZpH/O5fAAAA//8DAGypOZ2qEwAA
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"350135356fead9430fa453cbf5047172"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode <transaction><payment_method_token>g79ztd</payment_method_token><amount>10.61</amount><customer_id>80594570</customer_id><type>sale</type><options><submit_for_settlement
+      type="boolean">false</submit_for_settlement></options><custom_fields><participant_id
+      type="integer">2</participant_id></custom_fields></transaction>
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions
+  response:
+    body:
+      string: !!binary |
+        H4sIALEmXVgAA9xYTW/zNgy+91cUuauOkzRNC9fFhmHAMGwY8LbvYZdClplYrS15kpwm/fWjLNux
+        Y7ntDgOG3WLyESV+iHyU6OFQ5Jd7UJpLcT8Lr+azSxBMplzs7mdPjz+TzewhvoiMokJTZhAVX1xe
+        RjyNs3KXrgUsogA/rEwbaiod08pkUvF3SKOgEVmtOZYQa5pDFNQ/rYxVSuFuR8K1JLgpxE/ffoqC
+        sdiCaSErYeJwfrUOo6D5sooCFMuoMIQyZoUEz6NNcvu6unl/T14Wan39EgU+VH3qKiEe3aXg+f3M
+        qApmgduFagPqS1CpUkR6FEwBNZASai5tDO5nKX4aXsAsXszDNQkXZLF8DJd3i9u7RfgnRqJbUK+v
+        yvSfrT8taOKtjUQP7IdL4mZ+fbu6vpm3SUTplittiKAFnJ8flTmd1jFZlFQcPRooKM898jdINDc+
+        W2UmhU++pYdRVIO+W1HC8xyL9+Ti2/HfdU4bBYD1kKYKtPZ5fzAgUpuFSUguGc258ZlXsMNL5wuR
+        xNuVu/txuwrnN1HQF7XHxhpVx2mvnNquIDQvM7r4Emr5GUpUmA/OxrnqpQdd21Yi9V2UTqObQqdK
+        0eNAifHsNSWfkZIqwzEcGozJoQC8rMMVPuOn7vWZ+Z7ZhBqWeTEZL8t+NfpK+n9Zkh8UyH+mFvvZ
+        aXoj2XLIU936YyuI8ZK6cYGj7kzSaz+9lRHdawJKSUUwuKUUGrwxqXG9mA3R8W845T4EtCaG6T4D
+        /eKsfIip/d/vxyvHQgvd4Ux5o0fUvIC7Hjim9LgiolJJhrthHNprRWt4benHPx5vft1gSD8CDa0M
+        jxLO5/P+8vFBPTqDpR//UKJmbwnKFKIObZpyexIM/hg28nUvObMJ2mLicQUWXQJqHJHK0gfcxXGE
+        CZShB+IIjlcFByjKlgIkUuZAxSze0lxbctUBWsqBXhBGVTsCjXwFEe9ubt8NBsB9OU3CRbyah4vN
+        xvZp0W9BqzjcbJB2NR/NLUOjpCZz37mmWC3dd9tlSq5cMgspTBaHeINGwhH2CFQhn1nMB+Ba2uzb
+        zHtie1RNSZ++nVjASXo6ZSbzOtz+zsMLugNSqTzOjCn1XRBQjd1dXyWKcmEvTlPxV9hysQUcbdN/
+        LgCrNX3O5U4Ge/T/qhS7BxB7rqSwgHtNRZrIA7KPzn7TVhSUFLvH79IWoPvtNBnQ3GR4YmTC4lXI
+        NxEFPZkDpZBwc9K7z0ZVKUwcVuGuyi3x66HONd0MsYwWx+QJ2pO1bfCoZN5DtIImfFpX2EVxCorX
+        E2YgHXZluSVWSwWD2G43lrZxkmnF6kZ72vokc6BK8L8qaG4SijHyHFuxildLtlmF25SxJVtu1+vl
+        +noL1+F8yWADCcMan1zqLO9BFJLo9HXipnX6ZgwMb1rzHCIZx7JUxwHV6MZ0jQA01CTQXk+k86go
+        yi9S/A7fWfjwHVYjpp5SLqAaI6Bkxk1Jq/wVr2wt6c7XY0VaYjuDmJYczzGWOy+Dczc7SRMa1xhz
+        6mdZVaKZ4uUkC+vpuzZWU0xS4tSXKUGiQ2wQPRf/DInHUsaLxSOf7WOnA8FB4KGQKdd1TXt14KzI
+        tsgmWtLU+webyPhsQ6NIz+wDGv2aqNtO7wYEvmYFjK1izvd2om0BpmaR3Va+EZfNkRbDkFRKO4ac
+        gsEnYMurhip/bnr02r/9EDP6z+CLcDjYAGB7Vv5j2KcGVipSO5/BijEPe8aMTPhuPS8rA77SaOYK
+        4QK5WuWeK3aWur7ybPtKFEyBhmyn5+iQFPUJzyToc1s1RfrMVsejTIYTlOD1snUHePStHEZs0Dzi
+        i78BAAD//wMAPOq5LZQSAAA=
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"321ce9a2a144bd7424b6d1a3150fe027"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 201, message: Created}
+- request:
+    body: <transaction><amount>10.61</amount></transaction>
+    headers: {}
+    method: PUT
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/hpgd6ne2/submit_for_settlement
+  response:
+    body:
+      string: !!binary |
+        H4sIALImXVgAA9xYTW/jNhC9768IfGdk2Y7jLBQtWhQFiqJFgc3uoZeAokYWNxKpkpRj59d3KEqy
+        ZFFJelhg0Zs18zjkDOfj0dGnY1lcHUBpLsX9IrxeLq5AMJlysb9ffHn4lewWn+IPkVFUaMoMouIP
+        V1cRT+O82qdbAasowA8r04aaWse6TkpuDKSPmVSPGowpoARhoqAFWKw5VRBrWkAUND+tjNVK4d4n
+        wrUkeASIv3z+JQqmYgumpayFicPl9TaMgvbLKkpQLKfCEMqYFRI8nTbJ3dPm9uUl+bZS25tvUeBD
+        NT7UCfHorgQv7hdG1bAI3C5UG1DvgkqVItKjYAooholQc2VjcL9I8dPwEhbxahluSbgiq/VDuP64
+        uvu4Cv/GSPQLmvV1lf639ecFbby1keiB/XBXulve3G1ubpfdlaI040obImgJl+dHZUHndUyWFRUn
+        jwZKyguP/BkSzY3PVpVL4ZNn9DiJajB0K0p4UWAqn118Pn1f57RRAJgPaapAa5/3RwMitbcwCykk
+        owU3PvMK9liCvhBJrK7C1cfdJlzeRsFQ1B0bc1Sd5r1yaruC0KLK6epdqPVbKFHjfXA2vavB9aBr
+        WS1SX6H0Gt0mOlWKnkZKjOegRfmMVFQZjuE4N6SLFT7jtDa5VPzlbfMDswk1LPdicl5Vw2z0pfT/
+        MiVfSZAfJheHt9P2RpJxKFLd+WMziPGKunGBg+9CMmg/g5URPWgCSklFMLiVFBq8MWlwg5iN0fEf
+        OOVeBXQmxtd9AfrNWXkV0/h/OExXToUWuseZ8kxPqPkGrjxwTOlpRkSVkgx3wzh0ZUUbeGPp578e
+        bn/fYUhfA42tjI8SLpfL4fLpQT06g6kf/1Sh5gCpd3WDaEKbptyeBIM/hU18PUjO7AVlePG4ApMu
+        ATWNSG3pA+7iOMIMytAjcQTHq4IjlFVHARIpC6BiEWe00JZc9YCOcqAXhFHVjUAjn0DE+9u7F4MB
+        cF9Ok3ARb5bharezfVoMW9AmDnc7pF3tR1tlaJQ0ZO4r1xSzpf/uukzFlbvMUgqTxyFW0EQ4wZ6A
+        KuQzq+UI3Ejbfdt5T2yPagjql89nFnCWnk+Zy6IJt7/z8JLugdSqiHNjKv0xCKjG7q6vE0W5sIXT
+        Zvw1tlxsASfb9B9LwGxNHwu5l8EB/b+uxP4TiANXUljAvaYiTeQR2Udvv20rCiqK3eNPaRPQ/Xaa
+        HGhhcjwxMmHxJOSziIKBzIFSSLg5691nq6oVXhxm4b4uLPEboC41/QyxjBbH5Bk6kHVt8KRkMUB0
+        gjZ8WtfYRXEKiqczZiQdd2WZEaulgkFst5tKuzjJtGZNoz1vfZY5UC34PzW0lYRijDzHVqzizZrt
+        NmGWMrZm62y7XW9vMrgJl2sGO0gY5vjsUmf5AKKURKdPM5XW69sxMK609nFEco5pqU4jqtGP6QYB
+        aKi9QFueSOdRUVbvpPg9vrfQPrrOTGb4DmsQc08pF1CNEVAy56aidfGEJdtI+vMNWJGW2M4gphXH
+        c0zlzstg6uZ39vw979EfIA69pE0RNyAK6mebdaKZ4tUsGx3o+3beUG1SIfuRKUHCR2xIPQ3wAonH
+        UsaLxSNf7GOnJMGB6KHSKddNbXt14KzIrthmWvPcOxCb6fRsY6NIU+0fCejXTP32ejco8VUvYGoV
+        7/xgJ3sGMDeT7bbymbjbnGgxDEmttHsppGDwKdzxy7HKfzeDZ4Z/+zFm8t/JO+FwtAHAMaX8x7BP
+        LsxUpLg+gzVjnlcE3siM79bzqjbgS412vhIukLPW7tlmOYXrr4+2v0bBHGjM+gaOjsnhkPjNgt62
+        1VDFt2z1fNLkyCQIlpfNO8CjZ3IcsVHziD/8CwAA//8DAA6Cmh6qEwAA
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"a1f656408e096853e37f2a56125525f2"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode <search><status type="array"><item>authorized</item></status></search>
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search_ids
+  response:
+    body:
+      string: !!binary |
+        H4sIALMmXVgAA1yNMQqAMBRDd09RuktF0OnbuxQNtaCl/F+HenqtiIPZkrwQEjie15Yhx5bFNkpR
+        ch6thBMql4RJh5jhwdoOHZmvfNCwyAs5Zld0DasoZOx2TX4ZI3oyj60Dcy9sQ+Z/ewEAAP//AwDo
+        mRL1iAAAAA==
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"6f5535d34c0a06bdb78f8f86ee304b12"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode <search><status type="array"><item>authorized</item></status><ids
+      type="array"><item>hpgd6ne2</item></ids></search>
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search
+  response:
+    body:
+      string: !!binary |
+        H4sIALMmXVgAA3TOwQrCMAwG4FcZuddtB8FD1918An2A2oVSaNORZkN9essQkaHH5P9+Ej3eU2xW
+        5BIyDdAfOmiQXJ4C+QGul7M6wWi0Y5yCKGd5UsKWinVSC6WRx4wDuBwjbhuodmFGEjVbj4qWdEN+
+        s0CCHhlMr9sfyuhtKOGJ+8Kx0+0nNFqy2KiCYCp7WeFXauqhP6+bFwAAAP//AwCNtt0D+wAAAA==
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"a94a39ca276658f6f807aad2955608bf"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/py/fixtures/TestRoutes.yml
+++ b/tests/py/fixtures/TestRoutes.yml
@@ -1,37 +1,37 @@
 interactions:
 - request:
-    body: !!python/unicode '<payment_method><customer_id>35060504</customer_id><options><verify_card
-      type="boolean">true</verify_card></options><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>'
+    body: !!python/unicode <payment_method><customer_id>38515680</customer_id><options><verify_card
+      type="boolean">true</verify_card></options><payment_method_nonce>fake-valid-nonce</payment_method_nonce></payment_method>
     headers: {}
     method: POST
     uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods
   response:
     body:
       string: !!binary |
-        H4sIAAHbk1UAA7RWS5PiNhC+8yso7h4/eM6U8dReUpVDcslODrlsyVIDGmzJkWR22F+flt+AMZ7a
-        zQ19/bnVar5+hK8faTI9gdJciu3Mf/JmUxBUMi7229nb19+czew1moRUAePGoUSxaDKdhjFPEqQ4
-        hDEFWlsMUc4ifQxdzqozzbWRKSgHkfnSW3lLbxG6XbTk7bjSxhEkhangyXZmVA4ztzIm5L6NyjQj
-        4txj0UYBmDq+HgJ8GBAM2AAlkZQk3PS5V7DHhPUYMqkNSRzMIETPC99bh24XqsPOhVHnAnJIkh1I
-        0Pu4a9b8EUvkmFdOB2j3EqmAGJsMMzXnDLYzhkfDU5hFgecvHW/teP5XP3gJvBd//Q/+ic0HlYc8
-        Y5/z0H5QKMrtkRTKTEQLzw82G2sXBWY16Ngror+5JhhJc66tB5kwlFffU61iMEWUkyR6E0chvwv0
-        0GKTTqrkzuFa50RQiN7++mJ5t4bJzydvXJm0LCtLg+rDoDqsBrVcBjE37QPLY2nYkTyp44ylTICI
-        WWQTZGmFsSTmChPuoM7zxMbacXZtmRTVlHFV3O+kUphD5AehewNeMc9AFGYo8C6oBdowgV3HuiOJ
-        huqL6vYDkMQc8K+HNswOZik8JXtwcpVEB2My/eK6RGsw+ilWhAvbLPb4mO/k/IRqcDNyTkGYbymY
-        g2TfErmX7gnV9pSJ/SuIE1dSWMJWE8Fi+YE9r/Ff3IbysFqOiTi2IV2gk7q1LSJ/s/FDtzpYHK9X
-        MukotAYKo4KMoCb+lIhXvy2u81hTxTObRF0ljShFzpXyjTyCiJ7P+yBYhW55sngu+L950TriQmz4
-        LL7joKLFnG4W/o5ROqfz3Wo1Xy13sPS9OYUNxBRL8u6nk1/QEE4gUulodrwjgMZesRVeXZbA5eur
-        /tQllFAxJYjJdVTagIVuBdR2ejqh0HWGPqFs4H9gyd2ANZ2ctANKSXVpv+23FbczGW6vGSZ03VzO
-        uivi76WnQU7trCoBtL4DLYoRG5Xum3NIti3zQAT6pEVjtH1Km/j5uFj/+BG/B2q1fA/dPlbtIVOS
-        YjDX6Yp8z/OstvutA18bHOrRlwwtJ/tn3mPUHjAU+rE+zt/blaVdberzg/Xk0YoyvKaMWlVGrisP
-        VpbBtWX06jJil+jM8raOLtfHCr3TkZr/4Wb2d9N92zbru4b2gyabI8fVLX94aNUxjJ/VnagH9paK
-        9T/16loA/ZOlsj4eshXx3vJRmz+1WbQV9GBtq98wMDoryrjhfKX1sctgk0rJclp0uzaSFmsKpacw
-        PrdOrnp28Z8fvja064F5ieCMvIr+PwAAAP//AwB6ardcSw4AAA==
+        H4sIALAoXVgAA7RWTZPiNhC98yso7h7bGBjPlPHUXrYqh+SSnRxy2ZKlBjQjS44ks8P++rT8gQ0Y
+        w9YkN/T6udVqXn8kLx+5mO5BG67kehY+BLMpSKoYl9v17PXbVy+evaSThGpg3HqUaJZOptMk40Ig
+        xSOMaTDGYYhyltK3xOesOdPSWJWD9hCJ4mW4XMVB4vfRmrfh2lhPkhymkov1zOoSZn5jFOS6jaq8
+        IPIwYDFWA9g2vgECfFiQDNgIRShKBLdD7jVsMWEDhkIZS4SHGYT0aREGj4nfh9qwS2n1oYI8Iood
+        mQ8+7pwV3WLJEvPK6QjtWiI1EOuSYaf2UMB6xvBoeQ6zdB6EKy+ce/PoWxg9R4/Py/nf+CceP2g8
+        lAX7NQ/dB5Wi/AFJocxkugjCeRw7u6wwp0HPXZH+xQ3BSI7n1rpTgqG8hp7qFIMpopyI9FW+S/VD
+        oocOm/RSpTYeN6YkkkLqSJfo5POZu69GOpbTpEXppa9/9lhH1HEZZNx2r6uPtWFDStHGmSklgMhZ
+        6rLjaJWxJpYas+2hyEvhYu05O7dMqlIquK7u93Il7S4N54l/AZ4xD0A0ZmgenFAr9MgEdh7rhggD
+        zRfN7Tsgwu7wf4cuzB7mKDwnW/BKLdKdtYV59n1iDFjzkGnCpesUW3zMD3J4QCn4BTnkIO33HOxO
+        se9CbZW/R6k9FHL7AnLPtZKOsDZEskx9YMM7+q9uQ3k4IWdEvnchnaCTtq8t0jCOw8RvDg7H67US
+        PXm2QGXUUBDUxB8K8eZ3jStWUuvk0n3XYY5iysxQzQuXZ9PklWhNDk1lWPUOMo2XZmVs4tcnh5eS
+        /1NWrSWr9Igv5xsOOl1ENF6EG0ZpRKPNahWtlhtYhkFEIYaMYsle/XTyHzSMPchceYa9X9HI0d6w
+        NV5dV8np65v+1SfUUDVFiC1NWtuAJX4DtHa632MtmAJ9Qt3gf8eqvABbOtkbD7RW+tR+2Y8bbm9y
+        XF4zTui7OZ2FZ8Tfak+jnNZZUyVofQNa1Sv2MjM0B5HsWuqOSPRJq97pdGhs9vS+ePz5M3ub69US
+        d4UhVusBBUwxmPN0pWEQBJW8B60jX1sc+umXAi1792deY7QeMJRt8BjvwqeiW2q65ac931hgbi0x
+        44vMXcvMnQvNjaVmdLG5e7m5Y9voTfuukk4XzAa90pOO/8PFdtBP92Vvbe8a2yCO2bxzpl3yxydb
+        G8P9A70X9chm07D+p27dCmB4/DTW25O4IV7bUFrzL60fXQXdWOzaN4zM14Zy3wQ/0/pd6+Ixj7fG
+        dV0lA1Xx+VX987PXhXY+L08RHJFn0f8LAAD//wMAHfjXfmoOAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"98ee24bf55e7c9e866c13ea2eda8a37d"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"556ea70d937b2b8697192f3ea4f93220"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
@@ -39,38 +39,38 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/35060504
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/38515680
   response:
     body:
       string: !!binary |
-        H4sIAALbk1UAA7RXS3OjOBC+51e4fCeAX3FShNRctmoOu5ed7GEvUwK1bdkgMZJw7Pn127yFMRhX
-        sjfU/alptfrxyXs7xdHkCFIxwV+n7qMznQAPBWV8+zp9//GHtZ6++Q9emCotYpD+w2TiMerPl87K
-        WToLz8ZFJkNduCNcW7jeP28/6GZPD6dzvKNb6dmmNkNvmFTa4iSGCWfR61TLFKZ2ropInyYUcUL4
-        uSOHmLCoI012gndtbMipI/uAQDF95X8SiAZqET3R5wRepxSXmsUw9WeOu7ScJ8txf7izF/fpZfH8
-        r2c3G/L9aULH7Z85aAL3NxuK/+cxtzYMIqpqlyjTVkgkVaVRIiU5TzNtW19IUBawKMLbtAilEpSq
-        5MU9qkN1g6WsumirdcmmtMH232IJ6L3L6mfXb7TUKi0BdOV3DwhOGjjNgjYIi0RIIqb7fiVhi/nf
-        o0yE0iSysCjAf164zpNnmyLzOCnX8pyLLRIlOzLrPfglcj4GyVO8AxbegA4FfGxKVynZTunSyicT
-        O7dh96Qlpiv3F447W68zDK/lWU5b2e/8f5gi6Fm9NhE7EVFM074QZBmX9SJGIv+dH7j44GipkTWw
-        IpRiYzGlUsJD8N///pZhu4p60+eDO778GmSW2hqzFx00kLW0wlMImG4OXSwb5YakUeV3IEQEhE/9
-        LHgZNFc24FTixVhYM2mU+W8YvdRUW+CUMJn7Y8WC653vzjy7I7yCPgORGL2Z04Ln0hYa6KXvGxIp
-        KHcZnuyARHqHqQKN24asgrGYbMFKZeTvtE7Ui20TpUCrx0ASxrPGtMUDfpDzI2aPnZBzDFz/jEHv
-        BP0Zia2wj5iljwnfvgE/Mil4BnhVhNNAnLDn1vbrP2I6ZfUQEH5oXGtJK2jeVhe+u167nl0uKh26
-        IkVkZHclqAESEoJ59JdAXfld6VQaqFCyJAtye740FaTFAbj/fN7OZivPLlaVLuXsV5q3qSBPVjwy
-        w/El/cU8XC/cDQ3DeTjfrFbz1XIDS9eZh7CGIMRS791a2/6CpnMEHgtL0UNPstR6Y4dEN4pSujZx
-        O6BGnE8wolPlF3qgnl0KTEx4PGLBqATtQzFQ/sQy7gjNLeSoLJBSyDbmes8v8cbE6v5uGHBpqj2X
-        L8DfC2uDGNNgWUaI2EOYFzc2RdU3i02iScK8GWc9Ueng+bB4+v072M/kark3CKeBMq0kUoTo2GUI
-        fddxnKwurmtvWNBIRvxvCWqO2WX3IUwr6FZ4ejrM920a1tA2UzaCcuWgG7SrSLsh6lUm7236lQPH
-        UbDCs0EalkOGqFgR+JF0rDzmLU5kcJF2XXapdKkZ6ID13V3lMOb1XG/f1b9vcZ068neM1e6e28O1
-        8uc+rmGc4gYfK5H/49yokqZ/6pWIccSgBA+RqQpyN0uqwjaKolbnujHuS9h4clE7cT8BrkMtaBrm
-        HbfxqpG1Cq+nyO6j0qued8rXkIbMzWsDvi0tZ3rnRC1BDvLKLglXH/CXr6HOE/2OF8LwrBieEkPz
-        YcRkGDUTBqfBwBwYOQHGPsfHPsZHP8VvDp0veSl+OrWRqDXJVi8Al006+Q//AQAA//8DAF2fqcIh
-        FAAA
+        H4sIALEoXVgAA+xYy5KrNhDd369wec8Afg0zxTCVTaqySDa5k0U2twRqG9kgEUl47Pv1EQ+BMAYz
+        NZNNyjur+6jVarV0jvFfT2kyOwIXhNGXufvgzGdAI4YJ3b3M377/annz1+CbH+VCshR48G028wkO
+        lt7aXW88x7fVoLApXxQjKi013j/t3vF2jw+ncxrjHfdt01ugt4QLaVGUwoyS5GUueQ5zu3QlaMgT
+        sTRD9NyzQ4pI0rNmMaP9GFt06tneIRREXlmPA5KALSRn8pzByxyroSQpzIOF424sd2Etlt/d5bPr
+        Pa/cv327nVDOzzM8bf7y8Xm9UPPbCdX6Zc2tLYEEiyYlTKQVIY5FHRRxjs7zwtv1VxZlC0mSqNO0
+        EMYchND26hyjvT7B2qYP2uocsmltscOnWAMGz1Ivdv1Ea6+QHEDqvAdAcJJAcVG0UVjCIpQQObQU
+        h53q/wFnxoREiaUuBQRPK9d59G3TZG4np5KfS7OFkixGi8GNXyKXU5A0V2dAohvQsYJPbWndkt2W
+        rqN8srHLGPZAW6p2pcHKcReeV2BoYy962iqWC/4iAqnMmrGJiFmCVZsOlaDouOItIigJ3uiBsneq
+        IrW2FlaVkm0tIkSOaARBAexbmxmfr+z0u9cii76WqnWDtz8NZGPVeAwhke2Oq2Hr3KI80XmHjCWA
+        6DwoKldAS2cLzrk6FUtdmDwp8jeCXnr0FDhlhJf5WCmjMg7chW/3jFfQZ0BcVW/hdOCltYMGfJn7
+        FiUC6llGJjGgRMaqT6BN27BpGEnRDqycJ0EsZSaebRsJAVI8hBwRWrxKO7XBd3R+UK1jZ+icApU/
+        UpAxwz8StmP2UbXoQ0Z3r0CPhDNaAF4EojhkJ/XgNvGbFVU7FZchRPTQptaxamj5pq4C1/Nc364H
+        2qdS4SwxWlsbGgCHDKk++oMpX/279TGcRyVFt/Nbm4aJPBQRJ1lxFl0Oam+ZZAeggbcWGyF9uxpp
+        X07JP3n5lIVlT6vKEEVxPFgtI2/lbnEULaPldrNZbtZbWLvOMgIPwkg9B4NTm9hf8DAdgabMEvgw
+        0FON35jBVRrVjbvGyj1Qay5ZDslcBJUfsG/XBhMTHY/qXolMxYeKdH5Xt71nNKego7CAc8a7mOu8
+        UOMNVusvNw64DNXl7gvwb1W0UYwZsL5tCrGHqHwD1NsphvjaFKMoKt/son+FDJ8Oq8efP8P9gm/W
+        e0OUGigzimr+SCV2WcLAdRynvBpXvTciSCVYgl8y5TkWhz2EMKOotHbOoxe7T1lXrLXizrRNEGYl
+        6IY4qxpvTKDV7XtbpJXAaUKtymxUrJWQMcFWlX6iaKu3eUs5GYqlezP7grv2jLyBzdldVTrm8Vx/
+        5/XatxRRU/kP8G9/zm0W1vl8TJQYu7ih2mrkf8gcummG6bFGTFMQNXhMdWnIh+WULtskIav3dUMX
+        1LDpKqRJ4oMyuanzFKlRQu2BG/Y1f2W+RjMUaV7n9zvt32n/Tvt32jcRd9rXu7jT/p32/4e037XW
+        lN7bUcdQgvz6iYSrn/Yvv5P2Pt5/4PPhOFGMU8QYOUyghUmEMEoFIyQw8fmf+qF+6mf6yR/pbzLO
+        l3xG/nRrK53WNlszADVs2yn49i8AAAD//wMA2p9ICjscAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"9f8f0e8cdcdc2bcdc26fb50e704e003b"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"d3fb5764de5bf924c0a729f028d1b4d8"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
@@ -78,17 +78,17 @@ interactions:
     body: null
     headers: {}
     method: DELETE
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/9yg226
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/85s6st
   response:
     body:
       string: !!binary |
-        H4sIAAPbk1UAA1IAAAAA//8DAEXPbOkBAAAA
+        H4sIALEoXVgAA1IAAAAA//8DAEXPbOkBAAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
-      content-type: [application/xml; charset=utf-8]
-      etag: ['"5525e7db366506adfea72aa0e6a7d3af"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      content-type: [application/xml]
+      etag: [W/"3cb65ec5d68b5fa25ce554726afe616b"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
@@ -96,207 +96,107 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/35060504
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/38515680
   response:
     body:
       string: !!binary |
-        H4sIAAXbk1UAA5RTwXaCMBC8+xU87ikBtVQf4K1fYC+9pWSFaAi8JFT4+wZQwQLWHndmdjfsDMGu
-        yrj1DVKxXIS2+4JtC0ScUyaS0P7Yv6M3exctgrhUOs9ARgvLChiNlmv8itd4FTimaDDDxSkRGpn6
-        uEnO9HCkp6rOUprIwBmyjfrApNJIkAwswXhoa1mC7bQUJ3NMnGcFEfUIh4wwPkKLNBfjGQdSjbAz
-        fCmmJ/ZJIBooItrSdQGhTU2pWQZ25GF3jbCPsLt3va3rb1ebz8DpG9r+sqDP9Xt46zb9fUO3v705
-        OjDgVN2eRJlGMZFUXYYSKUl9eTGhVIJScM81VE92VeeiOl39a5GryejO4CF6Vc7719KzHnZrpn1s
-        OaUlgEaXt05KoNIgaHOmByKex4QzPb1EQmLSPkkVudKEI/MDQLRZudgPnCHUf0IptKxbEBFepMSb
-        +dTfuuXfOlGaa7P4oXD+uM+GtgmdPwptO+NfwfVHwTUTnEHYbgWYso9TtPgBAAD//wMAA/K1LHwE
-        AAA=
+        H4sIALIoXVgAA5RTO3aDMBDsfQoevcLPH+wHuMsJnCadghaQIwRPEjHcPgJsQwI4Trkzs7tiZwiO
+        dc6MLxCSFjw0nRfbNIDHBaE8Dc230yvyzWO0CuJKqiIHEa0MI6Ak8vyNs9n6dmDposU0F2eYK6Tr
+        8z69kORMPusmz0gqAmvMtuqECqkQxzkYnLLQVKIC0+oohpeYuMhLzJsJDjmmbIKWWcGnMxJcT7AL
+        fEiqZvYJwAoIwspQTQmhSXSpaA5m5NrOFjkucr2T4x0c/7B23gNraOj6q5I81+/tDhtP9w8N/f7u
+        5iihwIi8P4lQhWIsiLwOxULg5vpiTIgAKeEn11ID2Ve9i/H55l+H3ExGPwweozflsn8dvehhv2be
+        x46TSgAodH3rrARqBZy0Z3ogYkWMGVXzSwSkOu2zVFlIhRnSPwBE+7Vj7wJrDA2fUHElmg5EmJUZ
+        dhc+9bfO+1vHK31tGj8ULh/32dC2oXMnoe1m/Cu47iS4eoI1Ctu9AF0OcYpW3wAAAP//AwB0evtp
+        fAQAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"1d6edbb8f97c32fb009c4cf0cd5bdefa"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"bcf844519b7b3b4aa3dd233b80f9cabe"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<payment_method><customer_id>35060504</customer_id><options><verify_card
-      type="boolean">true</verify_card></options><payment_method_nonce>an-invalid-nonce</payment_method_nonce></payment_method>'
+    body: !!python/unicode <payment_method><customer_id>38515680</customer_id><options><verify_card
+      type="boolean">true</verify_card></options><payment_method_nonce>an-invalid-nonce</payment_method_nonce></payment_method>
     headers: {}
     method: POST
     uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods
   response:
     body:
       string: !!binary |
-        H4sIAAbbk1UAA5RTy27CMBC85ysi302CKBVIwdz4gnJGJl6CIbajtXnk7+sQJ4SUVurNu7OPmR05
-        W99VGV8BrTR6RaaTlMSgcyOkLlZk+7WhC7JmUcYrSQHRIEWwldEWWBTH2SNlm2cfxK6uYEU4Iq9J
-        EqCK1wq0owrc0Yg2+b6jwzr0GfuM5wVsOZumiyx5vIcgdw7l/uIgzLO12puSsLB71+7eaaNzyJK+
-        +mWGAmt5AWyrz9rcdPyud5IlXdmTa/JCNoTdYZKf8ocV/jrIlf37VPnFOqMAqRRsNk8/03n64Y8w
-        yHaVpnLeSzsg5+2Vh5rmHAVzePHqh5me86hxxIQ+xDOuqdRXXsqQGIsLZb8Kb4zKmz0sR+CucaIN
-        o+CwdmjKEnDkm20c77EouIX5kfvxXv1pWdzE4STO91odRYGNSU80asl0Z/63z57lmw/wDQAA//8D
-        AEj7v6o9AwAA
+        H4sIALMoXVgAA6RTy27CMBC85yss301AiCpIwdz6BeWMTLwEQ2xHa/PI39d5ElLaS2/emfV6dkZO
+        tw9dkBugU9Zs6GI2pwRMZqUy+Ybuvj5ZQrc8SkWpGCBaZAiutMYBjwhJG8jVx6EgviphQwWiqGjc
+        UaWoNBjPNPiTlS34/kbP9eyzDkjQBXy9XMyTNG7OY1J4j+pw9dDNc5U+2ILy7u19+/beWJNBGg/d
+        LzM0OCdy4DtzMfZuiEUCj1IhSPJuzCyN+xtP2fGL7q7sPYp/OjHuCEah0O5v17Kr81YDMiX5Mlkt
+        Vh/JPPgxQvtOW/oQqxuJC0mrY8UygZJ7vAYjxsigeXJxooQ1y3NhmDI3UagOmC7Xtf26eBOo8WiL
+        AnASk6sDHri2WWS1KJ4hCF8n2JZRFxxmJxHGh+3P6/wuj2d5eVT6JHOsQ3qyUSumt/k/kQcNb77F
+        NwAAAP//AwC1PXfyUwMAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 422, message: Unprocessable Entity}
 - request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/bkhpqm
-  response:
-    body:
-      string: !!binary |
-        H4sIAAjbk1UAA6RVTXPaMBC98ysY34U/MMRljDO99NhLkx566cjSGmuQJUeSSfj3XRkDDh9pM72x
-        b5+0u89PS/741sjpDowVWq2DeBYFU1BMc6E26+D56RvJgsdikjMDXDjCqOHFZDrNSyElUgjl3IC1
-        HkNU8CJ9zUPBh5h11ukGDEEkjtN0vkjSPByjB14ljHVE0QamSsh14EwHQTgkJb2fY7ppqdrfyFhn
-        ANyxvxsEeHOgOPAPKFIzKoW7db2BDQp2I9Fq66gkqCAUX9I4esjDMXRsu1PO7HuIUNnWNLk53CVr
-        /jeW6lBXwT6g3RPSAHVeDDd1+xbWAcfQiQaCIoniBYkeSBQ/xckqflgtkl/4EU8Hhhu6ln/uhvOB
-        3lHhDUuhzVSRRnGSZT6vesx7kPgSxU9hKXZyio/ZWkuO9ro1qncMSsQElcWz2ir9qvCGMzYZSaUr
-        IqztqGJQPP/46nnXicn/i/dvz+TM8rZ06D5sasQ6oZ7LoRTuPOAhPCQq2sljn6XWEqgKCi+Qp/XJ
-        A7EzKDhBn3fS9zq67DIz6V9TK0xfnzRaubqIkzy8Ai+Ye6AGFUqid9QePTGBX/ZaUWlhODFUr4FK
-        V+Onh3ObI8xTREM3QDoji9q51q7CkFoLzs5KQ4Xyy2KDw7zS/QzdELZ034Byvxtwtea/pd7ocIdu
-        m7Vq8whqJ4xWnrC2VPFSv+HOO93fV0N7eC+XVG3PLb1DJ8fVlhZxlsV5OAQex/JGy5FDj0CfNNBS
-        9MR3jfjw2+O2Ky0zovUi2kE0agzdD853eguqKLd1+9Lk4SHyeKfES9evjrI3G44lKgGmSOcsS+OK
-        MzZn82q5nC8XFSziaM4gg5Lhk7x7dPKphZCtFsvrhbAD1Whi+faOAU75gW2w9OEJXE3fv7jz/9cf
-        AAAA//8DALEILZ71BgAA
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-encoding: [gzip]
-      content-type: [application/xml; charset=utf-8]
-      etag: ['"34022798609eb2520c567ebb58f31266"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/11443524
-  response:
-    body:
-      string: !!binary |
-        H4sIAAnbk1UAA6xVTZOjOAy9969IcXcTCOnOdBG69jLHuez0HvYyZbAInhibsU0n+fcrE77SCRmm
-        em/o6ckW0rMUvx5LsXgHbbiSWy94XHoLkJliXO623tv3r2TjvSYPcVYbq0rQycNiEXOWBEEUrdZh
-        FPtoOAx9WUGlJWj//LI7sPwn2x9PZcF2OvbHXsfOuTaWSFrCQnKx9ayuwfMbl6BTnkyVFZWnKxxK
-        ysUVWhVKXp+R0+MVdoDUcHvjPg3UAiPULuypgq3H0LS8BC8Jl8GaLJ/JMvgehC/B88s6+Df2h4Am
-        vq7Y/PgQ44eA8/1NzUnOQTDTp8S4JRnVzLSHUq3pyXPeS/8ZQSzlQmA3CWVMgzEdfu5jdOg62GJd
-        o8lFk8fowJ3uYkuY7GV32e2Otl5jNYDt8p4gwdGCZK5od2lCZVRwO3WVhh3qf8JZKWOpIPgoIPkS
-        Bcvn2B9D49+ppdWnBiZUVAUNJ3/8I3M1hylr7AHPfkO9V/A/kXR4Jen2lE8KuznDn5AlylUm0TII
-        NxvHkT3uNE3cdck/3FDMrLfHjEIJhjKdKoFTnJtFnIrkTe6lOkg8acAG2rmUKifcmJrKDJK3v/9y
-        3GtHH/T54s5/fgPTSduiejHBEbNHOz6DlNvhp8/m4MxpLbq8U6UEUOklrniO2jgHcq2xMQTfTC1c
-        /qNDP3q6EDhWXDf5kFJJWyRBGPtX4A32CajG6oXLC3qDXrCBfcw9p8JAGzXKpAAqbIFSgSHtEdbR
-        eEl3QGotksLayrz4PjUGrHlMNeXSDaYd/uCBnh5RPX5FTyVI+6MEWyj2Q6id8t9RpY+V3L2CfOda
-        SUfYGipZqo44c/vz+xtRTu49pFTuh9Qu0I7ajNUoCTabIPZbo/NhKlqJkbo7oCdoqCjq6JtCX/vd
-        +UydmkzzyhX5cr8ML8iqPcgk3RfVrzL2z1bnqyX/VTdjKm3Eir/McX3pJFplmyjIWZatslX+9LR6
-        WuewDparDDaQZvjUJ0P7s2cPnc3L+un20HkHWSpi2H5CLL1/FKExjfNTulmR5hWPd+4F0Iy1uB1x
-        cHNlf5x/V0v5D2bC/YV8fx3fW8YzVvGsRXx3Dd9ZwjNX8NwFPHf9zl6+v129/8tu+PTajf2R2HoD
-        0BzklDz8BwAA//8DAM13fYwTDAAA
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-encoding: [gzip]
-      content-type: [application/xml; charset=utf-8]
-      etag: ['"b4633fa9570f8059a6d8a9df8f5f7544"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '<client_token><customer_id>11443524</customer_id><version
-      type="integer">2</version></client_token>'
-    headers: {}
-    method: POST
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/client_token
-  response:
-    body:
-      string: !!binary |
-        H4sIAAvbk1UAA7xVXW+jOhB976+o+r53wSS9i9R21TSBgMDZkASw3zCQArEhbQhfv/6O0+ym1VZX
-        K13pPiDAHs+cOXNmfPe9E/y6SV8PeVXe36h/KTfXaRlXSV4+399s1saXbzffH67uYp6nZf2lrnZp
-        +XB1fX3XRPyYPqS9jWhoD1GgH62i6p0nO0tCr2KavU+Foch1T/AjRX4fz+09K5f5Irc0ElgIm2RE
-        p1xggXOytlQXzXq8phkZjJ27nnCy5pyun4dFQDQ8fRzBf4GHZ4Wss9ydevDgDL4FCTzhTmfd1sQ9
-        DQyFBt6WhEvdLR47vFJa3Cut6y87F/C506rH+Wi8mJLBXVstLh5f3elj6xqdCu8esKix5jUs8PsQ
-        8d2P9azD0+WA15YSzjetO7WQ3CMoy1jpbaNgqUcFLxPkiUh4r+mc15HplTE/+ysnKhHdnqj6Kw13
-        uivoOA72Cg6NwUWxkpRJR3PrYAncMEH3VPV79mTdWiJTkvlkWOTfGhJO9k6JMya8nGnPR1LaWRSM
-        lVj4nCLIN0yydDUuGFJuJVYHqTwWuCLSptdfFkGiUZO+ULMepYFaUTPpHYQPUeAfE0PPYnPXJMWs
-        IUg/UgG5hFBDkzfsDRf46Q40GJc0dPMFrxOoMWcl3cdCPzLpQ+K94Mthv2AmBxtvEpvcj0ULNber
-        ZO618VA1DjLaaDUeAN+OCH3kCLsnAT8mc5vTIIHYvkbC3RHw1Itiqbi9XoPGisg0wMZtPuU713/G
-        3Eq+rLzNSYgHGnqDH9oH0GYezT0lnru3Tg85a5iDr3/jMv+p5c/Oy3WnpJwJtfnD2pz8MWEc0tDb
-        Ew24LA958rvvcx7LGvjJ2JxDD+HhT2NsV22emBn0gT/bIL8A/9wDP6BBTqFOwLFKP7Gxiv3fluga
-        hmo1Nv4nDWpeJc+HyNvGZxwOOmN4snXgqyUhb0F/BvCWM9PfAU4lLn1+2WtPPFKTD7HZZekGOAs2
-        Um/zWM6fcAK4Tjp+0/uMSx/HBDQtfcSCIxLg8YcaT6VG/REJ1JaZm5MOHW3SSk0lIebxzigl7pP2
-        P3D1KOvHU9OoAQt3ZE+vdIVBrSGW1CP/L1p8s8Of9BOuaIBfmeYrTgn5Qs7s6de5XQS8Es17usT/
-        lX/GzK5JlBN24NHrk2ADXEFegvcMjWvoe2Ut9AX0kQYz/fUd/7/PAKELCrOOiY2Mq8I+4PU4nV20
-        AOdhXneD1OD7fJeo28tYq0DeD3YNWBXZ8+deGCT37+buhCDcJBf7ITGtcTQstbTc51Fh97jwX04z
-        QIN7B/IhGrdjpE8Z8rjk3/fxzCqV09wFDKfavO8TCn0aI8nFBfs51qdaPmkD4rDgm7RpqCD5dnl/
-        f/f17Z68uvv68Qb9BwAA//8DABOH89l4BwAA
-    headers:
-      cache-control: ['max-age=0, private, must-revalidate']
-      content-encoding: [gzip]
-      content-type: [application/xml; charset=utf-8]
-      etag: ['"9d2182db15015e1b03843dc36d579675"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '<customer><custom_fields><participant_id type="integer">4</participant_id></custom_fields></customer>'
+    body: !!python/unicode <customer><custom_fields><participant_id type="integer">5</participant_id></custom_fields></customer>
     headers: {}
     method: POST
     uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers
   response:
     body:
       string: !!binary |
-        H4sIAAzbk1UAA5SRzVKDMBSF930KJvvIT+sInUB3PkHduLtyL5CWBCYJFt5egjh1RBcuzzn57l/E
-        aVRt8E7Gyk7nLH6IWEC67FDqOmcv52eeslOxE+VgXafIFLsgEBKLNMv2h30ci3AW3puzsgHt+Kwv
-        WX3D6oLXcVIN1kaE31P/upLGOq5BUaBlmzNnBmLhErXwV1J2qgc9bXxSINuN2zed3taoYNx4N3qz
-        0v3SzxA4Qg4ucFNPOcNZOqmIFUkUP/LoiUfxOU6OSXRM0lcR3oGFH3r8H38HPvsvN+eVpBatd/xW
-        YJwsZb/e8iDCH44Hww3pd0HpeAkG7ToNGAPTuiogGrKWNtlXLf/zHwAAAP//AwCkB3xhLAIAAA==
+        H4sIALUoXVgAA5SRzVKDMBSF930KJvtIAyK2E+jOJ6gbd1fuBVJJYJJg4e0ltU4d0YXLc06++xd5
+        mHQXvZN1qjcFE3dbFpGpelSmKdjz8Yk/skO5kdXofK/JlpsokgrLTKT3QqS5jBcRvCWrWjCeL/q0
+        a85Yn/BtmnWLjZXx9zS8rpV1nhvQFBnVFczbkVh8iTr4K6l6PYCZVz5pUN3KHdrerGvUMK28M706
+        5X/pZwk8IQcf+XmgguEivdLEymQrHrhIeJIeRbpP832Wv8j4Blz4ccD/8Tfgs//l5rxW1KELTtgK
+        rFeVGq63zGT8wwlgvCLDLqg8r8Ciu04D1sJ8XRUQLTlHq+yrVvj5DwAAAP//AwAYKBrjLAIAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"2d142edff1cdee2ca3180332c3c9a30a"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"65352f8ff7ac78fcc9d07ef338d28f7e"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode '<client_token><customer_id>89934311</customer_id><version
-      type="integer">2</version></client_token>'
+    body: !!python/unicode <client_token><customer_id>51341137</customer_id><version
+      type="integer">2</version></client_token>
     headers: {}
     method: POST
     uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/client_token
   response:
     body:
       string: !!binary |
-        H4sIAA7bk1UAA7xVXW+jOhB976+o+r53wSS9i9R21TSBgAJsSALYb9iQ8mGTNCF8/fo7TrPbVltd
-        rXSl+xQFj2fOnDlnfPe9E/y6SQ/HfFfd36h/KTfXacV2SV49399s1saXbzffH67uGM/Tqv5S78q0
-        eri6vr5rYn5KH9LeRiSyhzjUT1ax6xdPdpZE/o5q9j4VhiK/+4KfCAp6Nrf3tFrmXm61rjBKss4E
-        Me3SGWaaN3XGZPrckQIjbz3JnXA58qbW4A4kd0zcY0Q4HsqRE2JF3sNFxr11qckYMnUFCYNya7o9
-        CQ2FhP4WR0vdKR47d6W0bq+0TrDsHMDnTHe9txqNnbXTeVMG/8uDM31sHaNT4bd3hasyzW9oGPQR
-        4uWP9fPYWzsKYOyi+aZ1phaSZxhlGa38bRwu9bjgVYJ8EQv/kM55HZt+xfglXzVRsej2WNUPJCp1
-        R5AxC/eKGxmDg5iSVElHcutoCbehguyJGvT0ybq1RKYk88ng5d8aHE32i8rNqPBzqj2fcGVncThW
-        mAg4QdBvlGTpalxQpNy60+WwQCpnwt1hGdPrL16YaMQkL8SsR2mo7oiZ9AvkHuMwOCWGnjGzbJJi
-        1mCkn4iAXiKYockb+ooL8nRHEo4rEjm5x+sEZsxpRfZM6Ccqc0i8b/hyOC+oySHGnzCTB0y0MHN7
-        l8z9lg27ZoGMNl6NB8BXYqGPFsLucchPydzmJEygdqDhqDwBntorlorT6zVorIhNA2Kc5lO+c/1n
-        za3ky8rbHEegnsgfgsg+gjbzeO4rbO7cLnroWXM55Po3LvOfWv7svvy+qAinQm3+cDbnfFQYxzTy
-        91gDLqtjnvye+9LHsgZ+Mjrn4CF3+NMa21WbJ2YGPghmGxQUkJ/7kAc0yAnMCThWyScxVrH/2xJd
-        Q1GtMuN/0qDm7+T9CPlbdsGxQBcMT7YOfLU44i3ozwDecmoGJeBUWBXwt7P2zCMx+cDMLks3wFm4
-        kXqbM7l/ogngOuv4Ve8zLnOcEtC0zMEERzh0xx9mPJUaDUY4VFtqbs46XGiTVmoqiVzOSqOSuM/a
-        /8DVo5wfT02jBix8IT290hUKs4ZaUo/8v2jxNc79xE/ujoTugWqBsqigX+iZPv26V8bAK9b8p7f6
-        v/rPqNk1iXLGDjz6fRJugCvoS/CeonENvlfWQvfARxrs9MM7/n/fAUIXBHYdFRtZV4VzwOtzMnvT
-        AtwXMM9BavB9v0vU7WWtVSjfB7sGrIr0/MULg+T+3d6dYOQ2yVv8kJjWOB6WWlrt87iwe7cIXs47
-        QIN3B/rBGrcZ0qcU+VzyHwTuzKqU894FDOfZvPcJAZ8yJLl4w36p9amWz9qAOjT8JmMaInC+Xd7f
-        3319fSev7r5+fEH/AQAA//8DAAocDD14BwAA
+        H4sIALYoXVgAA6RVXW+jOhB976+o+r53jWmqIrVdNU0goOBsaALYbxhoMbEh2yR8/fo7TrttVtu7
+        Wuk+RWHsmXPOnBnffOuUPG/yl52oq9sL4x90cZ5XaZ2J6vn2Yr2yv1xffLs7u0mlyKv9l329yau7
+        s/PzmyaRh/wu7z3MYm9IIuvglnU/f/CKLA5qbnrbXNlIfw+UPDAc9unM2/JqKRbCbUnpYrKaYrZ6
+        vmTKb8nK7WjkI1qmI4LpQCa2Ik4gF9EUvrtosfINitcdKVlB8RTiRelPPOGrKSbl2lisiHhySM8i
+        G7EoeKLx0vLL+44I1PkC9b6x7PyhHshQG4uHS6h3by5WEC+nL/7kvvXtzoDfnihipGbQ8CjsYyw3
+        31druAd3V74Zz9atP3GxjlFcFLwKnpJoaSWlrDIcqEQFL/lM7hMnqFL5lq8aG1R1W2pYLyzeWL5i
+        ozTaIhLbg49TlFVZx4S7cxVpuGJbZoQ9f3CvXFWgbDYeFuK6ofF4O69IwVUguPl8oJVXJNEIpSqU
+        DAPfOCvyx1HJMboik+Uwx4ZMFampPtNbPxZRZjKH/WDO/jKPjJo5WT/HZJdE4SGzrSJ1Nk1WThuK
+        rQNTwCWGHjqy4a+4IE+3Y9GoYrEvFnKfQY8lr9g2VdaB6xwa7wc+AfGSOxLOBOPUkWGqWui5V2ez
+        oE2Huplju00eRwPg21BlXc6V19NIHrKZJ1mUQe3QpPHmAHj2i3KJ/N7ag8fKxLHhjN98qrewftZ8
+        0nq5ohU0JgOLgyGMvR14UySzAKUz/2reA2eTSMj1Jy3FTy9/dl9/n1dMcmU0f9mbYz6u7F0eB1tq
+        gpbVTmS/537jsdyDPgWfSZghMvxljf/QxrOgNkq0vutgxSLwuAptwCK4E27ccovSKpRwpqWxbKHf
+        f4i1R9zMkUPqdEW+BozRWvd3lup5j8eA5eibV39Npc5xyMBDOkeqJKYRGf2i6UR7IrykkdFyZ33s
+        +9wct7qHWUxkurErzfXoNft0Pu61XjJ37D1gkXM9Q48W4qAt1NL9l/+n96/nyCf+JTVo+MLNEM0r
+        4Auc+cP7vU0Se5KawcNH/Xf+BXe6JkNH7KBj0GfRGrQCXkr2HI/2MGdopawF+NaEHfpyov/vM6cs
+        xWC3cLXWdQ2IA95AsunH/MN9Bf0c2CPMwwnfJe62utZjpPextwesSM/Ym/eG4/wouYP/B4ZO9J+R
+        U2+85z7ZiWOKSZN95B4yxx0lw9LMq61ISq8nZfjjmN+ENwG4U1N6KbYmHAdS9yoMydSt0HEnAt5j
+        HwOYBdijkgFvBjOUYq3bB8+3Wp/uuqOPoA6PrvWZhikqnpa3tzdfX9+ws5uvv75u/wIAAP//AwBy
+        r9+GFAcAAA==
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"af32680b1bb8ebd131ada7b99adcb467"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"b955528e1e006f8884c78f1ecdb86341"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
@@ -304,29 +204,29 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/bkhpqm
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/g79ztd
   response:
     body:
       string: !!binary |
-        H4sIAA/bk1UAA6RVTXPaMBC98ysY34U/MMRljDO99NhLkx566cjSGmuQJUeSSfj3XRkDDh9pM72x
-        b5+0u89PS/741sjpDowVWq2DeBYFU1BMc6E26+D56RvJgsdikjMDXDjCqOHFZDrNSyElUgjl3IC1
-        HkNU8CJ9zUPBh5h11ukGDEEkjtN0vkjSPByjB14ljHVE0QamSsh14EwHQTgkJb2fY7ppqdrfyFhn
-        ANyxvxsEeHOgOPAPKFIzKoW7db2BDQp2I9Fq66gkqCAUX9I4esjDMXRsu1PO7HuIUNnWNLk53CVr
-        /jeW6lBXwT6g3RPSAHVeDDd1+xbWAcfQiQaCIoniBYkeSBQ/xckqflgtkl/4EU8Hhhu6ln/uhvOB
-        3lHhDUuhzVSRRnGSZT6vesx7kPgSxU9hKXZyio/ZWkuO9ro1qncMSsQElcWz2ir9qvCGMzYZSaUr
-        IqztqGJQPP/46nnXicn/i/dvz+TM8rZ06D5sasQ6oZ7LoRTuPOAhPCQq2sljn6XWEqgKCi+Qp/XJ
-        A7EzKDhBn3fS9zq67DIz6V9TK0xfnzRaubqIkzy8Ai+Ye6AGFUqid9QePTGBX/ZaUWlhODFUr4FK
-        V+Onh3ObI8xTREM3QDoji9q51q7CkFoLzs5KQ4Xyy2KDw7zS/QzdELZ034Byvxtwtea/pd7ocIdu
-        m7Vq8whqJ4xWnrC2VPFSv+HOO93fV0N7eC+XVG3PLb1DJ8fVlhZxlsV5OAQex/JGy5FDj0CfNNBS
-        9MR3jfjw2+O2Ky0zovUi2kE0agzdD853eguqKLd1+9Lk4SHyeKfES9evjrI3G44lKgGmSOcsS+OK
-        MzZn82q5nC8XFSziaM4gg5Lhk7x7dPKphZCtFsvrhbAD1Whi+faOAU75gW2w9OEJXE3fv7jz/9cf
-        AAAA//8DALEILZ71BgAA
+        H4sIALYoXVgAA6RVTXPaMBC98ysY34U/IQ5jlFuPvTTpoZeOLK1Bgyy5kkzi/vpKxmACJm2mN/bt
+        k3b3+Wkpnt5qMT+ANlzJTRAvomAOkirG5XYTvDx/QXnwhGcF1cC4RZRohmfzeVFyIRwFEcY0GOMx
+        h3KGX7si5GyIaWusqkEjh+TR8jFbPkRFeIkeeRXXxiJJaphLLjaB1S0E4ZAU5H6OqrohspvIGKsB
+        7Km/CQK8WZAM2AcUoSgR3E5dr2HrBJtINMpYIpBTEPBjFkcPRXgJndpupdVdDyEimh1JJoe7ZqV/
+        Y8nW6crpB7R7Qmog1oth57ZrYBMwF1peQ4CTKF6hOEFJ+hyn6zhfZ+kP9xHPB4Yb2oZ97obxQO+o
+        cMJSzmYSZ1Gc5LnPyx7zHkS+BP7ODXGdnONTdqcEc/aaGtU7xklEORH4Re6lepXuhhGbXUilKsSN
+        aYmkgD3pFp39v3L/9kZGlvekddbDL98uWGfUcxmU3I7THcNjoiKtOPVZKiWAyAB7dTytTx6JrXZq
+        I2fyVvheLy67zsz6p9Rw3ddHtZJ2h+OkCG/AK2YHRDuFkugdtUfPTGDXvVZEGBhODNV3QITdue8O
+        Y5sXmKfwmmwBtVrgnbWNWYchMQasWZSacOk3xdYN80q6hbNC2JCuBml/1mB3iv0UaqvCg7PaopHb
+        J5AHrpX0hI0hkpXqzS288/19NWcPb+SSyP3Y0jt0dtprGY7zPC7CIfC4K6+VuLDnCeiTGhriPPFV
+        OXz4fcQVa6n1dhnPjZinmLY0VPPG62wGXYnWpBtehlV7kHj78PjbsiI8Rh5vJf/V9qul7P3oJucV
+        B42zlOZZXDFKU5pWq1W6WlawjKOUQg4ldU/27tHZZxZGEq+z1e3COICsFTJsf8cj5/zA1q708ZXc
+        TN8/yvH/7Q8AAAD//wMAftBqHxUHAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"225c87288dfc0c475f473b8e50394ef5"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"1e94b7c4d90c11486eaf93266ea15494"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
@@ -334,69 +234,69 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/11443524
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/80594570
   response:
     body:
       string: !!binary |
-        H4sIABDbk1UAA6xVTZOjOAy9969IcXcTCOnOdBG69jLHuez0HvYyZbAInhibsU0n+fcrE77SCRmm
-        em/o6ckW0rMUvx5LsXgHbbiSWy94XHoLkJliXO623tv3r2TjvSYPcVYbq0rQycNiEXOWBEEUrdZh
-        FPtoOAx9WUGlJWj//LI7sPwn2x9PZcF2OvbHXsfOuTaWSFrCQnKx9ayuwfMbl6BTnkyVFZWnKxxK
-        ysUVWhVKXp+R0+MVdoDUcHvjPg3UAiPULuypgq3H0LS8BC8Jl8GaLJ/JMvgehC/B88s6+Df2h4Am
-        vq7Y/PgQ44eA8/1NzUnOQTDTp8S4JRnVzLSHUq3pyXPeS/8ZQSzlQmA3CWVMgzEdfu5jdOg62GJd
-        o8lFk8fowJ3uYkuY7GV32e2Otl5jNYDt8p4gwdGCZK5od2lCZVRwO3WVhh3qf8JZKWOpIPgoIPkS
-        Bcvn2B9D49+ppdWnBiZUVAUNJ3/8I3M1hylr7AHPfkO9V/A/kXR4Jen2lE8KuznDn5AlylUm0TII
-        NxvHkT3uNE3cdck/3FDMrLfHjEIJhjKdKoFTnJtFnIrkTe6lOkg8acAG2rmUKifcmJrKDJK3v/9y
-        3GtHH/T54s5/fgPTSduiejHBEbNHOz6DlNvhp8/m4MxpLbq8U6UEUOklrniO2jgHcq2xMQTfTC1c
-        /qNDP3q6EDhWXDf5kFJJWyRBGPtX4A32CajG6oXLC3qDXrCBfcw9p8JAGzXKpAAqbIFSgSHtEdbR
-        eEl3QGotksLayrz4PjUGrHlMNeXSDaYd/uCBnh5RPX5FTyVI+6MEWyj2Q6id8t9RpY+V3L2CfOda
-        SUfYGipZqo44c/vz+xtRTu49pFTuh9Qu0I7ajNUoCTabIPZbo/NhKlqJkbo7oCdoqCjq6JtCX/vd
-        +UydmkzzyhX5cr8ML8iqPcgk3RfVrzL2z1bnqyX/VTdjKm3Eir/McX3pJFplmyjIWZatslX+9LR6
-        WuewDparDDaQZvjUJ0P7s2cPnc3L+un20HkHWSpi2H5CLL1/FKExjfNTulmR5hWPd+4F0Iy1uB1x
-        cHNlf5x/V0v5D2bC/YV8fx3fW8YzVvGsRXx3Dd9ZwjNX8NwFPHf9zl6+v129/8tu+PTajf2R2HoD
-        0BzklDz8BwAA//8DAM13fYwTDAAA
+        H4sIALcoXVgAA6xVTXebMBC851f4cVcw4DgkD5Nbj7206aGXPoEWUC0kKonY9NdXwnw5Ni596Q3N
+        zkqLdrQTvRxLtnoDqajgO8e7Xzsr4KkglOc75/XrJxQ6L/FdlNZKixJkfLdaRZTE4frhafPwuI5c
+        s7CYiaUF5hqZ9c+n/ECyn2R/bMqC5DJyp1HLzqhUGnFcwopTtnO0rMFx2xDDc5FUlBXmzQUOJabs
+        Aq0KwS/3yPDxAjtAoqi+cp4ErIEgrFe6qWDnELPUtAQn9tfeFnk+8oOvXvDshc8b/3vkjgltfl2R
+        5fmByR8TTue3d44yCoyooSRCNUqxJKrbFEuJG8dGz+MnxGAJZcx0E2FCJCjV46c+Hpq+gx3WNxqd
+        NXmKjtz5LnaE2V72h13vaBdVWgLovu4ZEhw1cGIv7SaNiRQzqueOkpAb/c8EK6E0Zsg8CoifNt76
+        MXKn0PR3aq5l08IIs6rA/uyPv2cGS5i8Nj2g6V+oty78XyQdXEi62+WDwm73cGdkaeTK483a88PQ
+        cviAW00je1z8jSpsKhvWU0YhGDEynbsCqzg7iyhm8Svfc3HgZqcRG2mnqxQZokrVmKcQW+IlOmR8
+        /GaXv72RaXWtjXTj1y8T5oD2fAIJ1eMfn5ZjMMM16+tOhGCAuRPbm7PUNjiSa2m6gsyDqZmtf7Lp
+        +0ifAseKyrYeVAqui9jzI/cCvMJuAEtze/76jN6iZ2wg72vPMFPQZU0qKQAzXRidwFj2BOtptMQ5
+        oFqyuNC6Us+ui5UCre4TiSm3Uyk3P3jAzb2RjlvhpgSuf5SgC0F+MJEL981I9L7i+QvwNyoFt4Sd
+        wpwk4mgG7rD/cKKRk30MCeb7sbQztKe2M3UTe2HoRW636GOmFCnYRNo9MBAkVNjo6LMwse57jAlS
+        p61Fj/kj1tNUnahU0sr24tyDxlemxR54nD8+/dYkck+rPlZz+qtuR1nSatrcDDUWJ+NNkIYbLyNp
+        GqRBtt0G24cMHrx1kEIISWrGwWzqsPfSweR7z5vt9cH0BrwUSJH9jKaG+CRDmjJOL+7qjbSPferL
+        Z0A7+qJuDMJVW38/Iy+M+x9Gx23Tvm3Ztwx7gV0vMuubVn3DqBfa9FKTXmrRiw36r/b8Xyzkw9Yc
+        uROxDQswy1FO8d0fAAAA//8DAE4odDc3DAAA
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"b95b2eb5c6738835caf30b3b8ac6cdd0"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"c00721f5ec2625abf9936344b88d9251"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<client_token><customer_id>11443524</customer_id><version
-      type="integer">2</version></client_token>'
+    body: !!python/unicode <client_token><customer_id>80594570</customer_id><version
+      type="integer">2</version></client_token>
     headers: {}
     method: POST
     uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/client_token
   response:
     body:
       string: !!binary |
-        H4sIABLbk1UAA7xVXW+jOhB976+o+r53wZTeRWq7aj4goOAsJAHsNwykQGySNoSvX3/HaXbTaqur
-        la50n0D2eObMmTMz9987wa+b7PVQ7KqHG/Uv5eY6q5JdWlTPDzfrlfnl2833x6v7hBdZVX+pd9us
-        ery6vr5vYn7MHrPeQTRyhjg0jna56+djJ08jf8c0Z58JU5HnvuBHioI+mTl7VnnForD7xWSLqCCt
-        a/mcllsND7RwJ7bmWp7urrzWFbaOJ7yg5XNHEOnd8hm5wlVImZcEuRpZEZ2UU5UILNzyqSWrJ2Vj
-        4Z6GpkJDf0Miz4DzDi+VFvdK6wZe5wI+d7Ib8Pi2XayeWoij48F+dSfwb3YqfHsssJpofsPCoI8Q
-        3/5YTTs88Qa8spVotm4BI5J3BOU5q/xNHHpGXPIqRb6Ihf+azXgdW36V8LO/agQYuz1RjVcabQ1X
-        UD0J9wqOzMFFiZJWaUcL+2AL3DBB91QNeja272yRK+lsNCyKbw2JRvt5hXMm/IJpz0dSOXkc6koi
-        Ak4R5BulebbUS4aUO4l1jlSeCLwj0qY3XhZhqlGLvlCrvs1CdUettJ8jfIjD4JiaRp5Y2yYtpw1B
-        xpEKyCWCGlq8YW+4wE93oKFe0cgtFrxOocacVXSfCOPIpA+J94KvgPuSWRxs/FFi8SARLdTc2aUz
-        v02GXTNHZhsv9QHwbYkwbufC6UnIj+nM4TRMIXagkWh7BDz1ovQUtzdq0FgZWybYuM2nfBfGz5gb
-        yZddtAWJQFWRPwSRcwBtFvHMV5KZezfvIWcNc/D1b1wWP7X82Xt5Pq8oZ0Jt/rA2J39MmIcs8vdE
-        Ay6rQ5H+7vuch1cDPzmbceghPPxpjM2yLVIrhz4IpmsUlOCf++AHNMgp1Ak4VuknNna5/9sWXcNQ
-        rSbm/6RBzd/J9xHyN8kZxxydMYwdA/hqScRb0J8JvBXMCraAU0mqgF/u2hOP1OJDYnV5tgbOwrXU
-        2yyR8ycaAa6Tjt/0PuXSxzEFTUsfieCIhFj/UOOJ1GhwS0K1Zdb6pMO5NmqlptII82RrVhL3Sfsf
-        uHqS9eOZZdaAhc9lTy8NhUGtIZbUI/8vWnyzw5/0E97REL8yLVDmFeQLObPxr3fbGHglmj++xP+V
-        f86srkmVE3bg0e/TcA1cQV6C9wzpNfS9shLGAvpIg5n++o7/32eAMASFWcfEWsZV4R7wwnyfXrQA
-        7wXUc5AafJ+vh7q9jLUM5X5wasCqyJ4/98IguX83d0cE4Sa92A+pZevx4GlZtS/i0ulxGbycZoAG
-        ewfyIRp3EmRMGPK55D8I8NSulNPcBQyn2rzvEwp9miDJxQX7OdanWj5pA+Kw8Ju0aWC3FRvv4eH+
-        69uevLr/+nGD/gMAAP//AwA0Ow2YeAcAAA==
+        H4sIALgoXVgAA6RVW2/iOhB+76+o+r5nnaRUjdR2VQoJiYhZAuTit9hJGwc7YYFcf/0Z027LantW
+        Kx3xgMDOzHebyd23TorLJtsfeFXeX2n/oKvLrGRVysuX+6vN2vpye/Xt4eKOCZ6Vxy/HapuVDxeX
+        l3dNIursIetdnUTukIRm7RRVP39y8zTyK2q4u0xaSP3vS1ETPejZzN3RcskX3Onx4EtPjxEunM6b
+        OB1Z+3lcsAGHm2u8fmnJhHAiXU7Cae+tXUkmj51nTxEpHDiLB/i0uIh1bE8Hb1girOPts417ElqI
+        hP5zHC1Nr3jsMEedx1HvacvOG6oBD5W2WF2P8LDR4Xy0WE/33uSx9axOg+8eS6wxw29oGPSRLrbf
+        AQtebxFeszaabVrAqquzWM9zWvrPSbg0k0KUqe7LRPr7bCaOie2XTLzVK8daLLtdrJl7Em1NT5IR
+        C3cIR9bg6QylZdoR7hwciRsqyY5oQU+fnBtH5iidjYcFv23iaLyblzin0ufUeKnj0s2TcISYDATR
+        gW+U5tlqVFAd3eDJcpjrmmASV7G605s/FmFqEJv8IPbxOgu1ithpP9fxIQmDOrXMnNnbJi2mTayb
+        NZHAJQIPbdHQV1xQpzuQcFSSyOMLcUzBY0FLsmPSrKmqofB+4ONwXlBbwB1/zGwRMNmC526VzvyW
+        DVUz1602WY0GwLeNpXk9l24fh6JOZ64gYQq9AyOOtjXgOS6KJfJ68wgZKxLbgjte86ne3PzZ81np
+        5fCWxxEeSOQPQeQeIJs8mfmIzbybeQ+cDSyg1p+05D+z/Nnz6v95SQSVWvOX3pzqUWkdssjfxQZo
+        WR54+nvtNx7LI+iT05mAGcLDX/b4D21cE3qjROm78dckhIzLwAIsnNrB1il2iJWBgDttHIkW/P7D
+        WXvCTWwxMLvLsw1gDDfK3xlT8x6NAcspN6/5mgpVo04hQ6oGk0KPQzz6RdOJykRwHYdaS+3Nyfe5
+        MW6Vh2mEBdtapeJ6ypp1Ph+PSi+R2dYRsIi5mqGViShoC72U/+L/eP96D3+SX1yBhntqBGheAl/g
+        TJ/en9smkStiw3/66P/OP6d216TohB109Ps03IBWwEuKnuqjI8wZWktzAbk1YIfuz/T/feakKQns
+        Fio3qq8G54DXF2T6Mf/wvAQ/B7KCeTjju9S7neq1CtU+do+AFakZe8vecJofKQ7wuyboTP8ZPs/G
+        e+2znTiGrdykH7WH1HZGybA0snLHk8LtcRH8ONU34J0A3GNDuEw3J1T3hfIqCPDUKdFpJwLek48+
+        zALsUUGAN4EZYrrS7YPnW69Pd90pR9CHhrfqTkNkzJ+X9/d3X1/fYRd3X399u/0LAAD//wMAig7k
+        /BQHAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"6a5cf952b2f06dc9d39e7365ef937023"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"1c2ba2d744e8c48ed7a637e2580d366e"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 201, message: Created}
@@ -404,48 +304,148 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/bkhpqm
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/g79ztd
   response:
     body:
       string: !!binary |
-        H4sIABPbk1UAA6RVTXPaMBC98ysY34U/MMRljDO99NhLkx566cjSGmuQJUeSSfj3XRkDDh9pM72x
-        b5+0u89PS/741sjpDowVWq2DeBYFU1BMc6E26+D56RvJgsdikjMDXDjCqOHFZDrNSyElUgjl3IC1
-        HkNU8CJ9zUPBh5h11ukGDEEkjtN0vkjSPByjB14ljHVE0QamSsh14EwHQTgkJb2fY7ppqdrfyFhn
-        ANyxvxsEeHOgOPAPKFIzKoW7db2BDQp2I9Fq66gkqCAUX9I4esjDMXRsu1PO7HuIUNnWNLk53CVr
-        /jeW6lBXwT6g3RPSAHVeDDd1+xbWAcfQiQaCIoniBYkeSBQ/xckqflgtkl/4EU8Hhhu6ln/uhvOB
-        3lHhDUuhzVSRRnGSZT6vesx7kPgSxU9hKXZyio/ZWkuO9ro1qncMSsQElcWz2ir9qvCGMzYZSaUr
-        IqztqGJQPP/46nnXicn/i/dvz+TM8rZ06D5sasQ6oZ7LoRTuPOAhPCQq2sljn6XWEqgKCi+Qp/XJ
-        A7EzKDhBn3fS9zq67DIz6V9TK0xfnzRaubqIkzy8Ai+Ye6AGFUqid9QePTGBX/ZaUWlhODFUr4FK
-        V+Onh3ObI8xTREM3QDoji9q51q7CkFoLzs5KQ4Xyy2KDw7zS/QzdELZ034Byvxtwtea/pd7ocIdu
-        m7Vq8whqJ4xWnrC2VPFSv+HOO93fV0N7eC+XVG3PLb1DJ8fVlhZxlsV5OAQex/JGy5FDj0CfNNBS
-        9MR3jfjw2+O2Ky0zovUi2kE0agzdD853eguqKLd1+9Lk4SHyeKfES9evjrI3G44lKgGmSOcsS+OK
-        MzZn82q5nC8XFSziaM4gg5Lhk7x7dPKphZCtFsvrhbAD1Whi+faOAU75gW2w9OEJXE3fv7jz/9cf
-        AAAA//8DALEILZ71BgAA
+        H4sIALgoXVgAA6RVTXPaMBC98ysY34U/IQ5jlFuPvTTpoZeOLK1Bgyy5kkzi/vpKxmACJm2mN/bt
+        k3b3+Wkpnt5qMT+ANlzJTRAvomAOkirG5XYTvDx/QXnwhGcF1cC4RZRohmfzeVFyIRwFEcY0GOMx
+        h3KGX7si5GyIaWusqkEjh+TR8jFbPkRFeIkeeRXXxiJJaphLLjaB1S0E4ZAU5H6OqrohspvIGKsB
+        7Km/CQK8WZAM2AcUoSgR3E5dr2HrBJtINMpYIpBTEPBjFkcPRXgJndpupdVdDyEimh1JJoe7ZqV/
+        Y8nW6crpB7R7Qmog1oth57ZrYBMwF1peQ4CTKF6hOEFJ+hyn6zhfZ+kP9xHPB4Yb2oZ97obxQO+o
+        cMJSzmYSZ1Gc5LnPyx7zHkS+BP7ODXGdnONTdqcEc/aaGtU7xklEORH4Re6lepXuhhGbXUilKsSN
+        aYmkgD3pFp39v3L/9kZGlvekddbDL98uWGfUcxmU3I7THcNjoiKtOPVZKiWAyAB7dTytTx6JrXZq
+        I2fyVvheLy67zsz6p9Rw3ddHtZJ2h+OkCG/AK2YHRDuFkugdtUfPTGDXvVZEGBhODNV3QITdue8O
+        Y5sXmKfwmmwBtVrgnbWNWYchMQasWZSacOk3xdYN80q6hbNC2JCuBml/1mB3iv0UaqvCg7PaopHb
+        J5AHrpX0hI0hkpXqzS288/19NWcPb+SSyP3Y0jt0dtprGY7zPC7CIfC4K6+VuLDnCeiTGhriPPFV
+        OXz4fcQVa6n1dhnPjZinmLY0VPPG62wGXYnWpBtehlV7kHj78PjbsiI8Rh5vJf/V9qul7P3oJucV
+        B42zlOZZXDFKU5pWq1W6WlawjKOUQg4ldU/27tHZZxZGEq+z1e3COICsFTJsf8cj5/zA1q708ZXc
+        TN8/yvH/7Q8AAAD//wMAftBqHxUHAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"ab541b17a61ab30a59c86c02083b0168"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"c3ce0d3fdfe53cc7c21e15846e0c563f"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<search><status type="array"><item>authorized</item></status></search>'
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/customers/80594570
+  response:
+    body:
+      string: !!binary |
+        H4sIALkoXVgAA6xVTXebMBC851f4cVcw4DgkD5Nbj7206aGXPoEWUC0kKonY9NdXwnw5Ni596Q3N
+        zkqLdrQTvRxLtnoDqajgO8e7Xzsr4KkglOc75/XrJxQ6L/FdlNZKixJkfLdaRZTE4frhafPwuI5c
+        s7CYiaUF5hqZ9c+n/ECyn2R/bMqC5DJyp1HLzqhUGnFcwopTtnO0rMFx2xDDc5FUlBXmzQUOJabs
+        Aq0KwS/3yPDxAjtAoqi+cp4ErIEgrFe6qWDnELPUtAQn9tfeFnk+8oOvXvDshc8b/3vkjgltfl2R
+        5fmByR8TTue3d44yCoyooSRCNUqxJKrbFEuJG8dGz+MnxGAJZcx0E2FCJCjV46c+Hpq+gx3WNxqd
+        NXmKjtz5LnaE2V72h13vaBdVWgLovu4ZEhw1cGIv7SaNiRQzqueOkpAb/c8EK6E0Zsg8CoifNt76
+        MXKn0PR3aq5l08IIs6rA/uyPv2cGS5i8Nj2g6V+oty78XyQdXEi62+WDwm73cGdkaeTK483a88PQ
+        cviAW00je1z8jSpsKhvWU0YhGDEynbsCqzg7iyhm8Svfc3HgZqcRG2mnqxQZokrVmKcQW+IlOmR8
+        /GaXv72RaXWtjXTj1y8T5oD2fAIJ1eMfn5ZjMMM16+tOhGCAuRPbm7PUNjiSa2m6gsyDqZmtf7Lp
+        +0ifAseKyrYeVAqui9jzI/cCvMJuAEtze/76jN6iZ2wg72vPMFPQZU0qKQAzXRidwFj2BOtptMQ5
+        oFqyuNC6Us+ui5UCre4TiSm3Uyk3P3jAzb2RjlvhpgSuf5SgC0F+MJEL981I9L7i+QvwNyoFt4Sd
+        wpwk4mgG7rD/cKKRk30MCeb7sbQztKe2M3UTe2HoRW636GOmFCnYRNo9MBAkVNjo6LMwse57jAlS
+        p61Fj/kj1tNUnahU0sr24tyDxlemxR54nD8+/dYkck+rPlZz+qtuR1nSatrcDDUWJ+NNkIYbLyNp
+        GqRBtt0G24cMHrx1kEIISWrGwWzqsPfSweR7z5vt9cH0BrwUSJH9jKaG+CRDmjJOL+7qjbSPferL
+        Z0A7+qJuDMJVW38/Iy+M+x9Gx23Tvm3Ztwx7gV0vMuubVn3DqBfa9FKTXmrRiw36r/b8Xyzkw9Yc
+        uROxDQswy1FO8d0fAAAA//8DAE4odDc3DAAA
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"5b53bb06d44c2386a53864e3e79a311e"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode <client_token><customer_id>80594570</customer_id><version
+      type="integer">2</version></client_token>
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/client_token
+  response:
+    body:
+      string: !!binary |
+        H4sIALkoXVgAA6RVXW/iOhB976+o+r538wFVI7VdlUJCImKWAHHst9hJmw87YQvk69ffMe22rLZ3
+        tdJ9QsTjmXPOnBnffuukuGzSl31eV3dX+j/a1WVa8TrJq+e7q+3G/nJz9e3+4paLPK0OXw51mVb3
+        F5eXt00sjul92nsGjbwhxtbRLep+8ehlSRTUzPR2qbQ19T2Q4kiNsOdzb8eqVb7M3c7HpPOnYeZj
+        Kv0p75AMcn/Dx2TYDv6wNYkx08gGYoZy7OPtaDkNS+SsDCSpQI4tfBxK6tjF0nFHy01p+kVWPjmo
+        p9jWKA6eSLSy/OKhQ7nW+bnW+/oKctXDclq3/no08jezEZo+jCD/iz99aH270+G3RxLp3AwahsM+
+        MkT5ffPcok2poQ1vo/m29aeuoc6IkWWsCp5ivLLiQlSJEchYBi/pXBxiJ6i4eMtXTXQiux3RrRca
+        lZYv6ZjjnYYie/ANriVV0tHc3bsSNUzSHdXDnj26167MtGQ+GZb5TUOiyW5RoYyBRsx8PpLKy2I8
+        1rgMBTWAb5Rk6XpcMEO7RtPVsDB0wSWqiYrprR9LnJjUoT+ocxilWK+pk/QLA+1jHB4T28q4UzZJ
+        MWuIYR2pBC4R9NARDXvFBXm6PcXjikZ+vhSHBHosWEV3XFpHpnIovB/4cjgvmCMgJphwR4RcttBz
+        r07mQcuHulkYdhuvxwPgK4m0Rgvp9QSLYzL3BMUJ1A5NEpVHwHNYFivN760DeKyIHRti/OZTvXPr
+        Z80npZebtzmJ0ECjYAgjbw/ezON5oPG5f73ogbOJBOT6k5b5Ty9/dl99X1RUMKk3f9mbUz4m7X0a
+        BTtigpbVPk9+z/3GY3UAfTI2FzBDaPjLGv+hjWdBbS1W+m6DDcXgcRnagCVnTli6xU7jVSggpiWR
+        aKHffzhrT7ipIwbudFm6BYx4q/o752reowlgOfnm1V8zoXIcE/CQysGlMAhG4180nSpPhCOC9ZY5
+        21PfF+akVT1MIiR4aVeK68lr9vl8PCi9ROrYB8AiFmqG1pbGQFuopfov/k/vX+PQJ/5FNWj4wsxQ
+        W1TAFzizx/d7ZRx5gpjB40f9d/4Zc7om0U7YQcegT/AWtAJeUvTMGB9gzrSNtJbgWxN26MuZ/r/P
+        nLQkhd3C5FbV1eEc8AaCzj7mH+5L6OdA1zAPZ3xXRrdTtdZY7WPvAFg1NWNv3htO8yPFHv4fqXam
+        /xyde+M999lOnBADNclH7iFx3HE8rMy02uVx4fWoCH+c8pvwJgB3YgqPG9aUGYFQvQpDNHMr7bQT
+        Ae+pjwHMAuxRQYE3hRnihtLtg+dbrU933clHUIfhGxXTUEnyp9Xd3e3X1zfs4vbrr6/bvwAAAP//
+        AwA/UQB/FAcAAA==
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"c6508c4b347ea5553854fc85763e3164"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/payment_methods/any/g79ztd
+  response:
+    body:
+      string: !!binary |
+        H4sIALooXVgAA6RVTXPaMBC98ysY34U/IQ5jlFuPvTTpoZeOLK1Bgyy5kkzi/vpKxmACJm2mN/bt
+        k3b3+Wkpnt5qMT+ANlzJTRAvomAOkirG5XYTvDx/QXnwhGcF1cC4RZRohmfzeVFyIRwFEcY0GOMx
+        h3KGX7si5GyIaWusqkEjh+TR8jFbPkRFeIkeeRXXxiJJaphLLjaB1S0E4ZAU5H6OqrohspvIGKsB
+        7Km/CQK8WZAM2AcUoSgR3E5dr2HrBJtINMpYIpBTEPBjFkcPRXgJndpupdVdDyEimh1JJoe7ZqV/
+        Y8nW6crpB7R7Qmog1oth57ZrYBMwF1peQ4CTKF6hOEFJ+hyn6zhfZ+kP9xHPB4Yb2oZ97obxQO+o
+        cMJSzmYSZ1Gc5LnPyx7zHkS+BP7ODXGdnONTdqcEc/aaGtU7xklEORH4Re6lepXuhhGbXUilKsSN
+        aYmkgD3pFp39v3L/9kZGlvekddbDL98uWGfUcxmU3I7THcNjoiKtOPVZKiWAyAB7dTytTx6JrXZq
+        I2fyVvheLy67zsz6p9Rw3ddHtZJ2h+OkCG/AK2YHRDuFkugdtUfPTGDXvVZEGBhODNV3QITdue8O
+        Y5sXmKfwmmwBtVrgnbWNWYchMQasWZSacOk3xdYN80q6hbNC2JCuBml/1mB3iv0UaqvCg7PaopHb
+        J5AHrpX0hI0hkpXqzS288/19NWcPb+SSyP3Y0jt0dtprGY7zPC7CIfC4K6+VuLDnCeiTGhriPPFV
+        OXz4fcQVa6n1dhnPjZinmLY0VPPG62wGXYnWpBtehlV7kHj78PjbsiI8Rh5vJf/V9qul7P3oJucV
+        B42zlOZZXDFKU5pWq1W6WlawjKOUQg4ldU/27tHZZxZGEq+z1e3COICsFTJsf8cj5/zA1q708ZXc
+        TN8/yvH/7Q8AAAD//wMAftBqHxUHAAA=
+    headers:
+      cache-control: ['max-age=0, private, must-revalidate']
+      content-encoding: [gzip]
+      content-type: [application/xml; charset=utf-8]
+      etag: [W/"9649cc5309a87f879c23414b2f26d870"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode <search><status type="array"><item>authorized</item></status></search>
     headers: {}
     method: POST
     uri: https://api.sandbox.braintreegateway.com:443/merchants/j9gwdfjdkxymhdgr/transactions/advanced_search_ids
   response:
     body:
       string: !!binary |
-        H4sIABTbk1UAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
+        H4sIALsoXVgAA7IpTk0sSs7QLUotLs0pKbbjUlCwKUhMT9UtzqxKVSipLEi1VcrMK0lNTy1SsjM1
         sNGHS4KVZqYUQxUlFhUlViqBBfWBonZcNvroRgMAAAD//wMA9crnoGwAAAA=
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-encoding: [gzip]
       content-type: [application/xml; charset=utf-8]
-      etag: ['"060fb2445c8687e6771a9289daf0d95d"']
-      strict-transport-security: [max-age=31536000, max-age=31536000; includeSubDomains]
+      etag: [W/"434676942d356a29b21342d2998c3943"]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}


### PR DESCRIPTION
In limited situations, we send a participant's Gratipay escrow balance negative. For example, when they receive stolen money that we refund (https://github.com/gratipay/violations/issues/34), or when I forget to post back MassPay and subsequently overpay people (https://github.com/gratipay/inside.gratipay.com/issues/951). In these situations, we want to recoup the loss from future takes, but our current behavior is to charge their credit card (if they have one) to make up the difference. That penalizes the participant for a mistake on our part, so I think the best thing to do is update payday to not charge a card when a pre-payday balance is negative.

**Update:** We ended up working around the charges for the 10 people in question by manually overriding the `error` field on their route to prevent charging. The tests on this PR are still valuable as documentation of existing behavior.