### PR TITLE
Add support for npm scopes

### DIFF
--- a/gratipay/models/package/__init__.py
+++ b/gratipay/models/package/__init__.py
@@ -16,7 +16,7 @@ class Package(Model, Emails, Team):
 
     Packages are entities on open source package managers; `npm
     <https://www.npmjs.com/>`_ is the only one we support so far. Each package
-    on npm has a page on Gratipay with an URL of the form ``/on/npm/foo/``.
+    on npm has a page on Gratipay with an URL of the form ``/on/npm/foo``.
     Packages can be claimed by Gratipay participants, at which point we create
     a :py:class:`~gratipay.models.team.Team` for them under the hood so they
     can start accepting payments.
@@ -40,7 +40,7 @@ class Package(Model, Emails, Team):
     def url_path(self):
         """The path part of the URL for this package on Gratipay.
         """
-        return '/on/{}/{}/'.format(self.package_manager, self.name)
+        return '/on/{}/{}'.format(self.package_manager, self.name)
 
 
     @property

--- a/gratipay/models/package/team.py
+++ b/gratipay/models/package/team.py
@@ -40,9 +40,12 @@ class Team(object):
             return team
 
         def slug_options():
-            yield self.name
+            # Having analyzed existing names, we should never get `@` without
+            # `/`. Be conservative in what we accept! Oh, wait ...
+            base_name = self.name.split('/')[1] if self.name.startswith('@') else self.name
+            yield base_name
             for i in range(1, 10):
-                yield '{}-{}'.format(self.name, i)
+                yield '{}-{}'.format(base_name, i)
             yield uuid.uuid4().hex
 
         for slug in slug_options():

--- a/tests/py/test_packages.py
+++ b/tests/py/test_packages.py
@@ -64,9 +64,9 @@ class Basics(Harness):
 
 class Linking(Harness):
 
-    def link(self):
+    def link(self, package_name='foo'):
         alice = self.make_participant('alice')
-        package = self.make_package()
+        package = self.make_package(name=package_name)
         with self.db.get_cursor() as c:
             team = package.get_or_create_linked_team(c, alice)
         return alice, package, team
@@ -123,6 +123,10 @@ class Linking(Harness):
             self.make_team(name='foo-{}'.format(i)) # take `foo-{1-9}`
         _, _, team = self.link()
         assert team.slug == 'deadbeef-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+    def test_linking_team_ignores_scope(self):
+        _, _, team = self.link(package_name='@foo/bar')
+        assert team.slug == 'bar'
 
     def test_linked_team_takes_package_description(self):
         _, _, team = self.link()

--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -34,8 +34,12 @@ class TestPages(Harness):
         exchange_id = self.make_exchange('braintree-cc', 19, 0, alice, address=address)
 
         # for npm page
-        self.db.run("INSERT INTO packages (package_manager, name, description, emails) "
-                    "VALUES ('npm', 'foo-package', 'A package', ARRAY[]::text[])")
+        self.db.run("""
+            INSERT
+              INTO packages (package_manager, name, description, emails)
+            VALUES ('npm', 'foo-package', 'A package', ARRAY[]::text[])
+                 , ('npm', '@foo/package', 'A scoped package', ARRAY[]::text[])
+        """)
 
         if setup:
             setup(alice)
@@ -47,7 +51,7 @@ class TestPages(Harness):
                            .replace('/~/%username/', '/~alice/') \
                            .replace('/for/%slug/', '/for/wonderland/') \
                            .replace('/%platform/', '/github/') \
-                           .replace('/%package/', '/foo-package/') \
+                           .replace('/%package', '/foo-package') \
                            .replace('/%user_name/', '/gratipay/') \
                            .replace('/%to', '/1') \
                            .replace('/%country', '/TT') \
@@ -63,6 +67,7 @@ class TestPages(Harness):
            /about/me
            /about/me/
            /about/me/history
+           /on/npm/@foo/package
         """.split())
         for url in urls:
             try:

--- a/tests/py/test_www_npm_package.py
+++ b/tests/py/test_www_npm_package.py
@@ -10,27 +10,32 @@ class Tests(Harness):
     def setUp(self):
         self.make_package()
 
+    def test_trailing_slash_redirects(self):
+        response = self.client.GxT('/on/npm/foo/')
+        assert response.code == 302
+        assert response.headers['Location'] == '/on/npm/foo'
+
     def test_anon_gets_signin_page_from_unclaimed(self):
-        body = self.client.GET('/on/npm/foo/').body
+        body = self.client.GET('/on/npm/foo').body
         assert 'foo</a> npm package on Gratipay:' in body
 
     def test_auth_gets_send_confirmation_page_from_unclaimed(self):
         self.make_participant('bob', claimed_time='now')
-        body = self.client.GET('/on/npm/foo/', auth_as='bob').body
+        body = self.client.GET('/on/npm/foo', auth_as='bob').body
         assert 'foo</a> npm package:' in body
         assert 'alice@example.com' in body
 
     def test_auth_gets_multiple_options_if_present(self):
         self.make_package(NPM, 'bar', 'Bar', ['alice@example.com', 'alice@example.net'])
         self.make_participant('bob', claimed_time='now')
-        body = self.client.GET('/on/npm/bar/', auth_as='bob').body
+        body = self.client.GET('/on/npm/bar', auth_as='bob').body
         assert 'alice@example.com' in body
         assert 'alice@example.net' in body
 
     def test_auth_gets_something_if_no_emails(self):
         self.make_package(NPM, 'bar', 'Bar', [])
         self.make_participant('bob', claimed_time='now')
-        body = self.client.GET('/on/npm/bar/', auth_as='bob').body
+        body = self.client.GET('/on/npm/bar', auth_as='bob').body
         assert "No email addresses on file" in body
 
 
@@ -46,7 +51,7 @@ class Tests(Harness):
 
     def test_package_redirects_to_project_if_claimed(self):
         self.claim_package()
-        response = self.client.GxT('/on/npm/foo/')
+        response = self.client.GxT('/on/npm/foo')
         assert response.code == 302
         assert response.headers['Location'] == '/foo/'
 

--- a/tests/ttw/test_package_claiming.py
+++ b/tests/ttw/test_package_claiming.py
@@ -12,7 +12,7 @@ class Test(BrowserHarness):
     def check(self, choice=0):
         self.make_participant('alice', claimed_time='now')
         self.sign_in('alice')
-        self.visit('/on/npm/foo/')
+        self.visit('/on/npm/foo')
         self.css('#content label')[0].click() # activate select
         self.css('#content label')[choice].click()
         self.css('#content button')[0].click()
@@ -44,7 +44,7 @@ class Test(BrowserHarness):
         alice = self.make_participant('alice', claimed_time='now')
         self.add_and_verify_email(alice, 'alice@example.com', 'bob@example.com')
         self.sign_in('alice')
-        self.visit('/on/npm/foo/')
+        self.visit('/on/npm/foo')
         self.css('#content label')[0].click()            # activate select
         self.css('#content label')[1].click()            # click second item
         self.css('#content li')[0].has_class('selected') # first item is still selected
@@ -66,7 +66,7 @@ class Test(BrowserHarness):
 
         self.make_participant('bob', claimed_time='now')
         self.sign_in('bob')
-        self.visit('/on/npm/foo/')
+        self.visit('/on/npm/foo')
 
         self.css('.your-payment button.edit').click()
         self.wait_for('.your-payment input.amount').fill('10')
@@ -91,7 +91,7 @@ class Test(BrowserHarness):
     def test_deleted_packages_are_404(self):
         self.make_package()
         Package.from_names(NPM, 'foo').delete()
-        self.visit('/on/npm/foo/')
+        self.visit('/on/npm/foo')
         assert self.css('#content h1').text == '404'
 
 

--- a/www/on/npm/%package.spt
+++ b/www/on/npm/%package.spt
@@ -8,6 +8,8 @@ from gratipay.models.package.emails import PRIMARY, VERIFIED, UNVERIFIED, UNLINK
 [---]
 
 package_name = request.path['package']
+if package_name.endswith('/'):
+    website.redirect(request.path.raw[:-1])  # no trailing slash
 package = Package.from_names('npm', package_name)
 if package is None:
     raise Response(404)
@@ -21,7 +23,7 @@ banner = package_name
 if user.participant:
     emails = package.classify_emails_for_participant(user.participant)
     has_email_options = bool([x for x in emails if x[1] != OTHER])
-[---]
+[---] text/html
 {% extends "templates/base.html" %}
 
 {% block banner %}


### PR DESCRIPTION
npm has a concept of "[scoped](https://docs.npmjs.com/misc/scope)" packages with special package names of the form `@foo/bar`. We need to support these as package names under `/on/npm/` and do some smarts to use just `bar` for the project name when claiming. Closes #4496.