### PR TITLE
Clean up UX some more

### DIFF
--- a/401.spt
+++ b/401.spt
@@ -4,7 +4,8 @@ banner = "401"
 [---] text/html via jinja2
 {% extends "templates/base.html" %}
 {% block content %}
-Please {% include "templates/sign-in-using.html" %} to continue.
+<p>{{ _('Please sign in to continue.') }}</p>
+<p>{{ sign_in_using() }}</p>
 {% endblock %}
 [---] application/json via stdlib_percent
 { "error_code": 401

--- a/410.spt
+++ b/410.spt
@@ -8,7 +8,8 @@ title = _('Closed') if 'username' in request.path else '410'
     <p>{{ _("The account owner has closed this account.") }}</p>
     {% if user.ANON %}
     <h2>{{ _("Are you the account owner?") }}</h2>
-    <p>{% include "templates/sign-in-using.html" %} {{ _("to reopen your account.") }}</p>
+    <p>{{ _("You may reopen your account by signing in.") }}</p>
+    <p>{{ sign_in_using() }}</p>
     {% endif %}
 {% else %}
     <p>{{ status_strings[410] }}</p>

--- a/gratipay/testing/harness.py
+++ b/gratipay/testing/harness.py
@@ -388,3 +388,12 @@ class Harness(unittest.TestCase):
              LIMIT 1
 
         """, (tipper, tippee), back_as=dict, default=default)['amount']
+
+
+    def add_and_verify_email(self, participant, *emails):
+        """Given a participant and some email addresses, add and verify them.
+        """
+        for email in emails:
+            participant.start_email_verification(email)
+            nonce = participant.get_email(email).nonce
+            participant.finish_email_verification(email, nonce)

--- a/gratipay/utils/icons.py
+++ b/gratipay/utils/icons.py
@@ -1,5 +1,11 @@
-STATUS_ICONS = { "approved": "&#xe008;"
-               , "unreviewed": "&#xe009;"
-               , "rejected": "&#xe010;"
-               , "featured": "&#xe9d9;"
+STATUS_ICONS = { "success": "&#xe008;"
+               , "warning": "&#xe009;"
+               , "failure": "&#xe010;"
+               , "feature": "&#xe9d9;"
                 }
+
+REVIEW_MAP = { 'approved': 'success'
+             , 'unreviewed': 'warning'
+             , 'rejected': 'failure'
+             , 'featured': 'feature'
+              }

--- a/js/gratipay/packages.js
+++ b/js/gratipay/packages.js
@@ -1,7 +1,7 @@
 Gratipay.packages = {};
 
 Gratipay.packages.init = function() {
-    Gratipay.Select('.package-emails');
+    Gratipay.Select('.gratipay-select');
     $('button.apply').on('click', Gratipay.packages.post);
 };
 

--- a/js/gratipay/packages.js
+++ b/js/gratipay/packages.js
@@ -1,7 +1,7 @@
 Gratipay.packages = {};
 
 Gratipay.packages.init = function() {
-    Gratipay.Dropdown('.package-emails');
+    Gratipay.Select('.package-emails');
     $('button.apply').on('click', Gratipay.packages.post);
 };
 

--- a/js/gratipay/select.js
+++ b/js/gratipay/select.js
@@ -11,7 +11,7 @@ Gratipay.Select = function(selector) {
     var cursorOffset = 0;   // negative or positive int
 
     function unhover() {
-        $(this).removeClass('hover');
+        $(this).closest('li').removeClass('hover');
     }
 
     function hover() {
@@ -22,7 +22,7 @@ Gratipay.Select = function(selector) {
 
         var $label = $(this);
         unhover.call($('.hover'), $ul);
-        $label.addClass('hover');
+        $label.closest('li').addClass('hover');
         if ($ul.hasClass('open'))
             cursorOffset = $labels.index($label) - Math.round(topFactor);
     }
@@ -37,7 +37,7 @@ Gratipay.Select = function(selector) {
 
             // Don't call the hover function, because we don't want to
             // change cursorOffset. Just apply the class.
-            $labels.eq(hoverIndex).addClass('hover');
+            $labels.eq(hoverIndex).closest('li').addClass('hover');
         }
         topFactor = t;
     }

--- a/js/gratipay/select.js
+++ b/js/gratipay/select.js
@@ -1,5 +1,5 @@
 Gratipay.Select = function(selector) {
-    var $ul = $(selector);
+    var $ul = $('ul', selector);
     var $labels = $('label', $ul);
 
     // state for vertical position
@@ -9,8 +9,6 @@ Gratipay.Select = function(selector) {
     // state for hovering
     var hoverIndex = 0;     // int between 0 and $labels.length-1
     var cursorOffset = 0;   // negative or positive int
-
-    $('<div>').addClass('gratipay-select-wrapper').insertAfter($ul).append($ul.remove());
 
     function unhover() {
         $(this).removeClass('hover');

--- a/js/gratipay/select.js
+++ b/js/gratipay/select.js
@@ -1,4 +1,4 @@
-Gratipay.Dropdown = function(selector) {
+Gratipay.Select = function(selector) {
     var $ul = $(selector);
     var $labels = $('label', $ul);
 
@@ -10,7 +10,7 @@ Gratipay.Dropdown = function(selector) {
     var hoverIndex = 0;     // int between 0 and $labels.length-1
     var cursorOffset = 0;   // negative or positive int
 
-    $('<div>').addClass('gratipay-dropdown-wrapper').insertAfter($ul).append($ul.remove());
+    $('<div>').addClass('gratipay-select-wrapper').insertAfter($ul).append($ul.remove());
 
     function unhover() {
         $(this).removeClass('hover');

--- a/js/gratipay/select.js
+++ b/js/gratipay/select.js
@@ -52,7 +52,7 @@ Gratipay.Select = function(selector) {
     function close($label) {
         if ($label) {
             $('.selected', $ul).removeClass('selected')
-            $label.closest('li').addClass('selected');
+            $label.closest('li').addClass('selected').removeClass('hover');
         }
         $ul.css({'top': 0}).removeClass('open');
         $ul.unbind('mousewheel');

--- a/js/gratipay/select.js
+++ b/js/gratipay/select.js
@@ -51,6 +51,7 @@ Gratipay.Select = function(selector) {
 
     function close($label) {
         if ($label) {
+            if ($label.closest('li').hasClass('disabled')) return;
             $('.selected', $ul).removeClass('selected')
             $label.closest('li').addClass('selected').removeClass('hover');
         }
@@ -70,7 +71,7 @@ Gratipay.Select = function(selector) {
         close();
     }
 
-    $('label', $ul).click(select).hover(hover, unhover);
+    $('li label', $ul).click(select).hover(hover, unhover);
     $('html').click(clear);
 
 

--- a/scss/components/dropdown.scss
+++ b/scss/components/dropdown.scss
@@ -29,7 +29,7 @@ button.dropdown-toggle{
   width: 0;
   height: 0;
   vertical-align: top;
-  border-top: 4px solid #000000;
+  border-top: 4px solid $black;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
   content: "";

--- a/scss/components/listing.scss
+++ b/scss/components/listing.scss
@@ -96,6 +96,6 @@ table.listing {
         }
     }
 }
-.with-sidebar table.listing td.item .details {
+.with-sidebar table.listing td.item .listing-details {
     max-width: 384px;
 }

--- a/scss/components/nav.scss
+++ b/scss/components/nav.scss
@@ -123,10 +123,6 @@
             padding: 16px 16px 12px;
             font-weight: normal;
 
-            .icon {
-                font: normal 20px/20px 'icomoon';
-            }
-
             color: $black;
             border-bottom: 4px solid transparent;
             &:hover {

--- a/scss/components/select.scss
+++ b/scss/components/select.scss
@@ -89,11 +89,14 @@
                     white-space: nowrap;
                 }
             }
-            &.hover label {
+            &.hover:not(.disabled) label {
                 cursor: pointer;
             }
+            &.disabled label {
+                color: $medium-gray ! important;
+            }
         }
-        &.open .hover label {
+        &.open .hover:not(.disabled) label {
             color: $green ! important;
         }
     }

--- a/scss/components/select.scss
+++ b/scss/components/select.scss
@@ -25,17 +25,27 @@
         .arrow {
             display: block;
             position: absolute;
-            bottom: 16px;
+            z-index: 0;
             right: 16px;
-
             width: 0;
             height: 0;
-            border-top: 8px solid $light-gray;
-            border-right: 8px solid transparent;
-            border-left: 8px solid transparent;
+            border-right: 6px solid transparent;
+            border-left: 6px solid transparent;
             content: "";
+
+            &.up {
+                bottom: 22px;
+                border-top: 8px solid $light-gray;
+            }
+            &.down {
+                top: 22px;
+                border-bottom: 8px solid $light-gray;
+            }
         }
-        li.hover .arrow { border-top-color: $green; }
+        li.hover .arrow {
+            &.up { border-top-color: $green; }
+            &.down { border-bottom-color: $green; }
+        }
 
 
         /* Everything else. */
@@ -71,6 +81,7 @@
                     overflow: hidden;
                     text-overflow: ellipsis;
                     padding: 12px 24px 0 56px;
+                    z-index: 1;
                 }
                 .listing-details {
                     display: block;

--- a/scss/components/select.scss
+++ b/scss/components/select.scss
@@ -1,4 +1,4 @@
-.gratipay-dropdown-wrapper {
+.gratipay-select-wrapper {
 
     position: relative;
     height: 64px;
@@ -21,7 +21,7 @@
     }
 }
 
-.gratipay-dropdown {
+.gratipay-select {
 
     /* Everything else. */
 

--- a/scss/components/select.scss
+++ b/scss/components/select.scss
@@ -1,4 +1,4 @@
-.gratipay-select-wrapper {
+.gratipay-select {
 
     position: relative;
     height: 64px;
@@ -18,53 +18,51 @@
                 display: block;
             }
         }
-    }
-}
 
-.gratipay-select {
 
-    /* Everything else. */
+        /* Everything else. */
 
-    width: 66%;
-    background: white;
-    position: absolute;
-    left: 17%;
+        width: 66%;
+        background: white;
+        position: absolute;
+        left: 17%;
 
-    border-radius: 5px;
-    box-shadow: 2px 2px 8px $black;
+        border-radius: 5px;
+        box-shadow: 2px 2px 8px $black;
 
-    li {
-        margin: 0;
-        list-style: none;
-        position: relative;
-        text-align: left;
-        height: 64px;
-
-        input {
-            display: none;
-        }
-        .listing-wrapper {
+        li {
+            margin: 0;
+            list-style: none;
+            position: relative;
+            text-align: left;
             height: 64px;
-            label {
-                white-space: nowrap;
-                display: block;
-                height: 64px;
-                position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                padding: 12px 24px 0 56px;
-                &.hover {
-                    color: $green ! important;
-                    cursor: pointer;
-                }
+
+            input {
+                display: none;
             }
-            .listing-details {
-                display: block;
-                padding: 36px 24px 0 56px;
-                white-space: nowrap;
+            .listing-wrapper {
+                height: 64px;
+                label {
+                    white-space: nowrap;
+                    display: block;
+                    height: 64px;
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    padding: 12px 24px 0 56px;
+                    &.hover {
+                        color: $green ! important;
+                        cursor: pointer;
+                    }
+                }
+                .listing-details {
+                    display: block;
+                    padding: 36px 24px 0 56px;
+                    white-space: nowrap;
+                }
             }
         }
     }

--- a/scss/components/select.scss
+++ b/scss/components/select.scss
@@ -17,7 +17,25 @@
             li {
                 display: block;
             }
+            .arrow {
+                display: none;
+            }
         }
+
+        .arrow {
+            display: block;
+            position: absolute;
+            bottom: 16px;
+            right: 16px;
+
+            width: 0;
+            height: 0;
+            border-top: 8px solid $light-gray;
+            border-right: 8px solid transparent;
+            border-left: 8px solid transparent;
+            content: "";
+        }
+        li.hover .arrow { border-top-color: $green; }
 
 
         /* Everything else. */
@@ -53,10 +71,6 @@
                     overflow: hidden;
                     text-overflow: ellipsis;
                     padding: 12px 24px 0 56px;
-                    &.hover {
-                        color: $green ! important;
-                        cursor: pointer;
-                    }
                 }
                 .listing-details {
                     display: block;
@@ -64,6 +78,12 @@
                     white-space: nowrap;
                 }
             }
+            &.hover label {
+                cursor: pointer;
+            }
+        }
+        &.open .hover label {
+            color: $green ! important;
         }
     }
 }

--- a/scss/components/select.scss
+++ b/scss/components/select.scss
@@ -26,11 +26,11 @@
             display: block;
             position: absolute;
             z-index: 0;
-            right: 16px;
+            right: 5px;
             width: 0;
             height: 0;
-            border-right: 6px solid transparent;
-            border-left: 6px solid transparent;
+            border-right: 5px solid transparent;
+            border-left: 5px solid transparent;
             content: "";
 
             &.up {

--- a/scss/components/sign_in.scss
+++ b/scss/components/sign_in.scss
@@ -86,10 +86,10 @@
             line-height: 16px;
 
             .caret {
-                border-top: 5px solid $black;
+                border-top: 8px solid $black;
                 border-right: 5px solid transparent;
                 border-left: 5px solid transparent;
-                margin-top: 6px;
+                margin-top: 4px;
             }
         }
         .dropdown-menu {

--- a/scss/components/status-icon.scss
+++ b/scss/components/status-icon.scss
@@ -2,8 +2,8 @@
     display: inline-block;
     width: 14px;
     font: normal 14px/14px icomoon;
-    &.approved { color: $green; }
-    &.unreviewed { color: $gold; }
-    &.rejected { color: $red; }
-    &.featured { color: $blue; }
+    &.success { color: $green; }
+    &.warning { color: $gold; }
+    &.failure { color: $red; }
+    &.feature { color: $blue; }
 }

--- a/scss/components/text-treatments.scss
+++ b/scss/components/text-treatments.scss
@@ -1,3 +1,7 @@
+.icon {
+    font: normal 20px/20px 'icomoon';
+}
+
 #content {
     .important-thing-at-the-top {
         margin: 20px 0 60px;

--- a/scss/components/text-treatments.scss
+++ b/scss/components/text-treatments.scss
@@ -25,6 +25,7 @@
         font: bold 20px/24px $Ideal;
     }
     .listing-details {
+        color: $medium-gray;
         font: normal 12px/15px $Ideal;
         a {
             font-weight: normal;

--- a/scss/elements/buttons-knobs.scss
+++ b/scss/elements/buttons-knobs.scss
@@ -46,11 +46,6 @@ button.selected:hover:not(:disabled), button.selected.drag,
 .button.selected:hover:not(:disabled), .button.selected.drag {
     background: $darker-green;
 }
-button.large {
-    font: normal 16px/32px $Ideal;
-    padding: 10px 16px;
-    border-radius: 5px;
-}
 
 .buttons button {
     margin-top: 3px;

--- a/scss/elements/buttons-knobs.scss
+++ b/scss/elements/buttons-knobs.scss
@@ -27,24 +27,23 @@ button,
     display: inline;
 
     &:disabled {
-        opacity: .5;
+        background: $medium-gray;
 
         &:hover {
-            background: $gray;
             cursor: default;
         }
     }
 }
-button:hover,
-.button:hover {
+button:hover:not(:disabled),
+.button:hover:not(:disabled) {
     background: $darker-gray;
 }
-button.selected,
-.button.selected {
+button.selected:not(:disabled),
+.button.selected:not(:disabled) {
     background: $green;
 }
-button.selected:hover, button.selected.drag,
-.button.selected:hover, .button.selected.drag {
+button.selected:hover:not(:disabled), button.selected.drag,
+.button.selected:hover:not(:disabled), .button.selected.drag {
     background: $darker-green;
 }
 button.large {

--- a/scss/layouts/layout.scss
+++ b/scss/layouts/layout.scss
@@ -37,9 +37,6 @@
             float: left;
             a#sign-out {
                 padding-right: 8px; // tweak to make icon placement look right
-                .icon {
-                    font: normal 20px/20px 'icomoon';
-                }
             }
         }
     }

--- a/scss/pages/package.scss
+++ b/scss/pages/package.scss
@@ -23,6 +23,9 @@
         font-size: 24px;
         line-height: 24px;
     }
+    .disabled .icon {
+        color: $medium-gray;
+    }
 
     .status-icon {
         font-size: 12px;

--- a/scss/pages/package.scss
+++ b/scss/pages/package.scss
@@ -1,17 +1,6 @@
 #package #content {
     text-align: center;
 
-    .selected {
-        .icon { display: block; }
-    }
-    .icon {
-        display: none;
-        position: absolute;
-        top: 12px;
-        left: 16px;
-        font-size: 24px;
-        line-height: 24px;
-    }
     .instructions {
         text-align: center;
         margin: 0 0 30px;
@@ -24,6 +13,17 @@
         }
         padding: 0 17%;
     }
+
+    .selected .icon { display: block; }
+    .icon {
+        display: none;
+        position: absolute;
+        top: 12px;
+        left: 16px;
+        font-size: 24px;
+        line-height: 24px;
+    }
+
     .button-wrapper {
         margin: 38px auto 30px;
     }

--- a/scss/pages/package.scss
+++ b/scss/pages/package.scss
@@ -24,6 +24,12 @@
         line-height: 24px;
     }
 
+    .status-icon {
+        font-size: 12px;
+        line-height: 12px;
+        margin: 0;
+    }
+
     .button-wrapper {
         margin: 38px auto 30px;
     }

--- a/scss/pages/package.scss
+++ b/scss/pages/package.scss
@@ -29,6 +29,9 @@
         line-height: 12px;
         margin: 0;
     }
+    ul:not(.open) .status-icon {
+        color: $medium-gray;
+    }
 
     .button-wrapper {
         margin: 38px auto 30px;

--- a/scss/pages/package.scss
+++ b/scss/pages/package.scss
@@ -27,6 +27,7 @@
     .status-icon {
         font-size: 12px;
         line-height: 12px;
+        width: auto;
         margin: 0;
     }
     ul:not(.open) .status-icon {

--- a/scss/pages/package.scss
+++ b/scss/pages/package.scss
@@ -1,6 +1,17 @@
 #package #content {
     text-align: center;
 
+    .selected {
+        .icon { display: block; }
+    }
+    .icon {
+        display: none;
+        position: absolute;
+        top: 12px;
+        left: 16px;
+        font-size: 24px;
+        line-height: 24px;
+    }
     .instructions {
         text-align: center;
         margin: 0 0 30px;

--- a/scss/pages/package.scss
+++ b/scss/pages/package.scss
@@ -39,5 +39,26 @@
 
     .button-wrapper {
         margin: 38px auto 30px;
+
+        button.large {
+            font: normal 16px/32px $Ideal;
+            padding: 10px 16px;
+            border-radius: 5px;
+
+            .caret {
+                border-top: 8px solid #fff;
+                border-right: 5px solid transparent;
+                border-left: 5px solid transparent;
+                margin-top: 13px;
+            }
+        }
+        .dropdown-menu {
+            top: 50px;
+            width: 90%;
+            left: 5%;
+            border-radius: 0 0 3px 3px;
+        }
     }
+
+
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,3 +1,4 @@
+{% from "templates/sign-in-using.html" import sign_in_using with context %}
 <!DOCTYPE html>
 <html lang="{{ locale.language }}">
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
@@ -41,7 +42,7 @@
             {% set current_page = request.path.raw.split('/')[1] %}
             {% include "templates/nav.html" %}
             {% if user.ANON %}
-                {% include "templates/sign-in-using.html" %}
+                {{ sign_in_using() }}
             {% else %}
             <ul class="nav you-are">
                 <li>

--- a/templates/project-listing.html
+++ b/templates/project-listing.html
@@ -12,8 +12,8 @@
                 <span class="i">{{ i }}</span>
                 <span class="status">&middot;
                     <a href="{{ project.review_url }}"><span
-                        class="status-icon {{ project.status }}"
-                        >{{ icons.STATUS_ICONS[project.status]|safe }}</span
+                        class="status-icon {{ icons.REVIEW_MAP[project.status] }}"
+                        >{{ icons.STATUS_ICONS[icons.REVIEW_MAP[project.status]]|safe }}</span
                         >{{ i18ned_statuses[project.status] }}</a>
                 </span>
                 {% if project.status == 'approved' %}

--- a/templates/sign-in-using.html
+++ b/templates/sign-in-using.html
@@ -1,9 +1,9 @@
 {% from 'templates/auth.html' import auth_button with context %}
 
-{% macro sign_in_using() %}
+{% macro sign_in_using(button_class='') %}
 <div class="sign-in">
   <div class="dropdown">
-    <button class="dropdown-toggle" data-toggle="dropdown">
+    <button class="dropdown-toggle {{ button_class }}" data-toggle="dropdown">
         {{ _('Sign in / Sign up') }} <b class="caret"></b>
     </button>
     <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">

--- a/templates/sign-in-using.html
+++ b/templates/sign-in-using.html
@@ -1,8 +1,11 @@
 {% from 'templates/auth.html' import auth_button with context %}
 
+{% macro sign_in_using() %}
 <div class="sign-in">
   <div class="dropdown">
-    <button class="dropdown-toggle" data-toggle="dropdown">{{ _('Sign in / Sign up') }} <b class="caret"></b></button>
+    <button class="dropdown-toggle" data-toggle="dropdown">
+        {{ _('Sign in / Sign up') }} <b class="caret"></b>
+    </button>
     <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
     {% for platform in website.signin_platforms %}
       <li class="{{ platform.name }}">
@@ -14,3 +17,4 @@
     </ul>
   </div>
 </div>
+{% endmacro %}

--- a/templates/your-payment.html
+++ b/templates/your-payment.html
@@ -1,6 +1,7 @@
+{% from "templates/sign-in-using.html" import sign_in_using with context %}
 {% if user.ANON %}
     <div class="sign-in-to">
-        {% include "templates/sign-in-using.html" %}
+        {{ sign_in_using() }}
         {{ _("{sign_in}{br}to give to{br}{team}").format(sign_in="", team=team.name, br='<br>'|safe) }}
     </div>
 {% else %}

--- a/tests/py/test_routes.py
+++ b/tests/py/test_routes.py
@@ -41,10 +41,6 @@ class TestRoutes(BillingHarness):
         assert self.roman.get_credit_card_error() is None
 
 
-    def add_and_verify_email(self, participant, email_address):
-        participant.start_email_verification(email_address)
-        self.db.run("UPDATE emails SET verified=true WHERE address=%s", (email_address,))
-
     def test_associate_and_delete_valid_paypal(self):
         self.add_and_verify_email(self.roman, 'roman@gmail.com')
 

--- a/tests/ttw/test_package_claiming.py
+++ b/tests/ttw/test_package_claiming.py
@@ -28,3 +28,18 @@ class TestSendConfirmationLink(BrowserHarness):
     def test_can_send_to_second_email(self):
         self.make_package(emails=['alice@example.com', 'bob@example.com'])
         assert self.check(choice=1) == 'bob@example.com'
+
+    def test_disabled_items_are_disabled(self):
+        self.make_package(emails=['alice@example.com', 'bob@example.com'])
+        alice = self.make_participant('alice', claimed_time='now')
+        self.add_and_verify_email(alice, 'alice@example.com', 'bob@example.com')
+
+        self.make_participant('bob', claimed_time='now')
+        self.sign_in('bob')
+        self.visit('/on/npm/foo/')
+        self.css('label')[0].click()            # activate select
+        self.css('label')[1].click()            # click second item
+        self.css('li')[0].has_class('selected') # first item is still selected
+        self.css('ul')[0].has_class('open')     # still open
+        self.css('button').has_class('disabled')
+        assert self.db.all('select * from claims') == []

--- a/www/%team/index.html.spt
+++ b/www/%team/index.html.spt
@@ -31,11 +31,11 @@ is_team_owner = not user.ANON and team.owner == user.participant.username
 
     <a href="{{ team.review_url }}">
         {% if team.status == 'approved' %}
-        <span class="status-icon approved">&#xe008;</span> {{ _("Approved") }}
+        <span class="status-icon success">&#xe008;</span> {{ _("Approved") }}
         {% elif team.status == 'unreviewed' %}
-        <span class="status-icon unreviewed">&#xe009;</span> {{ _("Unreviewed") }}
+        <span class="status-icon warning">&#xe009;</span> {{ _("Unreviewed") }}
         {% elif team.status == 'rejected' %}
-        <span class="status-icon rejected">&#xe010;</span> {{ _("Rejected") }}
+        <span class="status-icon failure">&#xe010;</span> {{ _("Rejected") }}
         {% endif %}
     </a> |
 

--- a/www/assets/gratipay.css.spt
+++ b/www/assets/gratipay.css.spt
@@ -23,7 +23,6 @@
 
 @import "scss/elements/reset";
 @import "scss/elements/buttons-knobs";
-@import "scss/elements/dropdown";
 @import "scss/elements/elements";
 
 @import "scss/components/banner";
@@ -45,6 +44,7 @@
 @import "scss/components/nav";
 @import "scss/components/payments-by";
 @import "scss/components/profile-statement";
+@import "scss/components/select";
 @import "scss/components/sidebar";
 @import "scss/components/sign_in";
 @import "scss/components/status-icon";

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -49,8 +49,9 @@ nteams = 0
 for key, tab in tabs.items():
     n = tab['n'] = len(tab['teams'])
     nteams += n
-    tab['name'] = '<span class="status-icon {}">{}</span> {}'.format( key
-                                                                    , icons.STATUS_ICONS[key]
+    status = icons.REVIEW_MAP[key]
+    tab['name'] = '<span class="status-icon {}">{}</span> {}'.format( status
+                                                                    , icons.STATUS_ICONS[status]
                                                                     , i18ned_statuses[key]
                                                                      )
 

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -62,30 +62,32 @@ banner = package_name
     <p class="note">{{ _("No email addresses on file.") }}</p>
     {% else %}
     <input type="hidden" name="package_id" value="{{ package.id }}">
-    <ul class="package-emails gratipay-select">
-    {% set classified = package.classify_emails_for_participant(user.participant) %}
-    {% for i, (email, group) in enumerate(classified, start=1) %}
-        <li{% if i == 1 %} class="selected"{% endif %}>
-            <input type="radio" name="email" value="{{ email }}" id="email-{{i}}"
-                   {% if i == 1 %}checked{% endif %}>
-            <div class="listing-wrapper">
-                <label class="listing-name" for="email-{{ i }}">{{ email }}</label>
-                <div class="listing-details">
-                    <span class="i">{{ i }}</span>
-                    {% if group == PRIMARY %}
-                    <span>&middot; {{ _('Your primary email address') }}</span>
-                    {% elif group == VERIFIED %}
-                    <span>&middot; {{ _('Already linked to your account') }}</span>
-                    {% elif group in (UNVERIFIED, UNLINKED) %}
-                    <span>&middot; {{ _('Ready to link') }}</span>
-                    {% elif group == OTHER %}
-                    <span>&middot; {{ _('Already linked to another account') }}</span>
-                    {% endif %}
+    <div class="gratipay-select">
+        <ul>
+        {% set classified = package.classify_emails_for_participant(user.participant) %}
+        {% for i, (email, group) in enumerate(classified, start=1) %}
+            <li{% if i == 1 %} class="selected"{% endif %}>
+                <input type="radio" name="email" value="{{ email }}" id="email-{{i}}"
+                       {% if i == 1 %}checked{% endif %}>
+                <div class="listing-wrapper">
+                    <label class="listing-name" for="email-{{ i }}">{{ email }}</label>
+                    <div class="listing-details">
+                        <span class="i">{{ i }}</span>
+                        {% if group == PRIMARY %}
+                        <span>&middot; {{ _('Your primary email address') }}</span>
+                        {% elif group == VERIFIED %}
+                        <span>&middot; {{ _('Already linked to your account') }}</span>
+                        {% elif group in (UNVERIFIED, UNLINKED) %}
+                        <span>&middot; {{ _('Ready to link') }}</span>
+                        {% elif group == OTHER %}
+                        <span>&middot; {{ _('Already linked to another account') }}</span>
+                        {% endif %}
+                    </div>
                 </div>
-            </div>
-        </li>
-    {% endfor %}
-    </ul>
+            </li>
+        {% endfor %}
+        </ul>
+    </div>
 
     <div class="button-wrapper">
         <button type="submit" class="apply selected large">

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -75,24 +75,25 @@ banner = package_name
                     <div class="listing-details">
                         <span class="i">{{ i }}</span>
                         <span>&middot;
-                        {% if group == PRIMARY %}
-                            {{ _('Ready to use') }}
-                            &middot;
-                            <span class="status-icon feature">
-                                {{ icons.STATUS_ICONS['feature']|safe }}</span>
-                            {{ _('Your primary email address') }}
-                        {% elif group == VERIFIED %}
-                            {{ _('Ready to use') }}
-                            &middot;
-                            <span class="status-icon success">
-                                {{ icons.STATUS_ICONS['success']|safe }}</span>
-                            {{ _('Linked to your account') }}
-                        {% elif group in (UNVERIFIED, UNLINKED) %}
-                            {{ _('Ready to use') }}
-                        {% elif group == OTHER %}
+                        {% if group == OTHER %}
                             <span class="status-icon failure">
                                 {{ icons.STATUS_ICONS['failure']|safe }}</span>
                             {{ _('Linked to a different account') }}
+                        {% else %}
+                            {{ _('Ready to use') }}
+                            {% if group == PRIMARY %}
+                                &middot; <span class="status-icon feature">
+                                    {{ icons.STATUS_ICONS['feature']|safe }}</span>
+                                {{ _('Your primary email address') }}
+                            {% elif group == VERIFIED %}
+                                &middot; <span class="status-icon success">
+                                    {{ icons.STATUS_ICONS['success']|safe }}</span>
+                                {{ _('Linked to your account') }}
+                            {% elif group == UNVERIFIED %}
+                                &middot; <span class="status-icon warning">
+                                    {{ icons.STATUS_ICONS['warning']|safe }}</span>
+                                {{ _('Half-linked to your account') }}
+                            {% endif %}
                         {% endif %}
                     </div>
                 </div>

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -69,6 +69,7 @@ banner = package_name
             <li{% if i == 1 %} class="selected"{% endif %}>
                 <input type="radio" name="email" value="{{ email }}" id="email-{{i}}"
                        {% if i == 1 %}checked{% endif %}>
+                <span class="icon">&#xe007;</span>
                 <div class="listing-wrapper">
                     <label class="listing-name" for="email-{{ i }}">{{ email }}</label>
                     <div class="listing-details">

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -59,7 +59,7 @@ if user.participant:
 
 {% if user.ANON %}
     <div class="button-wrapper">
-        {% include "templates/sign-in-using.html" %}
+        {{ sign_in_using() }}
     </div>
 {% else %}
     {% if len(emails) == 0 %}

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -97,7 +97,8 @@ banner = package_name
                         {% endif %}
                     </div>
                 </div>
-                <span class="arrow"></span>
+                <span class="arrow up"></span>
+                <span class="arrow down"></span>
             </li>
         {% endfor %}
         </ul>

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -85,6 +85,7 @@ banner = package_name
                         {% endif %}
                     </div>
                 </div>
+                <span class="arrow"></span>
             </li>
         {% endfor %}
         </ul>

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -59,7 +59,7 @@ if user.participant:
 
 {% if user.ANON %}
     <div class="button-wrapper">
-        {{ sign_in_using() }}
+        {{ sign_in_using(button_class='large') }}
     </div>
 {% else %}
     {% if len(emails) == 0 %}

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -1,7 +1,7 @@
 import requests
 
 from aspen import Response
-from gratipay.utils import markdown, truncate
+from gratipay.utils import icons, markdown, truncate
 from gratipay.models.package import Package
 from gratipay.models.package.emails import PRIMARY, VERIFIED, UNVERIFIED, UNLINKED, OTHER
 
@@ -74,14 +74,25 @@ banner = package_name
                     <label class="listing-name" for="email-{{ i }}">{{ email }}</label>
                     <div class="listing-details">
                         <span class="i">{{ i }}</span>
+                        <span>&middot;
                         {% if group == PRIMARY %}
-                        <span>&middot; {{ _('Your primary email address') }}</span>
+                            {{ _('Ready to use') }}
+                            &middot;
+                            <span class="status-icon feature">
+                                {{ icons.STATUS_ICONS['feature']|safe }}</span>
+                            {{ _('Your primary email address') }}
                         {% elif group == VERIFIED %}
-                        <span>&middot; {{ _('Already linked to your account') }}</span>
+                            {{ _('Ready to use') }}
+                            &middot;
+                            <span class="status-icon success">
+                                {{ icons.STATUS_ICONS['success']|safe }}</span>
+                            {{ _('Linked to your account') }}
                         {% elif group in (UNVERIFIED, UNLINKED) %}
-                        <span>&middot; {{ _('Ready to link') }}</span>
+                            {{ _('Ready to use') }}
                         {% elif group == OTHER %}
-                        <span>&middot; {{ _('Already linked to another account') }}</span>
+                            <span class="status-icon failure">
+                                {{ icons.STATUS_ICONS['failure']|safe }}</span>
+                            {{ _('Linked to a different account') }}
                         {% endif %}
                     </div>
                 </div>

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -62,7 +62,7 @@ banner = package_name
     <p class="note">{{ _("No email addresses on file.") }}</p>
     {% else %}
     <input type="hidden" name="package_id" value="{{ package.id }}">
-    <ul class="package-emails gratipay-dropdown">
+    <ul class="package-emails gratipay-select">
     {% set classified = package.classify_emails_for_participant(user.participant) %}
     {% for i, (email, group) in enumerate(classified, start=1) %}
         <li{% if i == 1 %} class="selected"{% endif %}>

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -17,6 +17,10 @@ elif package.team:
 page_id = "package"
 suppress_sidebar = True
 banner = package_name
+
+if user.participant:
+    emails = package.classify_emails_for_participant(user.participant)
+    has_email_options = bool([x for x in emails if x[1] != OTHER])
 [---]
 {% extends "templates/base.html" %}
 
@@ -58,15 +62,15 @@ banner = package_name
         {% include "templates/sign-in-using.html" %}
     </div>
 {% else %}
-    {% if len(package.emails) == 0 %}
+    {% if len(emails) == 0 %}
     <p class="note">{{ _("No email addresses on file.") }}</p>
     {% else %}
     <input type="hidden" name="package_id" value="{{ package.id }}">
     <div class="gratipay-select">
         <ul>
-        {% set classified = package.classify_emails_for_participant(user.participant) %}
-        {% for i, (email, group) in enumerate(classified, start=1) %}
-            <li{% if i == 1 %} class="selected"{% endif %}>
+        {% for i, (email, group) in enumerate(emails, start=1) %}
+            <li class="{% if group == OTHER %}disabled{% endif %}
+                       {% if i == 1 %}selected{% endif %}">
                 <input type="radio" name="email" value="{{ email }}" id="email-{{i}}"
                        {% if i == 1 %}checked{% endif %}>
                 <span class="icon">&#xe007;</span>
@@ -105,7 +109,8 @@ banner = package_name
     </div>
 
     <div class="button-wrapper">
-        <button type="submit" class="apply selected large">
+        <button type="submit" class="apply selected large"
+                {% if not has_email_options %} disabled{% endif %}>
             {{ _('Apply to accept payments') }}
         </button>
     </div>

--- a/www/~/%username/emails/verify.html.spt
+++ b/www/~/%username/emails/verify.html.spt
@@ -35,7 +35,7 @@ suppress_sidebar = True
 
         <p>{{ _("Sign in to finish connecting your email.") }}</p>
 
-        <p>{% include "templates/sign-in-using.html" %}</p>
+        <p>{{ sign_in_using() }}</p>
     {% elif user.participant != participant %}
         <h1>{{ _("Wrong Account") }}</h1>
 

--- a/www/~/%username/routes/credit-card.spt
+++ b/www/~/%username/routes/credit-card.spt
@@ -22,25 +22,16 @@ else:
 {% extends "templates/profile-routes.html" %}
 
 {% block scripts %}
-
-{% if not user.ANON %}
 <script>
     $(document).ready(function() {
         Gratipay.routes.cc.init();
         $('#country').chosen();
     });
 </script>
-{% endif %}
-
 {{ super() }}
 {% endblock %}
 
 {% block content %}
-  {% if user.ANON %}
-    {% include "templates/sign-in-using.html" %}
-    {{ _("and then you'll be able to add or change your credit card.") }}
-  {% else %}
-
     <div id="feedback">{% if last_bill_result %}
     <h2><span>{{ _("Failure") }}</span></h2>
     <div class="details"><p>{{ last_bill_result }}</p></div>
@@ -115,5 +106,4 @@ else:
             <img src="https://s3.amazonaws.com/braintree-badges/braintree-badge-dark.png" width="164px" height ="44px" border="0"/>
         </a>
     </div>
-    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Part of #4305, follows on #4410.

- [x] ~~asterisk-out email addresses, ya?~~—let's wait for demand, these are all public in the npm registry
- [x] still getting a fouc on claim form?
- [x] add a nice mail icon for current selection in dropdown
- [x] add a nice dropdown arrow icon
    - [x] highlight that instead of name on hover when closed
- [x] implement status icons
    - [x] primary &rarr; feature
    - [x] verified &rarr; success
    - [x] unverified &rarr; [none]
    - [x] unlinked &rarr; warning
    - [x] other &rarr; failure
- [x] implement `disabled` (for emails linked to other accounts)
    - [x] disable Apply button when there are no "Ready to link" emails
- [x] if only one email, treat differently?
    - [x] no ~~radio~~ dropdown?
    - [x] no i?
- [x] double-check .details (grep it)
- [x] make the Sign In button bigger, too
- [x] cross-browserize
- [x] ~~seeing an off-by-one in hover state while scrolling?~~ &hellip; bumped to https://github.com/gratipay/gratipay.com/issues/4415