### PR TITLE
Fix regression in deployment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -49,7 +49,7 @@ version="$((prev + 1))"
 
 # Check that the environment contains all required variables
 heroku config -s -a gratipay | ./env/bin/honcho run -e /dev/stdin \
-    ./env/bin/python gratipay/wireup.py
+    ./env/bin/python -m gratipay.wireup
 
 
 # Sync the translations

--- a/gratipay/wireup.py
+++ b/gratipay/wireup.py
@@ -476,5 +476,6 @@ def env():
     return env
 
 
-if __name__ == '__main__':
+def __main__():
+    # deploy.sh uses this to validate production env config
     env()


### PR DESCRIPTION
Closes #4364. Python's [`-m`](https://docs.python.org/2/using/cmdline.html#cmdoption-m) does not perform the `sys.path` manipulations that got us in trouble.