### PR TITLE
Extend the ACME challenge system

### DIFF
--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -42,7 +42,8 @@ def _munge(website, request, url_prefix, fs_prefix):
         request.path.__init__(fs_prefix + request.path.raw[len(url_prefix):])
 
 def help_aspen_find_well_known(website, request):
-    return _munge(website, request, '/.well-known/', '/_well-known/')
+    _munge(website, request, '/.well-known/', '/_well-known/')
+    _munge(website, request, '/assets/.well-known/', '/assets/_well-known/')
 
 def use_tildes_for_participants(website, request):
     return _munge(website, request, '/~', '/~/')

--- a/gratipay/wireup.py
+++ b/gratipay/wireup.py
@@ -277,6 +277,9 @@ def compile_assets(website):
     for spt in find_files(website.www_root+'/assets/', '*.spt'):
         filepath = spt[:-4]                         # /path/to/www/assets/foo.css
         urlpath = spt[spt.rfind('/assets/'):-4]     # /assets/foo.css
+        if urlpath == '/assets/_well-known/acme-challenge/%token':
+            # This *should* be dynamic.
+            continue
         try:
             # Remove any existing compiled asset, so we can access the dynamic
             # one instead (Aspen prefers foo.css over foo.css.spt).

--- a/tests/py/test_acme_challenge.py
+++ b/tests/py/test_acme_challenge.py
@@ -9,8 +9,18 @@ class TestACMEChallenge(Harness):
     def test_cant_find_the_real_dot_well_known(self):
         assert self.client.GxT('/.well-known/README').code == 404
 
-    def test_the_index_is_empty(self):
-        assert self.client.GxT('/.well-known/acme-challenge/').code == 404
+    def test_index_requires_admin(self):
+        self.make_participant('alice')
+        assert self.client.GxT('/.well-known/acme-challenge/').code == 401
+        assert self.client.GxT('/.well-known/acme-challenge/', auth_as='alice').code == 403
+
+    def test_index_shows_number(self):
+        self.db.run("insert into acme_challenges values ('a', 'b')")
+        self.db.run("insert into acme_challenges values ('a', 'b')")
+        self.db.run("insert into acme_challenges values ('a', 'b')")
+        self.make_participant('alice', is_admin=True)
+        body = self.client.GET('/.well-known/acme-challenge/', auth_as='alice').body
+        assert '<b>3</b>' in body
 
     def test_anon_sees_401_when_empty(self):
         assert self.client.GxT('/.well-known/acme-challenge/deadbeef').code == 401
@@ -76,3 +86,40 @@ class TestACMEChallenge(Harness):
                          )
         self.client.GxT('/.well-known/acme-challenge/deadbeef')
         assert self.db.one('SELECT "authorization" FROM acme_challenges') is None
+
+
+class TestAssetsACMEChallenge(Harness):
+
+    def test_cant_find_the_real_dot_well_known(self):
+        assert self.client.GxT('/assets/.well-known/README').code == 404
+
+    def test_the_index_is_empty(self):
+        assert self.client.GxT('/assets/.well-known/acme-challenge/').code == 404
+
+    def test_missing_is_404(self):
+        self.db.run("insert into acme_challenges values ('deadbeef', 'beefdeaf')")
+        assert self.client.GxT('/assets/.well-known/acme-challenge/fooooooo').code == 404
+
+    def test_authorization_is_available(self):
+        self.db.run("insert into acme_challenges values ('deadbeef', 'beefdeaf')")
+        assert self.client.GxT('/assets/.well-known/acme-challenge/deadbeef').body == 'beefdeaf'
+
+    def test_getting_destroys_evidence(self):
+        self.db.run("insert into acme_challenges values ('deadbeef', 'beefdeaf')")
+        self.client.GxT('/assets/.well-known/acme-challenge/deadbeef')
+        assert self.db.one('SELECT "authorization" FROM acme_challenges') is None
+
+    def test_admins_can_set_from_non_assets(self):
+        self.make_participant('alice', claimed_time='now', is_admin=True)
+        self.client.POST( '/.well-known/acme-challenge/deadbeef'
+                        , auth_as='alice'
+                        , data={'authorization': 'rawr'}
+                         )
+        assert self.client.GxT('/assets/.well-known/acme-challenge/deadbeef').body == 'rawr'
+
+    def test_results_are_not_cached(self):
+        self.db.run("insert into acme_challenges values ('deadbeef', 'beefdeaf')")
+        response = self.client.GET( '/assets/.well-known/acme-challenge/foo'
+                                  , raise_immediately=False
+                                   )
+        assert response.headers['Cache-Control'] == 'no-cache'

--- a/www/_well-known/acme-challenge/index.spt
+++ b/www/_well-known/acme-challenge/index.spt
@@ -1,0 +1,15 @@
+from aspen import Response
+[----------]
+if not user.ADMIN:
+    raise Response(401 if user.ANON else 403)
+nchallenges = website.db.one('select count(*) from acme_challenges')
+banner = 'ACME'
+title = 'Challenges'
+[----------] text/html
+{% extends "templates/base.html" %}
+
+{% block content %}
+
+<p>Number of open challenges: <b>{{ nchallenges }}</b>.</p>
+
+{% endblock %}

--- a/www/assets/.well-known/README
+++ b/www/assets/.well-known/README
@@ -1,0 +1,3 @@
+Aspen can't find this hidden directory, so we have a function in the state
+chain algorithm in gratipay/main.py to internally redirect to ./_well-known
+instead.

--- a/www/assets/_well-known/acme-challenge/%token.spt
+++ b/www/assets/_well-known/acme-challenge/%token.spt
@@ -1,0 +1,13 @@
+from aspen import Response
+[---------]
+request.allow('GET')
+token = request.path['token']
+if not token:
+    raise Response(404)
+authorization = website.db.one('''
+DELETE FROM acme_challenges WHERE token=%s RETURNING "authorization"
+''', (token,))
+if not authorization:
+    raise Response(404)
+raise Response(200, authorization)
+[---------]


### PR DESCRIPTION
- mount read-only under /assets/
- display a count for admins on ./

Ready for review, @clone1018 et al.