### PR TITLE
Fix width bug

### DIFF
--- a/scss/components/select.scss
+++ b/scss/components/select.scss
@@ -87,6 +87,9 @@
                     display: block;
                     padding: 36px 24px 0 56px;
                     white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    width: 100%;
                 }
             }
             &.hover:not(.disabled) label {


### PR DESCRIPTION
Part of #4305, follows on #4428.

Turns this:

![screen shot 2017-04-26 at 8 34 15 pm](https://cloud.githubusercontent.com/assets/134455/25462844/cca7462c-2abf-11e7-9f05-bc457544d8e7.png)

Into this:

![asvjil91b5](https://cloud.githubusercontent.com/assets/134455/25543584/234ef77a-2c25-11e7-9b9e-e3ad2b346333.gif)

Still falls apart on a watch. ☺️