### PR TITLE
Improve git clone process, save time, bandwidth and disk space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
  - pwd
 
  # Sometimes ya just halfta ...
- - git clone https://github.com/lloyd/yajl.git && cd yajl && git checkout 2.1.0 && ./configure && sudo make install && cd ..
+ - git clone -b "2.1.0" --depth 1 https://github.com/lloyd/yajl.git && cd yajl && ./configure && sudo make install && cd ..
 
  - npm install marky-markdown
 cache:

--- a/bin/sync-npm.sh
+++ b/bin/sync-npm.sh
@@ -16,9 +16,8 @@ tar zxf cmake.tgz
 PATH=/app/cmake-3.6.2-Linux-x86_64/bin:$PATH
 
 # yajl
-git clone https://github.com/lloyd/yajl.git
+git clone -b "2.1.0" --depth 1 https://github.com/lloyd/yajl.git
 cd yajl
-git checkout 2.1.0
 ./configure -p /app/.heroku/python
 make install
 cd ..


### PR DESCRIPTION
Repo size reduce from 2084 KB to 1156 KB, we can save time, bandwidth and disk space, and a `checkout` command/process from this change.