### PR TITLE
Start recording ref when recording an exchange in masspay

### DIFF
--- a/tests/py/test_dashboard.py
+++ b/tests/py/test_dashboard.py
@@ -19,6 +19,7 @@ class TestNMassPays(BillingHarness):
                               , 'fee': '0'
                               , 'note': 'Exchange!'
                               , 'status': 'succeeded'
+                              , 'ref': 'transactionidref'
                               , 'route_id': unicode(self.homer_route.id)
                                }
                             , auth_as='admin'

--- a/www/~/%username/history/record-an-exchange.spt
+++ b/www/~/%username/history/record-an-exchange.spt
@@ -45,13 +45,17 @@ if request.method == 'POST':
     route = ExchangeRoute.from_id(route_id)
     if not route or route.participant.id != participant.id:
         raise Response(400, "Route doesn't exist")
+    
+    ref = request.body['ref']
+    if not ref:
+        ref = ""
 
     with website.db.get_cursor() as cursor:
         cursor.run("""
             INSERT INTO exchanges
-                        (amount, fee, route, participant, recorder, note, status)
-                 VALUES (%s, %s, %s, %s, %s, %s, %s)
-        """, (amount, fee, route_id, participant.username, user.participant.username, note, status))
+                        (amount, fee, route, participant, recorder, note, status, ref)
+                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """, (amount, fee, route_id, participant.username, user.participant.username, note, status, ref))
 
         if amount < 0:
             # For payouts, we need to take the fee out of their Gratipay balance.
@@ -96,6 +100,7 @@ if request.method == 'POST':
     </select>
     <br>
     <input name="note" placeholder="note" style="width: 420px" />
+    <input name="ref" placeholder="ref" />
     <h2>Route</h2>
     {% for route in routes %}
         <input type="radio" name="route_id" value="{{ route.id }}">

--- a/www/~/%username/history/record-an-exchange.spt
+++ b/www/~/%username/history/record-an-exchange.spt
@@ -46,9 +46,9 @@ if request.method == 'POST':
     if not route or route.participant.id != participant.id:
         raise Response(400, "Route doesn't exist")
     
-    ref = request.body['ref']
+    ref = request.body['ref'].strip()
     if not ref:
-        ref = ""
+        raise Response(400, "Invalid Reference")
 
     with website.db.get_cursor() as cursor:
         cursor.run("""


### PR DESCRIPTION
As per @dmk246 suggestion [here](https://github.com/gratipay/gratipay.com/pull/3912#issuecomment-283485576) #4361 only took care of exchanges that recorded charges to participants. Masspay which is used for payouts were still recording NULL refs since there was no way to record a ref via `record_an_exchange.spt` 
This PR is to fix this issue.