### PR TITLE
Use Application in Payday

### DIFF
--- a/gratipay/cli/payday.py
+++ b/gratipay/cli/payday.py
@@ -1,27 +1,12 @@
-"""This is installed as `payday`.
-"""
-from gratipay import wireup
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from gratipay.application import Application
 
 
 def main():
-
-    # Wire things up.
-    # ===============
-
-    env = wireup.env()
-    wireup.db(env)
-    wireup.billing(env)
-
-
-    # Lazily import the billing module.
-    # =================================
-    # This dodges a problem where db in billing is None if we import it from
-    # gratipay before calling wireup.billing.
-
-    from gratipay.billing.payday import Payday
-
     try:
-        Payday.start().run()
+        Application().payday_runner.run_payday()
     except KeyboardInterrupt:
         pass
     except:

--- a/gratipay/payday_runner.py
+++ b/gratipay/payday_runner.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import aspen
+from psycopg2 import IntegrityError
+
+from gratipay.billing.payday import Payday
+
+
+class PaydayRunner(object):
+    """The Gratipay application can start a weekly payday process.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+
+    def run_payday(self):
+        """Run Gratipay's weekly payday.
+
+        If there is a Payday that hasn't finished yet, then the UNIQUE
+        constraint on ts_end will kick in and notify us of that. In that case
+        we load the existing Payday and work on it some more. We use the start
+        time of the current Payday to synchronize our work.
+
+        """
+        self._start_payday().run()
+
+
+    def _start_payday(self):
+        try:
+            d = self.app.db.one("""
+                INSERT INTO paydays DEFAULT VALUES
+                RETURNING id, (ts_start AT TIME ZONE 'UTC') AS ts_start, stage
+            """, back_as=dict)
+            aspen.log("Starting a new payday.")
+        except IntegrityError:  # Collision, we have a Payday already.
+            d = self.app.db.one("""
+                SELECT id, (ts_start AT TIME ZONE 'UTC') AS ts_start, stage
+                  FROM paydays
+                 WHERE ts_end='1970-01-01T00:00:00+00'::timestamptz
+            """, back_as=dict)
+            aspen.log("Picking up with an existing payday.")
+
+        d['ts_start'] = d['ts_start'].replace(tzinfo=aspen.utils.utc)
+
+        aspen.log("Payday started at %s." % d['ts_start'])
+
+        payday = Payday(self)
+        payday.__dict__.update(d)
+        return payday

--- a/gratipay/testing/billing.py
+++ b/gratipay/testing/billing.py
@@ -19,10 +19,10 @@ class PaydayMixin(object):
     @mock.patch.object(Payday, 'fetch_card_holds')
     def run_payday(self, fch):
         fch.return_value = {}
-        Payday.start().run()
+        return self.app.payday_runner.run_payday()
 
     def start_payday(self):
-        Payday.start()
+        return self.app.payday_runner._start_payday()
 
 
 class BillingHarness(Harness, PaydayMixin):

--- a/gratipay/testing/harness.py
+++ b/gratipay/testing/harness.py
@@ -77,6 +77,7 @@ class Harness(unittest.TestCase):
     """
 
     client = ClientWithAuth(www_root=WWW_ROOT, project_root=PROJECT_ROOT)
+    app = client.app
     db = client.website.db
     platforms = client.website.platforms
     tablenames = db.all("SELECT tablename FROM pg_tables "

--- a/gratipay/website.py
+++ b/gratipay/website.py
@@ -22,11 +22,17 @@ class Website(BaseWebsite):
         self.app = app
 
         self.configure_renderers()
-        # TODO Can't do remaining config here because of wireup confustication.
 
+        # TODO Can't do remaining config here because of lingering wireup
+        # confustication up in Application.__init__.
 
-    def init_more(self, tell_sentry):
-        self.modify_algorithm(tell_sentry)
+    def init_more(self, env, db, tell_sentry):
+        self.env = env
+        self.db = db
+        self.tell_sentry = tell_sentry
+
+    def init_even_more(self):
+        self.modify_algorithm(self.tell_sentry)
         self.monkey_patch_response()
 
 

--- a/tests/py/test_close.py
+++ b/tests/py/test_close.py
@@ -5,13 +5,13 @@ from datetime import date
 import mock
 import pytest
 
-from gratipay.billing.payday import Payday
 from gratipay.models.community import Community
 from gratipay.models.participant import Participant
 from gratipay.testing import Harness, D,P
+from gratipay.testing.billing import PaydayMixin
 
 
-class TestClose(Harness):
+class TestClose(Harness, PaydayMixin):
 
     def test_close_closes(self):
         alice = self.make_participant('alice', claimed_time='now')
@@ -46,7 +46,7 @@ class TestClose(Harness):
         assert P('alice').is_closed
 
 
-class TestClosePage(Harness):
+class TestClosePage(Harness, PaydayMixin):
 
     def test_close_page_is_usually_available(self):
         self.make_participant('alice', claimed_time='now')
@@ -126,17 +126,17 @@ class TestClosePage(Harness):
 
     def test_close_page_is_not_available_during_payday(self):
         self.make_participant('alice', claimed_time='now')
-        Payday.start()
+        self.start_payday()
         self.check_under_payday('alice')
 
     def test_even_for_admin(self):
         self.make_participant('admin', claimed_time='now', is_admin=True)
         self.make_participant('alice', claimed_time='now')
-        Payday.start()
+        self.start_payday()
         self.check_under_payday('admin')
 
     def test_cant_post_to_close_page_during_payday(self):
-        Payday.start()
+        self.start_payday()
         self.make_participant('alice', claimed_time='now')
         body = self.client.POST('/~alice/settings/close', auth_as='alice').body
         assert 'Try Again Later' in body

--- a/tests/py/test_history.py
+++ b/tests/py/test_history.py
@@ -53,7 +53,7 @@ class TestHistory(BillingHarness):
 
     def test_iter_payday_events(self):
         now = datetime.now()
-        Payday().start().run()
+        self.run_payday()
         self.shift_all_paydays_by('-1 week')
 
         Enterprise = self.make_team(is_approved=True)
@@ -61,7 +61,7 @@ class TestHistory(BillingHarness):
         for i in range(2):
             with patch.object(Payday, 'fetch_card_holds') as fch:
                 fch.return_value = {}
-                Payday.start().run()
+                self.run_payday()
             self.shift_all_paydays_by('-1 week')
 
         obama = P('obama')
@@ -70,7 +70,7 @@ class TestHistory(BillingHarness):
         assert obama.balance == D('0.00')
         assert picard.balance == D('20.00')
 
-        Payday().start()  # to demonstrate that we ignore any open payday?
+        self.start_payday()  # to demonstrate that we ignore any open payday?
 
         # Make all events in the same year.
         if now.month < 2:

--- a/tests/py/test_paydays_json.py
+++ b/tests/py/test_paydays_json.py
@@ -2,14 +2,14 @@ from __future__ import unicode_literals
 
 import json
 
-from gratipay.billing.payday import Payday
 from gratipay.testing import Harness
+from gratipay.testing.billing import PaydayMixin
 
 
-class Tests(Harness):
+class Tests(Harness, PaydayMixin):
 
     def test_paydays_json_gives_paydays(self):
-        Payday.start()
+        self.start_payday()
         self.make_participant("alice")
 
         response = self.client.GET("/about/paydays.json")


### PR DESCRIPTION
Properly speaking, we should have zero global configuration. Everything should hang from a `Gratipay` object that we instantiate for gunicorn and in scripts. But for https://github.com/gratipay/gratipay.com/pull/4346#discussion_r102598587 we at least need to make the `application` object accessible from within `Payday`.