### PR TITLE
Finish sending out Terms notification

### DIFF
--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -284,48 +284,7 @@ def queue_branch_email(username, _argv=None, _input=None, _print=None):
     return retcode, stdout, stderr
 
 
-class TestGetRecentlyActiveParticipants(EmailHarness):
-
-    def check(self):
-        return _queue_branch_email.get_recently_active_participants(self.db)
-
-    def test_gets_recently_active_participants(self):
-        alice = self.make_participant('alice', claimed_time='now', email_address='a@example.com')
-        self.make_exchange('braintree-cc', 50, 0, alice)
-        assert self.check() == [alice]
-
-    def test_ignores_participants_with_no_exchanges(self):
-        self.make_participant('alice', claimed_time='now', email_address='a@example.com')
-        assert self.check() == []
-
-    def test_ignores_participants_with_no_recent_exchanges(self):
-        alice = self.make_participant('alice', claimed_time='now', email_address='a@example.com')
-        self.make_exchange('braintree-cc', 50, 0, alice)
-        self.db.run("UPDATE exchanges SET timestamp = timestamp - '181 days'::interval")
-        assert self.check() == []
-
-    def test_keeps_participants_straight(self):
-        alice = self.make_participant('alice', claimed_time='now', email_address='a@example.com')
-        self.make_exchange('braintree-cc', 50, 0, alice)
-
-        bob = self.make_participant('bob', claimed_time='now', email_address='b@example.com')
-        self.make_exchange('braintree-cc', 50, 0, bob)
-
-        carl = self.make_participant('carl', claimed_time='now', email_address='c@example.com')
-        self.make_exchange('braintree-cc', 50, 0, carl)
-        self.db.run("UPDATE exchanges SET timestamp = timestamp - '181 days'::interval "
-                    "WHERE participant='carl'")
-
-        self.make_participant('dana', claimed_time='now', email_address='d@example.com')
-
-        assert self.check() == [alice, bob]
-
-
-class TestQueueBranchEmail(EmailHarness):
-
-    def nsent(self):
-        Participant.dequeue_emails()
-        return self.mailer.call_count
+class QueueHarness(EmailHarness):
 
     def make_participant_with_exchange(self, name):
         participant = self.make_participant( name
@@ -334,6 +293,41 @@ class TestQueueBranchEmail(EmailHarness):
                                             )
         self.make_exchange('braintree-cc', 50, 0, participant)
         return participant
+
+
+class TestGetRecentlyActiveParticipants(QueueHarness):
+
+    def check(self):
+        return _queue_branch_email.get_recently_active_participants(self.db)
+
+    def test_gets_recently_active_participants(self):
+        alice = self.make_participant_with_exchange('alice')
+        assert self.check() == [alice]
+
+    def test_ignores_participants_with_no_exchanges(self):
+        self.make_participant('alice', claimed_time='now', email_address='a@example.com')
+        assert self.check() == []
+
+    def test_ignores_participants_with_no_recent_exchanges(self):
+        self.make_participant_with_exchange('alice')
+        self.db.run("UPDATE exchanges SET timestamp = timestamp - '181 days'::interval")
+        assert self.check() == []
+
+    def test_keeps_participants_straight(self):
+        alice = self.make_participant_with_exchange('alice')
+        bob = self.make_participant_with_exchange('bob')
+        self.make_participant_with_exchange('carl')
+        self.db.run("UPDATE exchanges SET timestamp = timestamp - '181 days'::interval "
+                    "WHERE participant='carl'")
+        self.make_participant('dana', claimed_time='now', email_address='d@example.com')
+        assert self.check() == [alice, bob]
+
+
+class TestQueueBranchEmail(QueueHarness):
+
+    def nsent(self):
+        Participant.dequeue_emails()
+        return self.mailer.call_count
 
     def test_is_fine_with_no_participants(self):
         retcode, output, errors = queue_branch_email('all')

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -290,17 +290,14 @@ class TestQueueBranchEmail(EmailHarness):
         Participant.dequeue_emails()
         return self.mailer.call_count
 
-
-    # qbe - queue_branch_email
-
-    def test_qbe_is_fine_with_no_participants(self):
+    def test_is_fine_with_no_participants(self):
         retcode, output, errors = queue_branch_email('all')
         assert retcode == 0
         assert output == ['Okay, you asked for it!', '0']
         assert errors == []
         assert self.nsent() == 0
 
-    def test_qbe_queues_for_one_participant(self):
+    def test_queues_for_one_participant(self):
         alice = self.make_participant( 'alice'
                                      , claimed_time='now'
                                      , email_address='alice@example.com'
@@ -314,7 +311,7 @@ class TestQueueBranchEmail(EmailHarness):
         assert errors == ['   1 queuing for alice@example.com (alice={})'.format(alice.id)]
         assert self.nsent() == 1
 
-    def test_qbe_queues_for_two_participants(self):
+    def test_queues_for_two_participants(self):
         alice = self.make_participant( 'alice'
                                      , claimed_time='now'
                                      , email_address='alice@example.com'
@@ -328,7 +325,7 @@ class TestQueueBranchEmail(EmailHarness):
                           ]
         assert self.nsent() == 2
 
-    def test_qbe_constrains_to_one_participant(self):
+    def test_constrains_to_one_participant(self):
         self.make_participant('alice', claimed_time='now', email_address='alice@example.com')
         bob = self.make_participant('bob', claimed_time='now', email_address='bob@example.com')
         retcode, output, errors = queue_branch_email('bob')
@@ -340,7 +337,7 @@ class TestQueueBranchEmail(EmailHarness):
         assert errors == ['   1 queuing for bob@example.com (bob={})'.format(bob.id)]
         assert self.nsent() == 1
 
-    def test_qbe_bails_if_told_to(self):
+    def test_bails_if_told_to(self):
         retcode, output, errors = queue_branch_email('all', _input=lambda prompt: 'n')
         assert retcode == 1
         assert output == []


### PR DESCRIPTION
Picking up from https://github.com/gratipay/gratipay.com/pull/4232#issuecomment-271026845 ...

- [x] Update the participants [query](https://github.com/gratipay/gratipay.com/blob/2034/gratipay/utils/emails/queue_branch_email.py#L50-L57) to only select those who have signed in (`session_expires`) or show up in `payments` or `exchanges` within the past [180 days](https://github.com/gratipay/gratipay.com/pull/4232#issuecomment-270976120).
- [ ] Mail all of them, tracking bounces in SQS.
- [ ] Manually retrieve bad addresses from the queue—**within 14 days!**—and drop them to unverified in the database.
- [x] Reticket proper bounce handling with a webhook back to https://gratipay.com/: #4284.