### PR TITLE
Homepage: Clear errors on resubmission

### DIFF
--- a/js/gratipay/homepage.js
+++ b/js/gratipay/homepage.js
@@ -73,6 +73,11 @@ Gratipay.homepage.submitFormWithNonce = function(nonce) {
                 self.$submit.prop('disabled', false);
                 self.$submit.removeClass('processing');
                 Gratipay.notification(data.msg, 'error');
+
+                // The user could be submitting the form after fixing an error.
+                // Let's first clear all errors, and then assign them again
+                // based on the response received.
+                self.$form.find('.error').removeClass('error');
                 for (var i=0, fieldName; fieldName=data.errors[i]; i++) {
                     $('.'+fieldName, self.$form).addClass('error');
                 }


### PR DESCRIPTION
**Steps**

- User makes multiple errors when filling the homepage form
- User fixes one error, submits form

**Expected:** 

The error highlighting and text should only be shown for the field that still has an error. 

**Actual**: 

Errors are still visible on both fields. 