### PR TITLE
"Ready to verify"

### DIFF
--- a/js/gratipay/packages.js
+++ b/js/gratipay/packages.js
@@ -1,14 +1,20 @@
 Gratipay.packages = {};
 
 Gratipay.packages.initBulk = function() {
-    $('button.apply').on('click', Gratipay.packages.postBulk);
+    $('.important-button button.apply').on('click', Gratipay.packages.postBulk);
 };
 
 Gratipay.packages.initSingle = function() {
-    Gratipay.Select('.gratipay-select');
-    $('button.apply').on('click', Gratipay.packages.postOne);
+    Gratipay.Select('.gratipay-select', Gratipay.packages.selectOne);
+    $('.important-button button').on('click', Gratipay.packages.postOne);
+    Gratipay.packages.selectOne($('.gratipay-select li.selected'));
 };
 
+Gratipay.packages.selectOne = function($li) {
+    var action = $li.data('action');
+    $('.important-button span').hide();
+    $('.important-button span.' + action).show();
+};
 
 Gratipay.packages.postBulk = function(e) {
     e.preventDefault();
@@ -20,20 +26,25 @@ Gratipay.packages.postBulk = function(e) {
         package_ids_by_email[pkg.email].push(pkg.packageId);
     });
     for (email in package_ids_by_email)
-        Gratipay.packages.post(email, package_ids_by_email[email], true);
+        Gratipay.packages.post(email, package_ids_by_email[email], 'yes');
 };
 
 Gratipay.packages.postOne = function(e) {
     e.preventDefault();
-    var email = $('input[name=email]:checked').val();
-    var package_id = $('input[name=package_id]').val();
-    Gratipay.packages.post(email, [package_id]);
+    var $input = $('input[name=email]:checked');
+    var email = $input.val();
+    var package_ids;
+    var show_address_in_message = 'no';
+    if ($input.closest('li').data('action') === 'apply') {
+        package_ids = [$('input[name=package_id]').val()];
+        show_address_in_message = 'yes';
+    }
+    Gratipay.packages.post(email, package_ids, show_address_in_message);
 }
 
-
-Gratipay.packages.post = function(email, package_ids, show_email) {
+Gratipay.packages.post = function(email, package_ids, show_address_in_message) {
     var action = 'start-verification';
-    var $button = $('button.apply')
+    var $button = $('.important-button button')
 
     $button.prop('disabled', true);
     function reenable() { $button.prop('disabled', false); }
@@ -43,7 +54,7 @@ Gratipay.packages.post = function(email, package_ids, show_email) {
         data: { action: action
               , address: email
               , package_id: package_ids
-              , show_address_in_message: true
+              , show_address_in_message: show_address_in_message
                },
         traditional: true,
         dataType: 'json',

--- a/js/gratipay/select.js
+++ b/js/gratipay/select.js
@@ -1,6 +1,7 @@
-Gratipay.Select = function(selector) {
+Gratipay.Select = function(selector, onselect) {
     var $ul = $('ul', selector);
     var $labels = $('label', $ul);
+    var onselect = onselect || function() {};
 
     // state for vertical position
     var topFactor = 0;      // float between 0 and $labels.length-1
@@ -51,9 +52,11 @@ Gratipay.Select = function(selector) {
 
     function close($label) {
         if ($label) {
-            if ($label.closest('li').hasClass('disabled')) return;
+            var $li = $label.closest('li');
+            if ($li.hasClass('disabled')) return;
             $('.selected', $ul).removeClass('selected')
-            $label.closest('li').addClass('selected').removeClass('hover');
+            $li.addClass('selected').removeClass('hover');
+            onselect($li);
         }
         $ul.css({'top': 0}).removeClass('open');
         $ul.unbind('mousewheel');

--- a/scss/pages/package.scss
+++ b/scss/pages/package.scss
@@ -14,6 +14,12 @@
         color: $medium-gray;
     }
 
+    .important-button {
+        span {
+            display: none;
+        }
+    }
+
     .status-icon {
         font-size: 12px;
         line-height: 12px;

--- a/www/on/npm/%package.spt
+++ b/www/on/npm/%package.spt
@@ -22,7 +22,6 @@ banner = package.name
 
 if user.participant:
     emails = package.classify_emails_for_participant(user.participant)
-    has_email_options = bool([x for x in emails if x[1] != OTHER])
 [---] text/html
 {% extends "templates/base.html" %}
 
@@ -77,7 +76,11 @@ if user.participant:
         <ul>
         {% for i, (email, group) in enumerate(emails, start=1) %}
             <li class="{% if group == OTHER %}disabled{% endif %}
-                       {% if i == 1 %}selected{% endif %}">
+                       {% if i == 1 %}selected{% endif %}"
+                data-action="{{ 'apply' if group in (PRIMARY, VERIFIED) else
+                                'resend' if group == UNVERIFIED else
+                                'verify' if group == UNLINKED else
+                                'none' }}">
                 <input type="radio" name="email" value="{{ email }}" id="email-{{i}}"
                        {% if i == 1 %}checked{% endif %}>
                 <span class="icon">&#xe007;</span>
@@ -91,19 +94,22 @@ if user.participant:
                                 {{ icons.STATUS_ICONS['failure']|safe }}</span>
                             {{ _('Linked to a different account') }}
                         {% else %}
-                            {{ _('Ready to use') }}
                             {% if group == PRIMARY %}
-                                &middot; <span class="status-icon feature">
+                                <span class="status-icon feature">
                                     {{ icons.STATUS_ICONS['feature']|safe }}</span>
                                 {{ _('Your primary email address') }}
                             {% elif group == VERIFIED %}
-                                &middot; <span class="status-icon success">
+                                <span class="status-icon success">
                                     {{ icons.STATUS_ICONS['success']|safe }}</span>
                                 {{ _('Linked to your account') }}
                             {% elif group == UNVERIFIED %}
-                                &middot; <span class="status-icon warning">
+                                <span class="status-icon warning">
                                     {{ icons.STATUS_ICONS['warning']|safe }}</span>
-                                {{ _('Half-linked to your account') }}
+                                {{ _('Verification pending') }}
+                            {% elif group == UNLINKED %}
+                                <span class="status-icon warning">
+                                    {{ icons.STATUS_ICONS['warning']|safe }}</span>
+                                {{ _('Unverified') }}
                             {% endif %}
                         {% endif %}
                     </div>
@@ -116,9 +122,11 @@ if user.participant:
     </div>
 
     <div class="important-button">
-        <button type="submit" class="apply selected large"
-                {% if not has_email_options %} disabled{% endif %}>
-            {{ _('Apply to accept payments') }}
+        <button type="submit" class="selected large disabled">
+            <span class="apply">{{ _('Apply to accept payments') }}</span>
+            <span class="resend">{{ _('Resend verification') }}</span>
+            <span class="verify">{{ _('Verify email address') }}</span>
+            <span class="dead-end">{{ _('Dead-end, sorry') }}</span>
         </button>
     </div>
     {% endif %}

--- a/www/on/npm/%package.spt
+++ b/www/on/npm/%package.spt
@@ -124,7 +124,7 @@ if user.participant:
     {% endif %}
     <p class="fine-print">
         {{ _( 'Addresses are from {a}{code}maintainers{_code}{_a}.'
-            , a=('<a href="' + package.remote_api_url + '">')|safe
+            , a='<a href="%s">'|safe % package.remote_api_url
             , _a='</a>'|safe
             , code='<code>'|safe
             , _code='</code>'|safe
@@ -132,7 +132,7 @@ if user.participant:
     </p>
     <p class="fine-print">
         {{ _( 'Out of date? Update {a}at npm{_a} and refresh.'
-            , a=('<a href="' + package.remote_human_url + '">')|safe
+            , a='<a href="%s">'|safe % package.remote_human_url
             , _a='</a>'|safe
              ) }}
     </p>

--- a/www/~/%username/emails/modify.json.spt
+++ b/www/~/%username/emails/modify.json.spt
@@ -12,7 +12,7 @@ participant = get_participant(state, restrict=True)
 
 action = request.body['action']
 address = request.body['address']
-show_address_in_message = bool(request.body.get('show_address_in_message', ''))
+show_address_in_message = request.body.get('show_address_in_message', '') == 'yes'
 
 # Basic checks. The real validation will happen when we send the email.
 if not is_valid_email_address(address):


### PR DESCRIPTION
&larr; Limit pending verifications (#4579) — Support queueing w/o participants (#4548) &rarr;

-------------

Implement the "Ready to verify" idea from https://github.com/gratipay/gratipay.com/issues/4557#issuecomment-324469116.

### Todo

- [x] vary button and action based on verification state of selected email address
- [x] ~~update claim action so it happens immediately (w/ notification to self)~~ &rarr; #4520
- [x] ~~update bulk claiming so it happens immediately (w/ notification to self)~~ &rarr; #4520
- [x] ~~implement verify action~~ &rarr; #4520
- [x] ~~rip out claim-by-email wiring entirely~~ &rarr; #4520
- [x] change base back to `master` post-#4579