### PR TITLE
Add "Referrer-Policy" header

### DIFF
--- a/gratipay/security/__init__.py
+++ b/gratipay/security/__init__.py
@@ -41,6 +41,10 @@ def add_headers_to_response(response):
     if 'X-XSS-Protection' not in response.headers:
         response.headers['X-XSS-Protection'] = '1; mode=block'
 
+    # https://www.w3.org/TR/referrer-policy/
+    if 'Referrer-Policy' not in response.headers:
+        response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
     if 'content-security-policy-report-only' not in response.headers:
         response.headers['content-security-policy-report-only'] = (

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,6 @@
     {% block head_early %}{% endblock %}
     <title>{% if title %}{{ title }} - {% endif %}{% if banner %}{{ banner }} - {% endif %}Gratipay</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="referrer" content="no-referrer-when-downgrade">
     <link rel="stylesheet" href="{{ website.asset('gratipay.css') }}" type="text/css">
     <link rel="apple-touch-icon-precomposed" href="{{ website.asset('touch/icon-60x60.png') }}">
     <link rel="apple-touch-icon-precomposed" href="{{ website.asset('touch/icon-76x76.png') }}" sizes="76x76">

--- a/tests/py/test_security.py
+++ b/tests/py/test_security.py
@@ -53,6 +53,10 @@ class TestSecurity(Harness):
         headers = self.client.GET('/about/').headers
         assert headers['X-XSS-Protection'] == '1; mode=block'
 
+    def test_ahtr_sets_referrer_policy(self):
+        headers = self.client.GET('/about/').headers
+        assert headers['Referrer-Policy'] == 'strict-origin-when-cross-origin'
+
     def test_ahtr_sets_content_security_policy(self):
         headers = self.client.GET('/about/').headers
         policy = (


### PR DESCRIPTION
Set the `Referrer-Policy` to `strict-origin-when-cross-origin`. This
should boost our grade on
https://securityheaders.io/?q=gratipay.com&hide=on&followRedirects=on.