### PR TITLE
Dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,8 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/
 RUN gpg --keyserver keys.gnupg.net --recv-key 7FCC7D46ACCC4CF8 && \
     gpg -a --export 7FCC7D46ACCC4CF8 | apt-key add -
 
-RUN apt-get -y update
-
-RUN apt-get -y install \
+RUN apt-get -y update && \
+    apt-get -y install \
     git \
     gcc \
     make \
@@ -27,7 +26,9 @@ RUN apt-get -y install \
     python-pip \
     postgresql-9.3 \
     postgresql-contrib-9.3 \
-    language-pack-en
+    language-pack-en && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ################################################## Configure Postgres #################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN gpg --keyserver keys.gnupg.net --recv-key 7FCC7D46ACCC4CF8 && \
     gpg -a --export 7FCC7D46ACCC4CF8 | apt-key add -
 
 RUN apt-get -y update && \
-    apt-get -y install \
+    apt-get -y --no-install-recommends --no-install-suggests install \
                 git \
                 gcc \
                 make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,16 @@ RUN gpg --keyserver keys.gnupg.net --recv-key 7FCC7D46ACCC4CF8 && \
 
 RUN apt-get -y update && \
     apt-get -y install \
-    git \
-    gcc \
-    make \
-    g++ \
-    libpq-dev \
-    python-dev \
-    python-pip \
-    postgresql-9.3 \
-    postgresql-contrib-9.3 \
-    language-pack-en && \
+                git \
+                gcc \
+                make \
+                g++ \
+                libpq-dev \
+                python-dev \
+                python-pip \
+                postgresql-9.3 \
+                postgresql-contrib-9.3 \
+                language-pack-en && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN apt-get -y update && \
                 make \
                 g++ \
                 libpq-dev \
+                libffi-dev \
+                libssl-dev \
                 python-dev \
                 python-pip \
                 postgresql-9.3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
-RUN apt-get -y install wget
-
-RUN wget --quiet --no-check-certificate https://www.postgresql.org/media/keys/ACCC4CF8.asc
-RUN apt-key add ACCC4CF8.asc
+RUN gpg --keyserver keys.gnupg.net --recv-key 7FCC7D46ACCC4CF8 && \
+    gpg -a --export 7FCC7D46ACCC4CF8 | apt-key add -
 
 RUN apt-get -y update
 


### PR DESCRIPTION
The old one was broken in not only one part, so just do a quick refactor to 

1. Make it work (I mean - at least the docker image can be built)
2. Optimize image build time spent - `5m43.605s` -> `4m15.379s` on my computer
3. Optimize the image size, from `839.8 MB` to `776 MB`