### PR TITLE
Fix export CSV bug (#4399)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,24 +8,45 @@ Welcome! This is the documentation for programmers working on `gratipay.com`_
 .. _web API: https://github.com/gratipay/gratipay.com#api
 
 
+.. _db-schema:
+
 DB Schema
 ---------
 
-is_suspipicous on participant can be None, True or False. It represents unknown,
-blacklisted or whitelisted user.
+Users
+^^^^^
+
+``is_suspicious`` on a participant can be ``None`` (unknown), ``True``
+(blacklisted) or ``False`` (whitelisted)
 
     * whitelisted can transfer money out of gratipay
     * unknown can move money within gratipay
     * blacklisted cannot do anything
 
+Money
+^^^^^
 
-The exchanges table records movements of money into and out of Gratipay. The
-``amount`` column shows a positive amount for payins and a negative amount for
-payouts. The ``fee`` column is always positive. For both payins and payouts,
+- ``transfers``
+
+Used under Gratipay 1.0, when users were allowed to tip each other (without
+having to setup a team). ``transfers`` models money moving **within** Gratipay,
+from one participant (``tipper``) to another (``tippee``).
+
+- ``payments``
+
+The replacement for ``transfers``, used in Gratipay 2.0. ``payments`` are
+between a Team and a Participant, in either direction (``to-team``, or
+``to-participant``)
+
+- ``exchanges``
+
+Records money moving into and out of Gratipay. Every ``exchange`` is linked to a
+participant. The ``amount`` column shows a positive amount for money flowing
+into gratipay (payins), and a negative amount for money flowing out of Gratipay
+(payouts). The ``fee`` column is always positive. For both payins and payouts,
 the ``amount`` does not include the ``fee`` (e.g., a $10 payin would result in
 an ``amount`` of ``9.41`` and a ``fee`` of ``0.59``, and a $100 payout with a
 2% fee would result in an ``amount`` of ``-98.04`` and a fee of ``1.96``).
-
 
 Contents
 --------

--- a/gratipay/utils/history.py
+++ b/gratipay/utils/history.py
@@ -200,6 +200,8 @@ def export_history(participant, year, key, back_as='namedtuple', require_key=Fal
            AND extract(year from timestamp) = %(year)s
       GROUP BY tippee
     """, params, back_as=back_as)
+
+    # FIXME: Include values from the `payments` table
     out['taken'] = lambda: db.all("""
         SELECT tipper AS team, sum(amount) AS amount
           FROM transfers

--- a/gratipay/utils/history.py
+++ b/gratipay/utils/history.py
@@ -1,3 +1,9 @@
+"""Helpers to fetch logs of payments made to/from a participant.
+
+Data is fetched from 3 tables: `transfers`, `payments` and `exchanges`. For
+details on what these tables represent, see :ref:`db-schema`.
+"""
+
 from datetime import datetime
 from decimal import Decimal
 
@@ -23,6 +29,8 @@ def get_end_of_year_balance(db, participant, year, current_year):
 
     username = participant.username
     start_balance = get_end_of_year_balance(db, participant, year-1, current_year)
+
+    # FIXME - delta from the `payments` table should be included too!
     delta = db.one("""
         SELECT (
                   SELECT COALESCE(sum(amount), 0) AS a
@@ -164,6 +172,8 @@ def export_history(participant, year, mode, key, back_as='namedtuple', require_k
     db = participant.db
     params = dict(username=participant.username, year=year)
     out = {}
+
+    # FIXME - values from the `payments` table should be included too!
     if mode == 'aggregate':
         out['given'] = lambda: db.all("""
             SELECT tippee, sum(amount) AS amount

--- a/gratipay/utils/history.py
+++ b/gratipay/utils/history.py
@@ -168,59 +168,27 @@ def iter_payday_events(db, participant, year=None):
     yield dict(kind='day-close', balance=balance)
 
 
-def export_history(participant, year, mode, key, back_as='namedtuple', require_key=False):
+def export_history(participant, year, key, back_as='namedtuple', require_key=False):
     db = participant.db
     params = dict(username=participant.username, year=year)
     out = {}
 
     # FIXME - values from the `payments` table should be included too!
-    if mode == 'aggregate':
-        out['given'] = lambda: db.all("""
-            SELECT tippee, sum(amount) AS amount
-              FROM transfers
-             WHERE tipper = %(username)s
-               AND extract(year from timestamp) = %(year)s
-          GROUP BY tippee
-        """, params, back_as=back_as)
-        out['taken'] = lambda: db.all("""
-            SELECT tipper AS team, sum(amount) AS amount
-              FROM transfers
-             WHERE tippee = %(username)s
-               AND context = 'take'
-               AND extract(year from timestamp) = %(year)s
-          GROUP BY tipper
-        """, params, back_as=back_as)
-    else:
-        out['exchanges'] = lambda: db.all("""
-            SELECT timestamp, amount, fee, status, note
-              FROM exchanges
-             WHERE participant = %(username)s
-               AND extract(year from timestamp) = %(year)s
-          ORDER BY timestamp ASC
-        """, params, back_as=back_as)
-        out['given'] = lambda: db.all("""
-            SELECT timestamp, tippee, amount, context
-              FROM transfers
-             WHERE tipper = %(username)s
-               AND extract(year from timestamp) = %(year)s
-          ORDER BY timestamp ASC
-        """, params, back_as=back_as)
-        out['taken'] = lambda: db.all("""
-            SELECT timestamp, tipper AS team, amount
-              FROM transfers
-             WHERE tippee = %(username)s
-               AND context = 'take'
-               AND extract(year from timestamp) = %(year)s
-          ORDER BY timestamp ASC
-        """, params, back_as=back_as)
-        out['received'] = lambda: db.all("""
-            SELECT timestamp, amount, context
-              FROM transfers
-             WHERE tippee = %(username)s
-               AND context NOT IN ('take', 'take-over')
-               AND extract(year from timestamp) = %(year)s
-          ORDER BY timestamp ASC
-        """, params, back_as=back_as)
+    out['given'] = lambda: db.all("""
+        SELECT tippee, sum(amount) AS amount
+          FROM transfers
+         WHERE tipper = %(username)s
+           AND extract(year from timestamp) = %(year)s
+      GROUP BY tippee
+    """, params, back_as=back_as)
+    out['taken'] = lambda: db.all("""
+        SELECT tipper AS team, sum(amount) AS amount
+          FROM transfers
+         WHERE tippee = %(username)s
+           AND context = 'take'
+           AND extract(year from timestamp) = %(year)s
+      GROUP BY tipper
+    """, params, back_as=back_as)
 
     if key:
         try:

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,3 @@
+-- A bug was discovered in https://github.com/gratipay/gratipay.com/pull/4439
+-- Let's delete all cached entries in the table, they'll be regenerated with proper values.
+DELETE FROM balances_at;

--- a/www/~/%username/history/export.spt
+++ b/www/~/%username/history/export.spt
@@ -18,10 +18,9 @@ except ValueError:
     raise Response(400, "bad year")
 
 key = request.qs.get('key')
-mode = request.qs.get('mode')
 
 [---] text/csv via csv_dump
-export_history(participant, year, mode, key, require_key=True)
+export_history(participant, year, key, require_key=True)
 
 [---] application/json via json_dump
-export_history(participant, year, mode, key, back_as=dict)
+export_history(participant, year, key, back_as=dict)

--- a/www/~/%username/history/index.html.spt
+++ b/www/~/%username/history/index.html.spt
@@ -58,7 +58,7 @@ else:
     <tr><td colspan="8" class="totals">
         {{ _("Total given: {0}", format_currency(event['given'], "USD")) }}
             {% if event['given'] %}
-            (<a href="export.csv?year={{ year }}&amp;key=given&amp;mode=aggregate">{{
+            (<a href="export.csv?year={{ year }}&amp;key=given">{{
                 _("Export as CSV")
             }}</a>)
             {% endif %}


### PR DESCRIPTION
#4399 (Export as CSV yields blank file)

This is a regression from the move to Gratipay 2.0. We moved all internal money-moving logic to the `payments` table instead of `transfers`, but when history is fetched - only the `transfers` table is hit. 

This affects the yearly balances calculation, exporting `giving` and exporting `taking`. I've solved the first 2 as part of this PR (since they are actually used in the UI right now). Added a note about fixing `taking` - that can be a separate PR. 