### PR TITLE
Fix label regression

### DIFF
--- a/scss/pages/homepage.scss
+++ b/scss/pages/homepage.scss
@@ -192,7 +192,7 @@
             }
 
             .field {
-                label, fieldset legend {
+                label {
                     display: block;
                     text-align: left;
                     font: normal 10px/12px $Ideal;
@@ -205,11 +205,6 @@
                     position: static;
                     margin: 0;
                     padding: 0;
-                    legend {
-                        color: $black;
-                        position: static;
-                        padding: 2em 0 0;
-                    }
                 }
                 input {
                     width: 100%;

--- a/www/index.spt
+++ b/www/index.spt
@@ -247,29 +247,27 @@ $(document).ready(function() {
         </div>
 
         <div class="field on_mailing_list">
-            <fieldset>
-                <legend>{{ _('Join Mailing List') }}</legend>
+            <label for="mailing-list-yes">{{ _('Join Mailing List') }}</label>
 
-                <div class="fancy-radio">
-                    <input type="radio" name="on_mailing_list" id="mailing-list-yes"
-                           value="yes" checked>
-                    <label for="mailing-list-yes">{{ _('Yes') }}</label>
-                </div>
+            <div class="fancy-radio">
+                <input type="radio" name="on_mailing_list" id="mailing-list-yes"
+                       value="yes" checked>
+                <label for="mailing-list-yes">{{ _('Yes') }}</label>
+            </div>
 
-                <div class="fancy-radio">
-                    <input type="radio" name="on_mailing_list" id="mailing-list-no"
-                           value="no">
-                    <label for="mailing-list-no">{{ _('No') }}</label>
-                </div>
+            <div class="fancy-radio">
+                <input type="radio" name="on_mailing_list" id="mailing-list-no"
+                       value="no">
+                <label for="mailing-list-no">{{ _('No') }}</label>
+            </div>
 
-                <p class="fine-print help">
-                    {{ _("I am surprised that you are seeing this message.") }}
-                </p>
+            <p class="fine-print help">
+                {{ _("I am surprised that you are seeing this message.") }}
+            </p>
 
-                <p class="fine-print">
-                    {{ _('We send updates related to #BackTheStack.') }}
-                </p>
-            </fieldset>
+            <p class="fine-print">
+                {{ _('We send updates related to #BackTheStack.') }}
+            </p>
         </div>
 
 


### PR DESCRIPTION
We were overloading the legend instead of using a label, which got gunked up in #4664:

![screen shot 2017-10-02 at 10 56 21 am](https://user-images.githubusercontent.com/134455/31083688-581358b4-a760-11e7-8ee9-72074be12175.png)

I've since learned we can use multiple labels for one input, so we don't need the legend hack after all.

cc: @EdOverflow @pinoaffe 