### PR TITLE
Pay for package.json in aggregate

### DIFF
--- a/tests/py/test_www_npm_package.py
+++ b/tests/py/test_www_npm_package.py
@@ -62,5 +62,5 @@ class Bulk(Harness):
 
     def test_anon_gets_payment_flow(self):
         body = self.client.GET('/on/npm/').body
-        assert 'Paste a package.json' in body
+        assert 'Paste your own package.json' in body
         assert '0 out of all 1 npm package' in body

--- a/tests/ttw/test_paying_for_package_json.py
+++ b/tests/ttw/test_paying_for_package_json.py
@@ -8,7 +8,7 @@ class Tests(BrowserHarness):
 
     def assertDiscovery(self):
         instructions = self.css('.instructions').text
-        assert instructions == 'Paste a package.json to find packages to pay for:'
+        assert instructions == 'Paste your own package.json:'
 
     def test_anon_gets_discovery_page_by_default(self):
         self.visit('/on/npm/')

--- a/tests/ttw/test_paying_for_package_json.py
+++ b/tests/ttw/test_paying_for_package_json.py
@@ -20,7 +20,7 @@ class Tests(BrowserHarness):
         self.visit('/on/npm/')
         self.assertDiscovery()
 
-    def test_pasting_a_package_json_works(self):
+    def test_paying_for_package_json_works(self):
         self.make_package(name='amperize', description='Amperize!')
         mysql = self.make_package(name='mysql', description='MySQL!', emails=['bob@example.com'])
         self.make_package(name='netjet', description='Netjet!', emails=['cat@example.com'])

--- a/www/on/npm/index.html.spt
+++ b/www/on/npm/index.html.spt
@@ -176,7 +176,7 @@ if request.method == 'POST':
 <form action="./" method="POST" class="package-json">
     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
     <p class="instructions">
-        {{ _('Paste a package.json to find packages to pay for:') }}
+        {{ _('Paste your own package.json:') }}
     </p>
 
     <textarea name="package.json"{% if not discovered %} autofocus{% endif %} wrap="off"

--- a/www/on/npm/index.html.spt
+++ b/www/on/npm/index.html.spt
@@ -184,7 +184,7 @@ if request.method == 'POST':
 
     <div class="important-button">
         <button type="submit" class="selected large">
-            {{ _('Find packages') }}
+            {{ _('Continue') }}
         </button>
     </div>
 </form>


### PR DESCRIPTION
So far under #4427 we've deployed _discovery_ via `package.json`, but the payment mechanic is the same one we've always had: recurring weekly payments managed individually for each and every package. This PR adds a new payment mechanic (our first in years—ever?): givers can set a single dollar amount to pay for their entire `package.json` in aggregate.

### Todo

- [ ] replace listing with "How much?" prompt
- [ ] add Review page with receipt-y thing + credit card form
- [ ] add cron to process distributions daily
- [ ] add distribution customization UI
- [ ] email receipt
- [ ] email invitation to maintainers
- [ ] email distribution report