### PR TITLE
Fix bug in package claiming when address verified

### DIFF
--- a/gratipay/models/participant/email.py
+++ b/gratipay/models/participant/email.py
@@ -163,6 +163,7 @@ class Email(object):
         existing = c.one( 'SELECT * FROM emails WHERE address=%s AND participant_id=%s'
                         , (email, self.id)
                          )  # can't use eafp here because of cursor error handling
+                            # XXX I forget what eafp is. :(
 
         if existing is None:
 
@@ -233,7 +234,13 @@ class Email(object):
                 return VERIFICATION_FAILED, None, None
             packages = self.get_packages_claiming(cursor, nonce)
             if record.verified and not packages:
-                assert record.nonce is None  # and therefore, order of conditions matters
+
+                # If an email address is already verified, then we should only
+                # be going through this flow if they are verifying ownership of
+                # some packages.
+
+                assert record.nonce is None  # do this before constant_time_compare
+
                 return VERIFICATION_REDUNDANT, None, None
             if not constant_time_compare(record.nonce, nonce):
                 return VERIFICATION_FAILED, None, None

--- a/gratipay/models/participant/email.py
+++ b/gratipay/models/participant/email.py
@@ -247,9 +247,16 @@ class Email(object):
 
             if record.nonce is None:
 
-                # Nulling out the nonce only happens when marking an email
-                # address as verified (when we insert we always provide a
-                # nonce), so let's make sure that obtains.
+                # Nonces are nulled out only when updating to mark an email
+                # address as verified; we always set a nonce when inserting.
+                # Therefore, the main way to get a null nonce is to issue a
+                # link, follow it, and follow it again.
+
+                # All records with a null nonce should be verified, though not
+                # all verified records will have a null nonce. That is, it's
+                # possible to land here with an already-verified address, and
+                # this is in fact expected when verifying package ownership via
+                # an already-verified address.
 
                 assert record.verified
 


### PR DESCRIPTION
When the address is already verified and the user starts a package claim twice, we aren't clearing out old nonces properly.