### PR TITLE
Rise to the ACME challenge

### DIFF
--- a/gratipay/main.py
+++ b/gratipay/main.py
@@ -98,6 +98,7 @@ algorithm.functions = [
     algorithm['parse_environ_into_request'],
     algorithm['parse_body_into_request'],
 
+    utils.help_aspen_find_well_known,
     utils.use_tildes_for_participants,
     algorithm['redirect_to_base_url'],
     i18n.set_up_i18n,

--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -32,14 +32,20 @@ def dict_to_querystring(mapping):
     return u'?' + u'&'.join(arguments)
 
 
-def use_tildes_for_participants(website, request):
-    if request.path.raw.startswith('/~/'):
-        to = '/~' + request.path.raw[3:]
+def _munge(website, request, url_prefix, fs_prefix):
+    if request.path.raw.startswith(fs_prefix):
+        to = url_prefix + request.path.raw[len(fs_prefix):]
         if request.qs.raw:
             to += '?' + request.qs.raw
         website.redirect(to)
-    elif request.path.raw.startswith('/~'):
-        request.path.__init__('/~/' + request.path.raw[2:])
+    elif request.path.raw.startswith(url_prefix):
+        request.path.__init__(fs_prefix + request.path.raw[len(url_prefix):])
+
+def help_aspen_find_well_known(website, request):
+    return _munge(website, request, '/.well-known/', '/_well-known/')
+
+def use_tildes_for_participants(website, request):
+    return _munge(website, request, '/~', '/~/')
 
 
 def canonicalize(redirect, path, base, canonical, given, arguments=None):

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    CREATE TABLE acme_challenges (token text, "authorization" text);
+END;

--- a/tests/py/test_acme_challenge.py
+++ b/tests/py/test_acme_challenge.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from gratipay.testing.harness import Harness
+
+
+class TestACMEChallenge(Harness):
+
+    def test_cant_find_the_real_dot_well_known(self):
+        assert self.client.GxT('/.well-known/README').code == 404
+
+    def test_anon_sees_401_when_empty(self):
+        assert self.client.GxT('/.well-known/acme-challenge/deadbeef').code == 401
+
+    def test_auth_sees_403_when_empty(self):
+        self.make_participant('alice', claimed_time='now')
+        assert self.client.GxT('/.well-known/acme-challenge/deadbeef', auth_as='alice').code == 403
+
+    def test_anon_sees_404_for_wrong_token(self):
+        self.db.run("insert into acme_challenges values ('deadbeef', 'beefdeaf')")
+        response = self.client.GxT('/.well-known/acme-challenge/feeeeeee')
+        response.code == 404
+
+    def test_anon_receives_authorization_response_for_right_token(self):
+        self.db.run("insert into acme_challenges values ('deadbeef', 'beefdeaf')")
+        response = self.client.GxT('/.well-known/acme-challenge/deadbeef')
+        response.code, response.body == 200, 'deadbeef'
+
+    def test_so_does_auth_for_that_matter(self):
+        self.make_participant('alice', claimed_time='now')
+        self.db.run("insert into acme_challenges values ('deadbeef', 'beefdeaf')")
+        response = self.client.GxT('/.well-known/acme-challenge/deadbeef', auth_as='alice')
+        response.code, response.body == 200, 'deadbeef'
+
+    def test_admin_sees_form(self):
+        self.make_participant('alice', claimed_time='now', is_admin=True)
+        self.db.run("insert into acme_challenges values ('deadbeef', 'beefdeaf')")
+        actual = self.client.GET('/.well-known/acme-challenge/deadbeef', auth_as='alice').body
+        assert '<form action="/.well-known/acme-challenge/deadbeef"' in actual
+
+    def test_anon_cant_post_form(self):
+        assert self.client.PxST('/.well-known/acme-challenge/foo').code == 405
+
+    def test_auth_cant_post_form(self):
+        self.make_participant('alice', claimed_time='now')
+        assert self.client.PxST('/.well-known/acme-challenge/foo', auth_as='alice').code == 405
+
+    def test_admin_can_post_form(self):
+        self.make_participant('alice', claimed_time='now', is_admin=True)
+        actual = self.client.POST( '/.well-known/acme-challenge/deadbeef'
+                                 , auth_as='alice'
+                                 , data={'authorization': 'rawr'}
+                                  ).body
+        assert '<pre>rawr</pre>' in actual
+
+    def test_posting_overwrites_existing(self):
+        self.make_participant('alice', claimed_time='now', is_admin=True)
+        self.client.POST( '/.well-known/acme-challenge/deadbeef'
+                        , auth_as='alice'
+                        , data={'authorization': 'rawr'}
+                         )
+        self.client.POST( '/.well-known/acme-challenge/deadbeef'
+                        , auth_as='alice'
+                        , data={'authorization': 'roo'}
+                         )
+        assert self.db.one('SELECT "authorization" FROM acme_challenges') == 'roo'
+
+    def test_getting_destroys_evidence(self):
+        self.make_participant('alice', claimed_time='now', is_admin=True)
+        self.client.POST( '/.well-known/acme-challenge/deadbeef'
+                        , auth_as='alice'
+                        , data={'authorization': 'rawr'}
+                         )
+        self.client.GxT('/.well-known/acme-challenge/deadbeef')
+        assert self.db.one('SELECT "authorization" FROM acme_challenges') is None

--- a/tests/py/test_acme_challenge.py
+++ b/tests/py/test_acme_challenge.py
@@ -9,6 +9,9 @@ class TestACMEChallenge(Harness):
     def test_cant_find_the_real_dot_well_known(self):
         assert self.client.GxT('/.well-known/README').code == 404
 
+    def test_the_index_is_empty(self):
+        assert self.client.GxT('/.well-known/acme-challenge/').code == 404
+
     def test_anon_sees_401_when_empty(self):
         assert self.client.GxT('/.well-known/acme-challenge/deadbeef').code == 401
 

--- a/www/.well-known/README
+++ b/www/.well-known/README
@@ -1,0 +1,3 @@
+Aspen can't find this hidden directory, so we have a function in the state
+chain algorithm in gratipay/main.py to internally redirect to ./_well-known
+instead.

--- a/www/_well-known/acme-challenge/%token.spt
+++ b/www/_well-known/acme-challenge/%token.spt
@@ -1,6 +1,8 @@
 from aspen import Response
 [---------]
 token = request.path['token']
+if not token:
+    raise Response(404)
 if user.ADMIN:
     posted = request.method == 'POST'
     if posted:

--- a/www/_well-known/acme-challenge/%token.spt
+++ b/www/_well-known/acme-challenge/%token.spt
@@ -1,0 +1,42 @@
+from aspen import Response
+[---------]
+token = request.path['token']
+if user.ADMIN:
+    posted = request.method == 'POST'
+    if posted:
+        authorization = request.body['authorization']
+        with website.db.get_cursor() as c:
+            c.run('DELETE FROM acme_challenges WHERE token=%s', (token,))
+            c.run('INSERT INTO acme_challenges VALUES (%s, %s)', (token, authorization))
+else:
+    request.allow('GET')
+    authorization = website.db.one('''
+    DELETE FROM acme_challenges WHERE token=%s RETURNING "authorization"
+    ''', (token,))
+    if not authorization:
+        raise Response(401 if user.ANON else 403)
+    raise Response(200, authorization)
+
+title = 'Take the Challenge!'
+banner = 'ACME'
+suppress_sidebar = True
+[---------] text/html
+{% extends "templates/base.html" %}
+
+{% block content %}
+{% if posted %}
+
+<p>Okay! The next non-admin to <code>GET</code> this resource (and <i>only</i> the
+next <code>GET</code>) will receive this response:</p>
+
+<pre>{{ authorization }}</pre>
+{% else %}
+<form action="/.well-known/acme-challenge/{{ token }}" method="POST">
+    <p>Let's do it! Enter the authorization response for this token:</p>
+    <pre>{{ token }}</pre>
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+    <input placeholder="authorization" name="authorization" autofocus>
+    <button type="submit">Save</button>
+</form>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
StartSSL is hosed, so we need a new TLS cert vendor (https://github.com/gratipay/gratipay.com/issues/4327). Let's Encrypt suggests itself, but we need a way to pass verification challenges for multiple domains. Let's build a way!