### PR TITLE
Add bulk claiming at /on/npm/

### DIFF
--- a/js/gratipay/packages.js
+++ b/js/gratipay/packages.js
@@ -1,33 +1,60 @@
 Gratipay.packages = {};
 
-Gratipay.packages.init = function() {
-    Gratipay.Select('.gratipay-select');
-    $('button.apply').on('click', Gratipay.packages.post);
+Gratipay.packages.initBulk = function() {
+    $('button.apply').on('click', Gratipay.packages.postBulk);
 };
 
-Gratipay.packages.post = function(e) {
+Gratipay.packages.initSingle = function() {
+    Gratipay.Select('.gratipay-select');
+    $('button.apply').on('click', Gratipay.packages.postOne);
+};
+
+
+Gratipay.packages.postBulk = function(e) {
     e.preventDefault();
-    var $this = $(this);
-    var action = 'start-verification';
-    var package_id = $('input[name=package_id]').val();
+    var pkg, email, package_id, package_ids_by_email={};
+    $('table.listing td.item ').not('.disabled').each(function() {
+        pkg = $(this).data();
+        if (package_ids_by_email[pkg.email] === undefined)
+            package_ids_by_email[pkg.email] = [];
+        package_ids_by_email[pkg.email].push(pkg.packageId);
+    });
+    for (email in package_ids_by_email)
+        Gratipay.packages.post(email, package_ids_by_email[email], true);
+};
+
+Gratipay.packages.postOne = function(e) {
+    e.preventDefault();
     var email = $('input[name=email]:checked').val();
+    var package_id = $('input[name=package_id]').val();
+    Gratipay.packages.post(email, [package_id]);
+}
 
-    var $inputs = $('input, button');
-    $inputs.prop('disabled', true);
 
+Gratipay.packages.post = function(email, package_ids, show_email) {
+    var action = 'start-verification';
+    var $button = $('button.apply')
+
+    $button.prop('disabled', true);
+    function reenable() { $button.prop('disabled', false); }
     $.ajax({
         url: '/~' + Gratipay.username + '/emails/modify.json',
         type: 'POST',
-        data: {action: action, address: email, package_id: package_id},
+        data: { action: action
+              , address: email
+              , package_id: package_ids
+              , show_address_in_message: true
+               },
+        traditional: true,
         dataType: 'json',
         success: function (msg) {
             if (msg) {
                 Gratipay.notification(msg, 'success');
+                reenable();
             }
-            $inputs.prop('disabled', false);
         },
         error: [
-            function () { $inputs.prop('disabled', false); },
+            reenable,
             Gratipay.error
         ],
     });

--- a/scss/components/listing.scss
+++ b/scss/components/listing.scss
@@ -94,6 +94,24 @@ table.listing {
                 border-bottom: 1px solid $light-brown;
             }
         }
+
+        &.disabled {
+            img.avatar {
+                filter: grayscale(100%) brightness(110%);
+            }
+            .package-manager img {
+                filter: grayscale(100%) brightness(120%);
+            }
+            .listing-name {
+                color: $light-gray ! important;
+            }
+            .status a {
+                color: $medium-gray! important;
+            }
+            .owner a {
+                color: $medium-gray! important;
+            }
+        }
     }
 }
 .with-sidebar table.listing td.item .listing-details {

--- a/scss/components/text-treatments.scss
+++ b/scss/components/text-treatments.scss
@@ -15,12 +15,13 @@
         }
     }
 
-    .sorry {
+    .instructions {
         text-align: center;
-        font: normal 12px/15px $Ideal;
-        color: $medium-gray;
+        margin: 0 0 30px;
+        font-family: $Ideal;
     }
-    .note {
+
+    .note, .sorry, .fine-print {
         font: normal 12px/15px $Ideal;
         color: $medium-gray;
         a {
@@ -28,6 +29,9 @@
             text-decoration: underline;
             color: $medium-gray;
         }
+    }
+    .sorry, .fine-print {
+        text-align: center;
     }
     .listing-name {
         color: $black;

--- a/scss/pages/package.scss
+++ b/scss/pages/package.scss
@@ -1,12 +1,6 @@
 #package #content {
     text-align: center;
 
-    .instructions {
-        text-align: center;
-        margin: 0 0 30px;
-        font-family: $Ideal;
-    }
-
     .selected .icon { display: block; }
     .icon {
         display: none;

--- a/tests/py/test_www_npm_package.py
+++ b/tests/py/test_www_npm_package.py
@@ -53,3 +53,13 @@ class Tests(Harness):
     def test_package_served_as_project_if_claimed(self):
         self.claim_package()
         assert 'owned by' in self.client.GET('/foo/').body
+
+
+class Bulk(Harness):
+
+    def setUp(self):
+        self.make_package()
+
+    def test_anon_gets_signin_page(self):
+        body = self.client.GET('/on/npm/').body
+        assert '0 out of all 1 npm package' in body

--- a/www/on/npm/%package/index.html.spt
+++ b/www/on/npm/%package/index.html.spt
@@ -37,7 +37,7 @@ if user.participant:
 {% block scripts %}
 <script>
     $(document).ready(function() {
-        Gratipay.packages.init();
+        Gratipay.packages.initSingle();
     });
 </script>
 {{ super() }}
@@ -48,14 +48,14 @@ if user.participant:
 {% if package.description %}
 <p class="description important-thing-at-the-top{% if len(package.description) > 256 %} long{% endif %}">{{ package.description }}</p>
 {% else %}
-<p class="note important-thing-at-the-top">{{ _("No description available.") }}</p>
+<p class="sorry important-thing-at-the-top">{{ _("No description available.") }}</p>
 {% endif %}
 
 <p class="instructions">
     {{ _( 'Apply to accept payments for the {package_link} npm package:'
         , package_link=('<a href="' + package.remote_human_url + '">' + package_name + '</a>')|safe
          ) }}
- </p>
+</p>
 
 {% if user.ANON %}
     <div class="important-button">
@@ -63,7 +63,7 @@ if user.participant:
     </div>
 {% else %}
     {% if len(emails) == 0 %}
-    <p class="note">{{ _("No email addresses on file.") }}</p>
+    <p class="sorry">{{ _("No email addresses on file.") }}</p>
     {% else %}
     <input type="hidden" name="package_id" value="{{ package.id }}">
     <div class="gratipay-select">
@@ -115,15 +115,19 @@ if user.participant:
         </button>
     </div>
     {% endif %}
-    <p class="note">{{ _( 'Addresses are from {a}{code}maintainers{_code}{_a}.'
-                        , a=('<a href="' + package.remote_api_url + '">')|safe
-                        , _a='</a>'|safe
-                        , code='<code>'|safe
-                        , _code='</code>'|safe
-                         ) }}</p>
-    <p class="note">{{ _( 'Out of date? Update {a}at npm{_a} and refresh.'
-                        , a=('<a href="' + package.remote_human_url + '">')|safe
-                        , _a='</a>'|safe
-                         ) }}</p>
+    <p class="fine-print">
+        {{ _( 'Addresses are from {a}{code}maintainers{_code}{_a}.'
+            , a=('<a href="' + package.remote_api_url + '">')|safe
+            , _a='</a>'|safe
+            , code='<code>'|safe
+            , _code='</code>'|safe
+             ) }}
+    </p>
+    <p class="fine-print">
+        {{ _( 'Out of date? Update {a}at npm{_a} and refresh.'
+            , a=('<a href="' + package.remote_human_url + '">')|safe
+            , _a='</a>'|safe
+             ) }}
+    </p>
 {% endif %}
 {% endblock %}

--- a/www/on/npm/index.html.spt
+++ b/www/on/npm/index.html.spt
@@ -2,8 +2,9 @@ from gratipay.utils import icons
 [---]
 banner = manager = "npm"
 suppress_sidebar = True
-npackages, Npackages = website.db.one('''
-    select (select count(*) from teams_to_packages) as n, (select count(*) from packages) as t
+npm_stats = website.db.one('''
+    select (select count(*) from teams_to_packages) as claimed_packages
+         , (select count(*) from packages) as total_packages
 ''')
 if user.participant:
     packages_for_claiming = user.participant.get_packages_for_claiming(manager)
@@ -122,8 +123,8 @@ if user.participant:
 {% endif %}
 <p class="fine-print">
     {{ _( "{n} out of all {N} npm packages are on Gratipay."
-        , n=format_number(npackages)
-        , N=format_number(Npackages)
+        , n=format_number(npm_stats.claimed_packages)
+        , N=format_number(npm_stats.total_packages)
          ) }}
 </p>
 {% endblock %}

--- a/www/on/npm/index.html.spt
+++ b/www/on/npm/index.html.spt
@@ -1,9 +1,129 @@
+from gratipay.utils import icons
 [---]
-title = "Search npm"
+banner = manager = "npm"
 suppress_sidebar = True
-website.redirect('/')  # nothing here yet
+npackages, Npackages = website.db.one('''
+    select (select count(*) from teams_to_packages) as n, (select count(*) from packages) as t
+''')
+if user.participant:
+    packages_for_claiming = user.participant.get_packages_for_claiming(manager)
+    any_claimable = any([rec.claimed_by is None for rec in packages_for_claiming])
 [---]
 {% extends "templates/base.html" %}
+
+{% block banner %}
+<a class="elsewhere" href="https://www.npmjs.com/">
+    <div class="avatar">
+        <img class="avatar" src="{{ website.asset('package-default-large.png') }}" />
+        <img class="platform" src="{{ website.asset('npm-n.png') }}" />
+    </div>
+    {{ super() }}
+</a>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    $(document).ready(function() {
+        Gratipay.packages.initBulk();
+    });
+</script>
+{{ super() }}
+{% endblock %}
+
 {% block content %}
-<input type="text" name="q"> <button class="selected">Search</button>
+
+<p class="description important-thing-at-the-top">
+    {{ _('Free as in money.') }}
+</p>
+
+<p class="instructions">
+    {{ _('Apply to accept payments for your npm packages:') }}
+</p>
+
+{% if user.ANON %}
+    <div class="important-button">
+        {{ sign_in_using(button_class='large') }}
+    </div>
+{% else %}
+
+    {% if not packages_for_claiming %}
+    <p class="sorry">{{ _("No packages found.") }}</p>
+    {% else %}
+    <table class="listing">
+        {% for i, rec in enumerate(packages_for_claiming, start=1) %}
+        <tr>
+            <td class="item i{{i}}{% if rec.claimed_by %} disabled{% endif %}"
+                data-email="{{ rec.email_address }}" data-package-id="{{ rec.package.id }}">
+                <img class="avatar" src="{{ website.asset('package-default-small.png') }}">
+                <div class="package-manager"><img src="{{ website.asset('npm-n.png') }}"></div>
+                <a class="listing-name" href="{{ rec.package.url_path }}">
+                    {{ rec.package.name }}
+                </a>
+
+                <div class="listing-details">
+                    <span class="i">{{ i }}</span>
+                    {% if rec.claimed_by %}
+                    <span class="owner">&middot;
+                    <span class="status-icon failure">
+                        {{ icons.STATUS_ICONS['failure']|safe }}</span>
+                        {% if rec.claimed_by == user.participant %}
+                        {{ _( "already claimed by {a}you{_a}"
+                            , a=('<a class="owner" href="{}">'|safe
+                                 ).format(rec.claimed_by.url_path)
+                            , _a='</a>'|safe
+                             ) }}
+                        {% else %}
+                        {{ _( "already claimed by {a}{owner}{_a}"
+                            , owner='~'+rec.claimed_by.username
+                            , a=('<a class="owner" href="{}">'|safe
+                                 ).format(rec.claimed_by.url_path)
+                            , _a='</a>'|safe
+                             ) }}
+                        {% endif %}
+                    </span>
+                    {% else %}
+                    <span class="owner">
+                        &middot;
+                        {% if rec.email_address_is_primary %}
+                        <span class="status-icon feature">
+                            {{ icons.STATUS_ICONS['feature']|safe }}</span>
+                        {% else %}
+                        <span class="status-icon success">
+                            {{ icons.STATUS_ICONS['success']|safe }}</span>
+                        {% endif %}
+                        {{ rec.email_address }}
+                    </span>
+                    {% endif %}
+                    <span class="description">&middot;
+                        {{ rec.package.description }}
+                    </span>
+                </div>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endif %}
+
+    <div class="important-button">
+        <button type="submit" class="apply selected large"
+            {% if not any_claimable %}disabled{% endif %}>
+            {{ _('Apply to accept payments') }}
+        </button>
+    </div>
+
+    <p class="fine-print">
+        {{ _( "{a}Link an email{_a} from npm to see related packages."
+            , a=('<a href="/about/me/emails/">'|safe
+                 if packages_for_claiming else
+                 '<a href="/about/me/emails/" class="highlight">'|safe)
+            , _a='</a>'|safe
+             ) }}
+    </p>
+{% endif %}
+<p class="fine-print">
+    {{ _( "{n} out of all {N} npm packages are on Gratipay."
+        , n=format_number(npackages)
+        , N=format_number(Npackages)
+         ) }}
+</p>
 {% endblock %}

--- a/www/~/%username/emails/modify.json.spt
+++ b/www/~/%username/emails/modify.json.spt
@@ -48,8 +48,15 @@ if action in ('add-email', 'resend', 'start-verification'):
 
     participant.start_email_verification(address, *packages)
     if show_address_in_message:
+
+        # When reverifying an already-verified email (package claiming is a
+        # special case of this), then don't worry about content spoofing,
+
         msg = _("Check {email_address} for a verification link.", email_address=address)
     else:
+
+        # ... but otherwise, do: https://hackerone.com/reports/117187.
+
         msg = _("Check your inbox for a verification link.")
 elif action == 'set-primary':
     participant.set_primary_email(address)

--- a/www/~/%username/emails/modify.json.spt
+++ b/www/~/%username/emails/modify.json.spt
@@ -17,6 +17,7 @@ participant = get_participant(state, restrict=True)
 
 action = request.body['action']
 address = request.body['address']
+show_address_in_message = bool(request.body.get('show_address_in_message', ''))
 
 # Basic checks. The real validation will happen when we send the email.
 if (len(address) > 254) or not email_re.match(address):
@@ -46,7 +47,10 @@ if action in ('add-email', 'resend', 'start-verification'):
         raise Response(400)
 
     participant.start_email_verification(address, *packages)
-    msg = _("Check your inbox for a verification link.")
+    if show_address_in_message:
+        msg = _("Check {email_address} for a verification link.", email_address=address)
+    else:
+        msg = _("Check your inbox for a verification link.")
 elif action == 'set-primary':
     participant.set_primary_email(address)
 elif action == 'remove':


### PR DESCRIPTION
Picking up from #4416.

### Todo

- [x] move package API to a mixin: #4495
- [x] insert into `emails` during `make_participant`: #4495
- [x] add `get_packages_for_claiming`
- [x] modify `get_packages_for_claiming` to sort/group as desired
- [x] link to the email settings page
- [x] set the avatar as the npm logo
- [x] disable apply when there are no claimable packages
- [x] indicate when a package is already claimed, differentiating claimed-by-self and -by-other
- [x] fix test suite
- [x] wire up to `emails/modify.json`, send to address displayed
- [x] verify that we test what happens when someone tries to claim an already claimed package
- [x] ~~reuse open review ticket where possible~~—bumping to #4505
- [x] tie into review process better