### PR TITLE
Present claimed packages as projects

### DIFF
--- a/gratipay/exceptions.py
+++ b/gratipay/exceptions.py
@@ -88,7 +88,3 @@ class NegativeBalance(Exception):
 
 class NotWhitelisted(Exception): pass
 class NoPackages(Exception): pass
-
-class OutOfOptions(Exception):
-    """Raised when an attempt to auto-name a team fails.
-    """

--- a/gratipay/exceptions.py
+++ b/gratipay/exceptions.py
@@ -88,4 +88,7 @@ class NegativeBalance(Exception):
 
 class NotWhitelisted(Exception): pass
 class NoPackages(Exception): pass
-class OutOfOptions(Exception): pass
+
+class OutOfOptions(Exception):
+    """Raised when an attempt to auto-name a team fails.
+    """

--- a/gratipay/exceptions.py
+++ b/gratipay/exceptions.py
@@ -88,3 +88,4 @@ class NegativeBalance(Exception):
 
 class NotWhitelisted(Exception): pass
 class NoPackages(Exception): pass
+class OutOfOptions(Exception): pass

--- a/gratipay/models/package/__init__.py
+++ b/gratipay/models/package/__init__.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import uuid
 
 from gratipay.models.team import Team
-from gratipay.exceptions import OutOfOptions
 from postgres.orm import Model
 
 
@@ -80,7 +79,7 @@ class Package(Model):
             yield self.name
             for i in range(1, 10):
                 yield '{}-{}'.format(self.name, i)
-            yield str(uuid.uuid4()).lower()
+            yield uuid.uuid4().hex
 
         for slug in slug_options():
             if cursor.one('SELECT count(*) FROM teams WHERE slug=%s', (slug,)) > 0:
@@ -96,8 +95,6 @@ class Package(Model):
             cursor.run('INSERT INTO teams_to_packages (team_id, package_id) '
                        'VALUES (%s, %s)', (team.id, self.id))
             break
-        else:
-            raise OutOfOptions()
 
 
     def _load_team(self, cursor):

--- a/gratipay/typecasting.py
+++ b/gratipay/typecasting.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Fork of aspen.typecasting to clean some stuff up. Upstream it, ya?
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from dependency_injection import resolve_dependencies
+
+
+def cast(website, request, state):
+    """Implement typecasting (differently from stock Aspen).
+
+    When matching paths, Aspen looks for ``/%foo/`` and then foo is a variable
+    with the value in the URL path, so ``/bar/`` would end up with
+    ``foo='bar'``.
+
+    There's a dictionary at ``website.typecasters`` that maps variable names to
+    functions, dependency-injectable as with ``website.algorithm``
+    (state-chain) functions. If an entry exists in ``typecasters`` for a given
+    path variable, then the value of ``path[part]`` is replaced with the result
+    of calling the function.
+
+    Before calling your cast function, we add an additional value to the state
+    dict at ``path_part``: the URL path part that matched, as a string. That is
+    user input, so handle it carefully. It's your job to raise
+    ``Response(40x)`` if it's bad input.
+
+    """
+    typecasters = website.typecasters
+    path = request.line.uri.path
+
+    for part in path.keys():
+        if part not in typecasters:
+            continue
+        state['path_part'] = path[part]
+        path.popall(part)
+        func = typecasters[part]
+        path[part] = func(*resolve_dependencies(func, state).as_args)

--- a/gratipay/utils/__init__.py
+++ b/gratipay/utils/__init__.py
@@ -34,6 +34,15 @@ def dict_to_querystring(mapping):
 
 
 def _munge(website, request, url_prefix, fs_prefix):
+    """Given website and requests objects along with URL and filesystem
+    prefixes, redirect or modify the request. The idea here is that sometimes
+    for various reasons the dispatcher can't handle a mapping, so this is a
+    hack to rewrite the URL to help the dispatcher map to the filesystem.
+
+    If you access the filesystem version directly through the web, we redirect
+    you to the URL version. If you access the URL version as desired, then we
+    rewrite so we can find it on the filesystem.
+    """
     if request.path.raw.startswith(fs_prefix):
         to = url_prefix + request.path.raw[len(fs_prefix):]
         if request.qs.raw:
@@ -110,35 +119,6 @@ def get_participant(state, restrict=True, resolve_unclaimed=True):
                 raise Response(403, _("You are not authorized to access this page."))
 
     return participant
-
-
-def get_team(state):
-    """Given a Request, raise Response or return Team.
-    """
-    redirect = state['website'].redirect
-    request = state['request']
-    user = state['user']
-    slug = request.line.uri.path['team']
-    qs = request.line.uri.querystring
-
-    from gratipay.models.team import Team  # avoid circular import
-    team = Team.from_slug(slug)
-
-    if team is None:
-        # Try to redirect to a Participant.
-        from gratipay.models.participant import Participant # avoid circular import
-        participant = Participant.from_username(slug)
-        if participant is not None:
-            qs = '?' + request.qs.raw if request.qs.raw else ''
-            redirect('/~' + request.path.raw[1:] + qs)
-        raise Response(404)
-
-    canonicalize(redirect, request.line.uri.path.raw, '/', team.slug, slug, qs)
-
-    if team.is_closed and not user.ADMIN:
-        raise Response(410)
-
-    return team
 
 
 def encode_for_querystring(s):

--- a/gratipay/website.py
+++ b/gratipay/website.py
@@ -6,10 +6,11 @@ import base64
 import aspen
 from aspen.website import Website as BaseWebsite
 
-from . import utils, security, version
+from . import utils, security, typecasting, version
 from .security import authentication, csrf
 from .utils import erase_cookie, http_caching, i18n, set_cookie, set_version_header, timer
 from .renderers import csv_dump, jinja2_htmlescaped, eval_, scss
+from .models import team
 
 
 class Website(BaseWebsite):
@@ -20,6 +21,7 @@ class Website(BaseWebsite):
         BaseWebsite.__init__(self)
         self.app = app
         self.version = version.get_version()
+        self.configure_typecasters()
         self.configure_renderers()
 
         # TODO Can't do remaining config here because of lingering wireup
@@ -33,6 +35,10 @@ class Website(BaseWebsite):
     def init_even_more(self):
         self.modify_algorithm(self.tell_sentry)
         self.monkey_patch_response()
+
+
+    def configure_typecasters(self):
+        self.typecasters['team'] = team.cast
 
 
     def configure_renderers(self):
@@ -87,7 +93,7 @@ class Website(BaseWebsite):
             http_caching.get_etag_for_file if self.cache_static else noop,
             http_caching.try_to_serve_304 if self.cache_static else noop,
 
-            algorithm['apply_typecasters_to_path'],
+            typecasting.cast,
             algorithm['get_resource_for_request'],
             algorithm['extract_accept_from_request'],
             algorithm['get_response_for_resource'],

--- a/tests/py/test_packages.py
+++ b/tests/py/test_packages.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import mock
+from gratipay.exceptions import OutOfOptions
 from gratipay.models.package import NPM, Package
 from gratipay.testing import Harness
 from psycopg2 import IntegrityError
@@ -20,6 +22,14 @@ class TestPackage(Harness):
 
 class Linking(Harness):
 
+    def link(self):
+        alice = self.make_participant('alice')
+        foo = self.make_package()
+        with self.db.get_cursor() as c:
+            foo.ensure_team(c, alice)
+            team = foo._load_team(c)
+        return alice, foo, team
+
     def test_package_team_is_none(self):
         foo = self.make_package()
         assert foo.team is None
@@ -29,25 +39,19 @@ class Linking(Harness):
         assert foo.package is None
 
     def test_can_link_to_a_new_team(self):
-        alice = self.make_participant('alice')
-        foo = self.make_package()
-        with self.db.get_cursor() as c:
-            foo.ensure_team(c, alice)
-            team = foo._load_team(c)
+        _, foo, team = self.link()
         assert team.package == foo
         assert foo.team == team
-        return alice, foo, team
 
     def test_linking_is_idempotent(self):
-        alice, package, _team = self.test_can_link_to_a_new_team()
+        alice, package, team = self.link()
         for i in range(5):
             with self.db.get_cursor() as c:
                 package.ensure_team(c, alice)
-                team = package._load_team(c)
-            assert team == _team
+                assert package._load_team(c) == team
 
     def test_team_can_only_be_linked_from_one_package(self):
-        alice, package, team = self.test_can_link_to_a_new_team()
+        _ , _, team = self.link()
         bar = self.make_package(name='bar')
         raises( IntegrityError
               , self.db.run
@@ -56,10 +60,28 @@ class Linking(Harness):
                )
 
     def test_package_can_only_be_linked_from_one_team(self):
-        alice, package, team = self.test_can_link_to_a_new_team()
+        _, package, _ = self.link()
         bar = self.make_team(name='Bar')
         raises( IntegrityError
               , self.db.run
               , 'INSERT INTO teams_to_packages (team_id, package_id) VALUES (%s, %s)'
               , (bar.id, package.id)
                )
+
+    def test_linked_team_takes_package_name(self):
+        _, _, team = self.link()
+        assert team.slug == 'foo'
+
+    def test_linking_team_tries_other_names(self):
+        self.make_team(name='foo')
+        _, _, team = self.link()
+        assert team.slug == 'foo-1'
+
+    @mock.patch('gratipay.models.package.uuid')
+    def test_linking_team_gives_up_on_names_eventually(self, uuid):
+        self.make_team(name='foo')                  # take `foo`
+        for i in range(1, 10):
+            self.make_team(name='foo-{}'.format(i)) # take `foo-{1-9}`
+        self.make_team(name='deadbeef')             # take `deadbeef`(!)
+        uuid.uuid4.return_value = 'deadbeef'        # force-try `deadbeef`
+        raises(OutOfOptions, self.link)

--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -51,7 +51,7 @@ class TestPages(Harness):
                            .replace('/%user_name/', '/gratipay/') \
                            .replace('/%to', '/1') \
                            .replace('/%country', '/TT') \
-                           .replace('/%exchange_id.int', '/%s' % exchange_id) \
+                           .replace('/%exchange_id', '/%s' % exchange_id) \
                            .replace('/%redirect_to', '/giving') \
                            .replace('/%endpoint', '/public') \
                            .replace('/about/me/%sub', '/about/me')

--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -72,7 +72,9 @@ class TestPages(Harness):
                     raise
             assert r.code != 404
             assert r.code < 500
-            assert not overescaping_re.search(r.body.decode('utf8'))
+            type_in = lambda *x: any([r.headers['Content-Type'].startswith(y) for y in x])
+            if r.code == 200 and type_in('text', 'application/json'):
+                assert not overescaping_re.search(r.body.decode('utf8'))
 
     def test_anon_can_browse(self):
         self.browse()

--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -42,8 +42,8 @@ class TestPages(Harness):
         i = len(self.client.www_root)
         urls = []
         for spt in find_files(self.client.www_root, '*.spt'):
-            url = spt[i:-4].replace('/%team/', '/alice/') \
-                           .replace('/alice/%sub', '/alice/foo') \
+            url = spt[i:-4].replace('/%team/', '/Gratipay/') \
+                           .replace('/Gratipay/%sub', '/alice/foo') \
                            .replace('/~/%username/', '/~alice/') \
                            .replace('/for/%slug/', '/for/wonderland/') \
                            .replace('/%platform/', '/github/') \

--- a/tests/py/test_teams.py
+++ b/tests/py/test_teams.py
@@ -510,3 +510,17 @@ class TestTeams(Harness):
 
     def test_slugize_disallows_backslashes(self):
         self.assertRaises(InvalidTeamName, slugize, 'abc\def')
+
+
+class Cast(Harness):
+
+    def test_casts_team(self):
+        team = self.make_team()
+        state = self.client.GET('/TheEnterprise/', return_after='cast', want='state')
+        assert state['request'].path['team'] == team
+
+    def test_canonicalizes(self):
+        self.make_team()
+        response = self.client.GxT('/theenterprise/', return_after='cast')
+        assert response.code == 302
+        assert response.headers['Location'] == '/TheEnterprise/'

--- a/tests/py/test_utils.py
+++ b/tests/py/test_utils.py
@@ -14,29 +14,6 @@ from gratipay.utils.username import safely_reserve_a_username, FailedToReserveUs
 from psycopg2 import IntegrityError
 
 
-class TestGetTeam(Harness):
-
-    def test_gets_team(self):
-        team = self.make_team()
-        state = self.client.GET( '/TheEnterprise/'
-                               , return_after='dispatch_request_to_filesystem'
-                               , want='state'
-                                )
-        assert utils.get_team(state) == team
-
-    def test_canonicalizes(self):
-        self.make_team()
-        state = self.client.GET( '/theenterprise/'
-                               , return_after='dispatch_request_to_filesystem'
-                               , want='state'
-                                )
-
-        with self.assertRaises(Response) as cm:
-            utils.get_team(state)
-        assert cm.exception.code == 302
-        assert cm.exception.headers['Location'] == '/TheEnterprise/'
-
-
 class TestGetParticipant(Harness):
 
     def test_gets_participant(self):

--- a/tests/py/test_www_npm_package.py
+++ b/tests/py/test_www_npm_package.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from gratipay.models.package import NPM
+from gratipay.models.package import NPM, Package
 from gratipay.testing import Harness
 
 
-class TestClaimingWorkflow(Harness):
+class Tests(Harness):
 
     def setUp(self):
         self.make_package()
@@ -35,3 +35,24 @@ class TestClaimingWorkflow(Harness):
         self.make_participant('bob', claimed_time='now')
         body = self.client.GET('/on/npm/bar/', auth_as='bob').body
         assert "didn&#39;t find any email addresses" in body
+
+
+    def claim_package(self):
+        foo = Package.from_names('npm', 'foo')
+        alice = self.make_participant('alice', claimed_time='now')
+        alice.start_email_verification('alice@example.com', foo)
+        nonce = alice.get_email('alice@example.com').nonce
+        alice.finish_email_verification('alice@example.com', nonce)
+        team = alice.get_teams()[0]
+        assert team.package == foo
+        return team.slug
+
+    def test_package_redirects_to_project_if_claimed(self):
+        self.claim_package()
+        response = self.client.GxT('/on/npm/foo/')
+        assert response.code == 302
+        assert response.headers['Location'] == '/foo/'
+
+    def test_package_served_as_project_if_claimed(self):
+        self.claim_package()
+        assert 'owned by' in self.client.GET('/foo/').body

--- a/tests/py/test_www_team_receiving.py
+++ b/tests/py/test_www_team_receiving.py
@@ -5,10 +5,10 @@ from gratipay.testing import Harness
 
 class Tests(Harness):
 
-    def test_receiving_returns_404_for_unapproved_teams(self):
+    def test_receiving_returns_302_for_unapproved_teams(self):
         self.make_team(is_approved=False)
 
-        assert self.client.GxT('/TheEnterprise/receiving/').code == 404
+        assert self.client.GxT('/TheEnterprise/receiving/').code == 302
 
     def test_receiving_is_not_visible_to_anon(self):
         self.make_team(is_approved=True)

--- a/www/%team/charts.json.spt
+++ b/www/%team/charts.json.spt
@@ -19,7 +19,7 @@ callback_pattern = re.compile(r'^[_A-Za-z0-9.]+$')
 
 [---]
 
-slug = request.path['team']
+team = request.path['team']
 
 # Fetch data from the database.
 # =============================
@@ -45,7 +45,7 @@ payments = website.db.all("""\
       AND direction='to-team'
  ORDER BY timestamp DESC
 
-""", (slug,), back_as=dict)
+""", (team.slug,), back_as=dict)
 
 
 if not payments:

--- a/www/%team/distributing/%to.json.spt
+++ b/www/%team/distributing/%to.json.spt
@@ -4,14 +4,13 @@ from decimal import InvalidOperation
 
 from aspen import Response
 from babel.numbers import NumberFormatError
-from gratipay.utils import get_team
 from gratipay.models.participant import Participant
 from gratipay.models.team.takes import ZERO, PENNY
 
 [--------------------]
 request.allow('POST')
 
-team = get_team(state)
+team = request.path['team']
 if team.available == 0:
     website.redirect('..', base_url='')
 

--- a/www/%team/distributing/index.html.spt
+++ b/www/%team/distributing/index.html.spt
@@ -1,8 +1,7 @@
 # encoding: utf8
-from gratipay.utils import get_team
 
 [-----------------------------------------------------------------------------]
-team = get_team(state)
+team = request.path['team']
 if team.available == 0:
     website.redirect('..', base_url='')
 title = _("Team Members")

--- a/www/%team/distributing/index.json.spt
+++ b/www/%team/distributing/index.json.spt
@@ -1,10 +1,8 @@
 """Endpoint to list team members.
 """
-from gratipay.utils import get_team
-
 [--------------------]
 request.allow('GET')
-team = get_team(state)
+team = request.path['team']
 if team.available == 0:
     website.redirect('..', base_url='')
 

--- a/www/%team/edit/close.spt
+++ b/www/%team/edit/close.spt
@@ -1,5 +1,4 @@
 from aspen import Response
-from gratipay.utils import get_team
 
 [----------------------------------------------------------------------------]
 
@@ -8,7 +7,7 @@ if user.ANON:
 
 request.allow('POST')
 
-team = get_team(state)
+team = request.path['team']
 
 if not user.ADMIN and user.participant.username != team.owner:
     raise Response(403, _("You are not authorized to access this page."))

--- a/www/%team/edit/edit.json.spt
+++ b/www/%team/edit/edit.json.spt
@@ -1,6 +1,5 @@
 from aspen import Response
 
-from gratipay.utils import get_team
 from gratipay.utils.images import (
     imgize,
     ImageTooLarge,
@@ -25,7 +24,7 @@ field_names = {
 if user.ANON:
     raise Response(401, _("You need to log in to access this page."))
 
-team = get_team(state)
+team = request.path['team']
 
 if not user.ADMIN and user.participant.username != team.owner:
     raise Response(403, _("You are not authorized to access this page."))

--- a/www/%team/edit/index.html.spt
+++ b/www/%team/edit/index.html.spt
@@ -1,14 +1,12 @@
 from aspen import Response
 
-from gratipay.utils import get_team
-
 [---]
 request.allow('GET')
 
 if user.ANON:
     raise Response(401, _("You need to log in to access this page."))
 
-team = get_team(state)
+team = request.path['team']
 
 if not user.ADMIN and user.participant.username != team.owner:
     raise Response(403, _("You are not authorized to access this page."))

--- a/www/%team/history/index.html.spt
+++ b/www/%team/history/index.html.spt
@@ -2,12 +2,11 @@ from datetime import datetime
 
 from aspen import Response
 
-from gratipay.utils import get_team
 from gratipay.utils.team_history import get_end_of_year_totals, iter_team_payday_events
 
 [-----------------------------------------------------------------------------]
 
-team = get_team(state)
+team = request.path['team']
 
 if user.ANON:
     raise Response(401)

--- a/www/%team/image.spt
+++ b/www/%team/image.spt
@@ -1,5 +1,4 @@
 import mimetypes
-from gratipay.utils import get_team
 from aspen import Response
 from os.path import join
 
@@ -7,7 +6,7 @@ load = lambda s: open(join(website.www_root, 'assets', 'team-default-{}.png'.for
 defaults = {size: load(size) for size in ('large', 'small')}
 defaults['original'] = defaults['large']
 [----]
-team = get_team(state)
+team = request.path['team']
 
 size = request.qs.get('size', 'large')
 if size not in team.IMAGE_SIZES:

--- a/www/%team/index.html.spt
+++ b/www/%team/index.html.spt
@@ -3,11 +3,11 @@
 from collections import OrderedDict
 
 from aspen import Response
-from gratipay.utils import get_team, markdown, truncate
+from gratipay.utils import markdown, truncate
 
 [-----------------------------------------------------------------------------]
 
-team = get_team(state)
+team = request.path['team']
 banner = name = team.name
 suppress_sidebar = not(team.is_approved or user.ADMIN)
 is_team_owner = not user.ANON and team.owner == user.participant.username

--- a/www/%team/payment-instruction.json.spt
+++ b/www/%team/payment-instruction.json.spt
@@ -5,7 +5,6 @@ from decimal import InvalidOperation
 from aspen import Response
 from babel.numbers import NumberFormatError
 from gratipay.exceptions import BadAmount
-from gratipay.utils import get_team
 
 [-----------------------------------------------------------------------------]
 
@@ -18,7 +17,7 @@ else:
     # Get team.
     # =========
 
-    team = get_team(state)
+    team = request.path['team']
     if team.is_closed or not team.is_approved:
         raise Response(400, "unapproved team")
 

--- a/www/%team/public.json.spt
+++ b/www/%team/public.json.spt
@@ -3,13 +3,12 @@
 import re
 
 from aspen import json, Response
-from gratipay.utils import get_team
 
 callback_pattern = re.compile(r'^[_A-Za-z0-9.]+$')
 
 [-----------------------------------------------------------------------------]
 
-team = get_team(state)
+team = request.path['team']
 
 # CORS - see https://github.com/gratipay/aspen-python/issues/138
 response.headers["Access-Control-Allow-Origin"] = "*"

--- a/www/%team/receiving/index.html.spt
+++ b/www/%team/receiving/index.html.spt
@@ -1,9 +1,8 @@
 from aspen import Response
-from gratipay.utils import get_team
 
 [-----------------------------------------------------------------------------]
 
-team = get_team(state)
+team = request.path['team']
 if team.is_approved in (None, False):
     raise Response(404)
 elif user.ANON:

--- a/www/%team/receiving/index.html.spt
+++ b/www/%team/receiving/index.html.spt
@@ -4,7 +4,7 @@ from aspen import Response
 
 team = request.path['team']
 if team.is_approved in (None, False):
-    raise Response(404)
+    raise website.redirect('..')
 elif user.ANON:
     raise Response(401)
 elif not (user.ADMIN or user.participant.username == team.owner):

--- a/www/%team/set-status.json.spt
+++ b/www/%team/set-status.json.spt
@@ -10,7 +10,7 @@ status = request.body.get('status')
 if not status in ('approved', 'rejected', 'unreviewed'):
     raise Response(400)
 
-team = Team.from_slug(request.path['team'])
+team = request.path['team']
 
 if not team:
     raise Response(404)

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -1,17 +1,22 @@
 import requests
 
 from aspen import Response
-from gratipay.utils import markdown
+from gratipay.utils import markdown, truncate
 from gratipay.models.package import Package
+
 [---]
+
 package_name = request.path['package']
 package = Package.from_names('npm', package_name)
 if package is None:
     raise Response(404)
-banner = package_name
+elif package.team:
+    website.redirect(package.team.url_path)
+
 page_id = "package"
 suppress_sidebar = True
 url = 'https://npmjs.com/package/' + package.name
+banner = package_name
 [---]
 {% extends "templates/base.html" %}
 
@@ -22,7 +27,7 @@ url = 'https://npmjs.com/package/' + package.name
         <p>{{ package.description }}</p>
         <img class="platform" src="{{ website.asset('npm-n.png') }}" />
     </div>
-    {{ super () }}
+    {{ super() }}
 </a>
 {% endblock %}
 

--- a/www/~/%username/receipts/%exchange_id.html.spt
+++ b/www/~/%username/receipts/%exchange_id.html.spt
@@ -9,13 +9,18 @@ from gratipay.billing.instruments import CreditCard
 
 participant = get_participant(state, restrict=True)
 
+try:
+    exchange_id = int(request.path['exchange_id'])
+except ValueError:
+    raise Response(400)
+
 exchange = website.db.one("""
     SELECT *
       FROM exchanges
      WHERE id = %s
        AND participant = %s
        AND amount > 0
-""", (request.path['exchange_id'], participant.username))
+""", (exchange_id, participant.username))
 if exchange is None:
     raise Response(404)
 


### PR DESCRIPTION
Part of #4305, follows on #4397.

#### Todo

- [x] redirect `/on/npm/bar/` to `/deadbeef/` when claimed
- [x] fix regression in project receiving charts: https://github.com/gratipay/gratipay.com/pull/4398#issuecomment-293363521 —done in 582af24b08d05a9691e7ff78f28f874c07a13fed