### PR TITLE
Whitelist the widget CSS for CSP

### DIFF
--- a/gratipay/security/__init__.py
+++ b/gratipay/security/__init__.py
@@ -53,7 +53,7 @@ def add_headers_to_response(website, response):
             "default-src 'self';"
             "script-src 'self' assets.gratipay.com 'unsafe-inline';"
             "style-src 'self' assets.gratipay.com downloads.gratipay.com cloud.typography.com"
-            "          'sha256-WLocK7HeCKzQLS0M+PGS++5IhyfFsOA5N4ZCeTcltoo=';"
+            "          'sha256-WLocK7HeCKzQLS0M+PGS++5IhyfFsOA5N4ZCeTcltoo=';" # CSS on widget.html
             "img-src *;"
             "font-src 'self' assets.gratipay.com cloud.typography.com data:;"
             "block-all-mixed-content;"

--- a/gratipay/security/__init__.py
+++ b/gratipay/security/__init__.py
@@ -52,7 +52,8 @@ def add_headers_to_response(website, response):
         response.headers['content-security-policy-report-only'] = (
             "default-src 'self';"
             "script-src 'self' assets.gratipay.com 'unsafe-inline';"
-            "style-src 'self' assets.gratipay.com downloads.gratipay.com cloud.typography.com;"
+            "style-src 'self' assets.gratipay.com downloads.gratipay.com cloud.typography.com"
+            "          'sha256-WLocK7HeCKzQLS0M+PGS++5IhyfFsOA5N4ZCeTcltoo=';"
             "img-src *;"
             "font-src 'self' assets.gratipay.com cloud.typography.com data:;"
             "block-all-mixed-content;"

--- a/tests/py/test_security.py
+++ b/tests/py/test_security.py
@@ -65,7 +65,8 @@ class AddHeadersToResponseTests(Harness):
             policy = (
                 "default-src 'self';"
                 "script-src 'self' assets.gratipay.com 'unsafe-inline';"
-                "style-src 'self' assets.gratipay.com downloads.gratipay.com cloud.typography.com;"
+                "style-src 'self' assets.gratipay.com downloads.gratipay.com cloud.typography.com"
+                "          'sha256-WLocK7HeCKzQLS0M+PGS++5IhyfFsOA5N4ZCeTcltoo=';"
                 "img-src *;"
                 "font-src 'self' assets.gratipay.com cloud.typography.com data:;"
                 "block-all-mixed-content;"

--- a/www/~/%username/widget.html.spt
+++ b/www/~/%username/widget.html.spt
@@ -9,6 +9,10 @@ response.headers['X-Frame-Options'] = "ALLOWALL"
 <!doctype html>
 <html>
     <head>
+
+        <!-- Changing CSS? Also update the style-src hash in the CSP header in
+             gratipay/security/__init__.py -->
+
         <style>
             body {
                 margin: 0;


### PR DESCRIPTION
This should resolve the worst of the CSP reports in https://github.com/gratipay/inside.gratipay.com/issues/1118.