### PR TITLE
Tinker with comments and copy

### DIFF
--- a/gratipay/models/__init__.py
+++ b/gratipay/models/__init__.py
@@ -171,15 +171,16 @@ def _check_no_team_balances(cursor):
 
 def _check_orphans(cursor):
     """
-    Finds participants that
-        * do not have a verified email address (i.e. did not signup via email)
-        * do not have corresponding elsewhere account
-        * have not been absorbed by other participant
+    Finds participants that:
 
-    These are broken because participants without an email attached arise from
-    elsewhere (signup via third-party providers), and elsewhere is detached
-    only by take over which makes a note in absorptions if it removes the last
-    elsewhere account.
+        * do not have a verified email address (i.e. did not signup via email),
+        * do not have a corresponding elsewhere account, and
+        * have not been absorbed by another participant.
+
+    These are broken because new participants are only ever created with either
+    an email address or an account on another platform, and email/elsewhere is
+    detached only by take_over which makes a note in absorptions if it removes
+    the last email/elsewhere account.
 
     Especially bad case is when also claimed_time is set because
     there must have been elsewhere account attached and used to sign in.

--- a/gratipay/models/participant/__init__.py
+++ b/gratipay/models/participant/__init__.py
@@ -520,9 +520,9 @@ class Participant(Model, Email, ExchangeRoutes, Identity, Packages):
         with self.db.get_cursor() as c:
             accounts = self.get_elsewhere_logins(c)
 
-            # A user who signed up via a third-party provider might not have
-            # and email attached. They must maintain at least one elsewhere
-            # account until they provide an email.
+            # A user who signed up via a third-party provider might not have an
+            # email attached. They must maintain at least one elsewhere account
+            # until they provide an email.
             assert self.email_address or (len(accounts) > 0)
 
             is_last = len(accounts) == 1 and accounts[0] == (platform, user_id)

--- a/gratipay/security/authentication/__init__.py
+++ b/gratipay/security/authentication/__init__.py
@@ -1,4 +1,3 @@
 """Gratipay authentication module.
 """
-
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/gratipay/security/authentication/website_helpers.py
+++ b/gratipay/security/authentication/website_helpers.py
@@ -9,7 +9,9 @@ from gratipay.security import csrf
 from gratipay.security.crypto import constant_time_compare
 from gratipay.security.user import User, SESSION
 
+
 ANON = User()
+
 
 def _get_user_via_api_key(api_key):
     """Given an api_key, return a User. This auth method is deprecated.
@@ -25,6 +27,7 @@ def _get_user_via_api_key(api_key):
                  WHERE id = %s
             """, (today, p.id))
     return user
+
 
 def _get_user_via_basic_auth(auth_header):
     """Given a basic auth header, return a User object.
@@ -48,12 +51,20 @@ def _get_user_via_basic_auth(auth_header):
             raise Response(401)
     return user
 
+
 def _turn_off_csrf(request):
     """Given a request, short-circuit CSRF.
     """
     csrf_token = csrf._get_new_token()
     request.headers.cookie['csrf_token'] = csrf_token
     request.headers['X-CSRF-TOKEN'] = csrf_token
+
+
+def start_user_as_anon():
+    """Make sure we always have a user object, regardless of exceptions during authentication.
+    """
+    return {'user': ANON}
+
 
 def authenticate_user_if_possible(request, user):
     """This signs the user in.
@@ -71,6 +82,7 @@ def authenticate_user_if_possible(request, user):
         user = User.from_session_token(token)
     return {'user': user}
 
+
 def add_auth_to_response(response, request=None, user=ANON):
     if request is None:
         return  # early parsing must've failed
@@ -80,8 +92,3 @@ def add_auth_to_response(response, request=None, user=ANON):
     if SESSION in request.headers.cookie:
         if not user.ANON:
             user.keep_signed_in(response.headers.cookie)
-
-def start_user_as_anon():
-    """Make sure we always have a user object, regardless of exceptions during authentication.
-    """
-    return {'user': ANON}

--- a/templates/sign-in-modal.html
+++ b/templates/sign-in-modal.html
@@ -27,9 +27,9 @@
         </header>
         <section>
             <p class="sign-in-togglable"
-               data-sign-in-to-continue="{{ _('Enter your email to sign-in to Gratipay') }}"
-               data-sign-in-or-sign-up="{{ _('Enter your email to sign-in or create an account on Gratipay') }}">
-                {{ _('Enter your email to sign-in or create an account on Gratipay') }}
+               data-sign-in-to-continue="{{ _('Enter your email to sign in to Gratipay') }}"
+               data-sign-in-or-sign-up="{{ _('Enter your email to sign in or create an account on Gratipay') }}">
+                {{ _('Enter your email to sign in or create an account on Gratipay') }}
             </p>
 
             <form class="email-form">

--- a/tests/ttw/test_sign_in.py
+++ b/tests/ttw/test_sign_in.py
@@ -28,4 +28,4 @@ class Tests(BrowserHarness):
         self.visit('/about/me/emails.json')
 
         assert self.css('#sign-in-modal').visible
-        assert self.css('#sign-in-modal p')[0].text == 'Enter your email to sign-in to Gratipay'
+        assert self.css('#sign-in-modal p')[0].text == 'Enter your email to sign in to Gratipay'

--- a/www/auth/signup.json.spt
+++ b/www/auth/signup.json.spt
@@ -44,4 +44,4 @@ else:
     raise Response(400, _('This link is invalid.'))
 
 [---] application/json
-{'message': _('Account created! Signing you in...')}
+{'message': _('Account created! Signing you in ...')}


### PR DESCRIPTION
Part of #4539, follows #4550.

- "sign-in" is a noun, verb is "sign in"
- order of functions is per order in algorithm
- usual Python style is actually two spaces between functions
- ... and no space between docstring and first import