### PR TITLE
Further Application improvements

### DIFF
--- a/gratipay/__init__.py
+++ b/gratipay/__init__.py
@@ -1,39 +1,4 @@
+# -*- coding: utf-8 -*-
 """This is the Python library behind gratipay.com.
 """
-import locale
-from decimal import Decimal
-
-
-try:  # XXX This can't be right.
-    locale.setlocale(locale.LC_ALL, "en_US.utf8")           # Heroku
-except locale.Error:
-    import sys
-    if sys.platform == 'win32':
-        locale.setlocale(locale.LC_ALL, '')                 # Windows
-    else:
-        try:
-            locale.setlocale(locale.LC_ALL, "en_US.UTF-8")  # Mac OS
-        except locale.Error:
-            locale.setlocale(locale.LC_ALL, "C.UTF-8")      # Read the Docs
-
-
-class NotSane(Exception):
-    """This is used when a sanity check fails.
-
-    A sanity check is when it really seems like the logic shouldn't allow the
-    condition to arise, but you never know.
-
-    """
-
-db = None # This global is wired in wireup. It's an instance of
-          # gratipay.postgres.PostgresManager.
-
-
-MAX_TIP = MAX_PAYMENT = Decimal('1000.00')
-MIN_TIP = MIN_PAYMENT = Decimal('0.00')
-
-RESTRICTED_IDS = None
-
-
-def set_version_header(response, website):
-    response.headers['X-Gratipay-Version'] = website.version
+from __future__ import absolute_import, division, print_function, unicode_literals

--- a/gratipay/application.py
+++ b/gratipay/application.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from . import utils, wireup
+import psycopg2.extras
+
+from . import utils
 from .cron import Cron
+from .models import GratipayDB
 from .models.participant import Participant
 from .payday_runner import PaydayRunner
 from .version import get_version
@@ -14,6 +17,13 @@ class Application(object):
     """
 
     def __init__(self):
+
+        # Eventually we want to move all of the wireup functionality into
+        # objects as we've done with Website, GratipayDB, email.Queue, and
+        # PaydayRunner. For now, dodge a circular import.
+
+        from . import wireup
+
         utils.i18n.set_locale()
         website = Website(self)
 
@@ -25,7 +35,7 @@ class Application(object):
             website.version = 'x'
 
         env = self.env = wireup.env()
-        db = self.db = wireup.db(env)
+        db = self.db = GratipayDB(self, env.database_url, env.database_maxconn)
         tell_sentry = self.tell_sentry = wireup.make_sentry_teller(env)
 
         website.init_more(env, db, tell_sentry) # TODO Fold this into Website.__init__
@@ -55,3 +65,23 @@ class Application(object):
         cron(env.update_cta_every, lambda: utils.update_cta(website))
         cron(env.check_db_every, db.self_check, True)
         cron(env.dequeue_emails_every, Participant.dequeue_emails, True)
+
+
+    def add_event(self, c, type, payload):
+        """Log an event.
+
+        This is the function we use to capture interesting events that happen
+        across the system in one place, the ``events`` table.
+
+        :param c: a :py:class:`Postres` or :py:class:`Cursor` instance
+        :param unicode type: an indicator of what type of event it is--either ``participant``,
+          ``team`` or ``payday``
+        :param payload: an arbitrary JSON-serializable data structure; for ``participant`` type,
+          ``id`` must be the id of the participant in question
+
+        """
+        SQL = """
+            INSERT INTO events (type, payload)
+            VALUES (%s, %s)
+        """
+        c.run(SQL, (type, psycopg2.extras.Json(payload)))

--- a/gratipay/application.py
+++ b/gratipay/application.py
@@ -8,7 +8,6 @@ from .cron import Cron
 from .models import GratipayDB
 from .models.participant import Participant
 from .payday_runner import PaydayRunner
-from .version import get_version
 from .website import Website
 
 
@@ -27,13 +26,6 @@ class Application(object):
         utils.i18n.set_locale()
         website = Website(self)
 
-        exc = None
-        try:
-            website.version = get_version()
-        except Exception, e:
-            exc = e
-            website.version = 'x'
-
         env = self.env = wireup.env()
         db = self.db = GratipayDB(self, env.database_url, env.database_maxconn)
         tell_sentry = self.tell_sentry = wireup.make_sentry_teller(env)
@@ -50,9 +42,6 @@ class Application(object):
         wireup.load_i18n(website.project_root, tell_sentry)
         wireup.other_stuff(website, env)
         wireup.accounts_elsewhere(website, env)
-
-        if exc:
-            tell_sentry(exc, {})
 
         website.init_even_more()                # TODO Fold this into Website.__init__
         self.install_periodic_jobs(website, env, db)

--- a/gratipay/application.py
+++ b/gratipay/application.py
@@ -14,6 +14,7 @@ class Application(object):
     """
 
     def __init__(self):
+        utils.i18n.set_locale()
         website = Website(self)
 
         exc = None

--- a/gratipay/cli/queue_branch_email.py
+++ b/gratipay/cli/queue_branch_email.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 import random
 
-from gratipay import wireup
+from gratipay.application import Application
 
 
 def get_recently_active_participants(db):
@@ -24,7 +24,7 @@ def get_recently_active_participants(db):
     """)
 
 
-def main(_argv=sys.argv, _input=raw_input, _print=print):
+def main(_argv=sys.argv, _input=raw_input, _print=print, _app=None):
     """This is a script to enqueue global site notification emails.
 
     It should only be used for important transactional messages like a Terms of
@@ -42,7 +42,7 @@ def main(_argv=sys.argv, _input=raw_input, _print=print):
             - push to GitHub
 
     """
-    db = wireup.db(wireup.env())
+    app = _app or Application()
 
     def prompt(msg):
         answer = _input(msg + " [y/N]")
@@ -64,11 +64,11 @@ def main(_argv=sys.argv, _input=raw_input, _print=print):
         prompt("Are you REALLY ready?")
         prompt("... ?")
         _print("Okay, you asked for it!")
-        participants = get_recently_active_participants(db)
+        participants = get_recently_active_participants(app.db)
     else:
         _print("Okay, just {}.".format(username))
-        participants = db.all("SELECT p.*::participants FROM participants p "
-                              "WHERE p.username=%s", (username,))
+        participants = app.db.all("SELECT p.*::participants FROM participants p "
+                                  "WHERE p.username=%s", (username,))
 
     N = len(participants)
     _print(N)

--- a/gratipay/exceptions.py
+++ b/gratipay/exceptions.py
@@ -52,6 +52,15 @@ class ProblemChangingNumber(Exception):
         return self.msg
 
 
+class NotSane(Exception):
+    """This is used when a sanity check fails.
+
+    A sanity check is when it really seems like the logic shouldn't allow the
+    condition to arise, but you never know.
+
+    """
+
+
 class TooGreedy(Exception): pass
 class NoSelfTipping(Exception): pass
 class NoTippee(Exception): pass

--- a/gratipay/fake_data.py
+++ b/gratipay/fake_data.py
@@ -12,9 +12,8 @@ import sys
 from faker import Factory
 from psycopg2 import IntegrityError
 
-from gratipay import MAX_TIP, MIN_TIP
 from gratipay.elsewhere import PLATFORMS
-from gratipay.models.participant import Participant
+from gratipay.models.participant import Participant, MAX_TIP, MIN_TIP
 from gratipay.models.team import slugize, Team
 from gratipay.exceptions import InvalidTeamName
 

--- a/gratipay/models/exchange_route.py
+++ b/gratipay/models/exchange_route.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import braintree
 from postgres.orm import Model
-from gratipay.models import add_event
 
 
 class ExchangeRoute(Model):
@@ -73,7 +72,7 @@ class ExchangeRoute(Model):
                           , action='invalidate route'
                           , address=self.address
                            )
-            add_event(cursor, 'participant', payload)
+            self.app.add_event(cursor, 'participant', payload)
         self.set_attributes(is_deleted=True)
 
     def revive(self):
@@ -85,7 +84,7 @@ class ExchangeRoute(Model):
                           , action='revive route'
                           , address=self.address
                            )
-            add_event(cursor, 'participant', payload)
+            self.app.add_event(cursor, 'participant', payload)
         self.set_attributes(is_deleted=False)
 
     def update_error(self, new_error):

--- a/gratipay/models/participant/__init__.py
+++ b/gratipay/models/participant/__init__.py
@@ -13,8 +13,8 @@ from postgres.orm import Model
 from psycopg2 import IntegrityError
 
 import gratipay
-from gratipay import NotSane
 from gratipay.exceptions import (
+    NotSane,
     UsernameIsEmpty,
     UsernameTooLong,
     UsernameContainsInvalidCharacters,
@@ -40,6 +40,9 @@ from gratipay.utils.username import safely_reserve_a_username
 
 from .identity import Identity
 from .email import Email
+
+MAX_TIP = MAX_PAYMENT = Decimal('1000.00')
+MIN_TIP = MIN_PAYMENT = Decimal('0.00')
 
 ASCII_ALLOWED_IN_USERNAME = set("0123456789"
                                 "abcdefghijklmnopqrstuvwxyz"
@@ -593,7 +596,7 @@ class Participant(Model, Email, Identity):
         assert self.is_claimed  # sanity check
 
         amount = Decimal(amount)  # May raise InvalidOperation
-        if (amount < gratipay.MIN_PAYMENT) or (amount > gratipay.MAX_PAYMENT):
+        if (amount < MIN_PAYMENT) or (amount > MAX_PAYMENT):
             raise BadAmount
 
         # Insert payment instruction

--- a/gratipay/models/participant/identity.py
+++ b/gratipay/models/participant/identity.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from psycopg2 import IntegrityError
-from gratipay.models import add_event
 
 
 class ParticipantIdentityError(StandardError): pass
@@ -78,7 +77,7 @@ class Identity(object):
                           , identity_id=identity_id
                           , action=action + ' identity'
                            )
-            add_event(cursor, 'participant', payload)
+            self.app.add_event(cursor, 'participant', payload)
 
         params = dict( participant_id=self.id
                      , country_id=country_id
@@ -144,7 +143,7 @@ class Identity(object):
                           , action='retrieve identity'
                            )
 
-            add_event(cursor, 'participant', payload)
+            self.app.add_event(cursor, 'participant', payload)
 
         return info
 
@@ -224,7 +223,7 @@ class Identity(object):
                           , action=action + ' identity'
                            )
 
-            add_event(cursor, 'participant', payload)
+            self.app.add_event(cursor, 'participant', payload)
             self._update_has_verified_identity(cursor)
 
 
@@ -249,7 +248,7 @@ class Identity(object):
                           , country_id=country_id
                           , action='clear identity'
                            )
-            add_event(cursor, 'participant', payload)
+            self.app.add_event(cursor, 'participant', payload)
             self._update_has_verified_identity(cursor)
 
 

--- a/gratipay/models/team/closing.py
+++ b/gratipay/models/team/closing.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from gratipay.models import add_event
-
 
 class Closing(object):
     """This mixin implements team closing.
@@ -18,5 +16,8 @@ class Closing(object):
         """
         with self.db.get_cursor() as cursor:
             cursor.run("UPDATE teams SET is_closed=true WHERE id=%s", (self.id,))
-            add_event(cursor, 'team', dict(id=self.id, action='set', values=dict(is_closed=True)))
+            self.app.add_event( cursor
+                              , 'team'
+                              , dict(id=self.id, action='set', values=dict(is_closed=True))
+                               )
             self.set_attributes(is_closed=True)

--- a/gratipay/testing/harness.py
+++ b/gratipay/testing/harness.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from os.path import dirname, join, realpath
 from decimal import Decimal
 
-import gratipay
 from aspen import resources
 from aspen.utils import utcnow
 from aspen.testing.client import Client
@@ -18,7 +17,7 @@ from gratipay.elsewhere import UserInfo
 from gratipay.exceptions import NoSelfTipping, NoTippee, BadAmount
 from gratipay.models.account_elsewhere import AccountElsewhere
 from gratipay.models.exchange_route import ExchangeRoute
-from gratipay.models.participant import Participant
+from gratipay.models.participant import Participant, MAX_TIP, MIN_TIP
 from gratipay.security import user
 from gratipay.testing.vcr import use_cassette
 from psycopg2 import IntegrityError, InternalError
@@ -297,7 +296,7 @@ class Harness(unittest.TestCase):
             raise NoSelfTipping
 
         amount = Decimal(amount)  # May raise InvalidOperation
-        if (amount < gratipay.MIN_TIP) or (amount > gratipay.MAX_TIP):
+        if (amount < MIN_TIP) or (amount > MAX_TIP):
             raise BadAmount
 
         # Insert tip

--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -288,3 +288,7 @@ def get_featured_projects(popular, unpopular):
     featured_projects = random.sample(popular, p) + random.sample(unpopular, u)
     random.shuffle(featured_projects)
     return featured_projects
+
+
+def set_version_header(response, website):
+    response.headers['X-Gratipay-Version'] = website.version

--- a/gratipay/utils/i18n.py
+++ b/gratipay/utils/i18n.py
@@ -1,8 +1,9 @@
 # encoding: utf8
 from __future__ import print_function, unicode_literals
 
-from io import BytesIO
+import locale
 import re
+from io import BytesIO
 from unicodedata import combining, normalize
 
 from aspen.simplates.pagination import parse_specline, split_and_escape
@@ -242,3 +243,17 @@ def extract_spt(fileobj, *args, **kw):
         if extractor:
             for match in extractor(f, *args, **kw):
                 yield match
+
+
+def set_locale():
+    try:  # XXX This can't be right.
+        locale.setlocale(locale.LC_ALL, b"en_US.utf8")          # Heroku
+    except locale.Error:
+        import sys
+        if sys.platform == 'win32':
+            locale.setlocale(locale.LC_ALL, b'')                # Windows
+        else:
+            try:
+                locale.setlocale(locale.LC_ALL, b"en_US.UTF-8") # Mac OS
+            except locale.Error:
+                locale.setlocale(locale.LC_ALL, b"C.UTF-8")     # Read the Docs

--- a/gratipay/version.py
+++ b/gratipay/version.py
@@ -1,6 +1,7 @@
 from os.path import abspath, dirname, join
 
 def get_version():
+    # setup.py uses this
     root = dirname(dirname(abspath(__file__)))
     with open(join(root, 'www/version.txt')) as f:
         version = f.read().strip()

--- a/gratipay/website.py
+++ b/gratipay/website.py
@@ -6,10 +6,9 @@ import base64
 import aspen
 from aspen.website import Website as BaseWebsite
 
-import gratipay
 from . import utils, security
 from .security import authentication, csrf
-from .utils import erase_cookie, http_caching, i18n, set_cookie, timer
+from .utils import erase_cookie, http_caching, i18n, set_cookie, set_version_header, timer
 from .renderers import csv_dump, jinja2_htmlescaped, eval_, scss
 
 
@@ -96,7 +95,7 @@ class Website(BaseWebsite):
             tell_sentry,
             algorithm['get_response_for_exception'],
 
-            gratipay.set_version_header,
+            set_version_header,
             authentication.add_auth_to_response,
             csrf.add_token_to_response,
             http_caching.add_caching_to_response,

--- a/gratipay/website.py
+++ b/gratipay/website.py
@@ -6,7 +6,7 @@ import base64
 import aspen
 from aspen.website import Website as BaseWebsite
 
-from . import utils, security
+from . import utils, security, version
 from .security import authentication, csrf
 from .utils import erase_cookie, http_caching, i18n, set_cookie, set_version_header, timer
 from .renderers import csv_dump, jinja2_htmlescaped, eval_, scss
@@ -19,7 +19,7 @@ class Website(BaseWebsite):
     def __init__(self, app):
         BaseWebsite.__init__(self)
         self.app = app
-
+        self.version = version.get_version()
         self.configure_renderers()
 
         # TODO Can't do remaining config here because of lingering wireup

--- a/tests/py/test_take_over.py
+++ b/tests/py/test_take_over.py
@@ -6,7 +6,7 @@ import datetime
 import pytest
 from aspen.utils import utcnow
 
-from gratipay import NotSane
+from gratipay.exceptions import NotSane
 from gratipay.models.account_elsewhere import AccountElsewhere
 from gratipay.models.participant import (
     NeedConfirmation, Participant, TeamCantBeOnlyAuth, WontTakeOverWithIdentities

--- a/www/%team/set-status.json.spt
+++ b/www/%team/set-status.json.spt
@@ -1,6 +1,5 @@
 from aspen import Response
 
-from gratipay.models import add_event
 from gratipay.models.team import Team
 from gratipay.models.participant import Participant
 [---]
@@ -31,7 +30,7 @@ with website.db.get_cursor() as c:
             """, (is_approved, team.slug))
         status = {True: 'approved', False: 'rejected', None: 'unreviewed'}[is_approved]
 
-        add_event(c, 'team', dict(
+        website.app.add_event(c, 'team', dict(
             id=team.id,
             recorder=dict(id=user.participant.id, username=user.participant.username),
             action='set', values=dict(status=status)

--- a/www/~/%username/payout-status.spt
+++ b/www/~/%username/payout-status.spt
@@ -2,7 +2,6 @@ from __future__ import print_function, unicode_literals
 
 from aspen import Response
 from gratipay.utils import get_participant
-from gratipay.models import add_event
 
 workflow = ['too-little', 'pending-application', 'pending-review', 'rejected', 'pending-payout',
             'completed']
@@ -35,7 +34,7 @@ with website.db.get_cursor() as c:
      RETURNING status_of_1_0_payout
     """, (new_status, participant.id))
 
-    add_event(c, 'participant', dict(
+    website.app.add_event(c, 'participant', dict(
         id=participant.id,
         recorder=dict(id=user.participant.id, username=user.participant.username),
         action='set', values=dict(status_of_1_0_payout=new_status)

--- a/www/~/%username/toggle-is-suspicious.json.spt
+++ b/www/~/%username/toggle-is-suspicious.json.spt
@@ -1,5 +1,4 @@
 from aspen import Response
-from gratipay.models import add_event
 from gratipay.utils import get_participant
 [---]
 if not user.ADMIN:
@@ -31,7 +30,7 @@ with website.db.get_cursor() as c:
 
         """, (to == 'true', request.path['username'],))
 
-    add_event(c, 'participant', dict(
+    website.app.add_event(c, 'participant', dict(
         id=get_participant(state).id,
         recorder=dict(id=user.participant.id, username=user.participant.username),
         action='set', values=dict(is_suspicious=is_suspicious)


### PR DESCRIPTION
Picking up from #4345:

- Clear out `gratipay/__init__.py` as part of moving away from global config.
- Make `.app` available on models.
- Simplify `website.version`.