### PR TITLE
Turn campaign box off until we're really ready

### DIFF
--- a/www/index.spt
+++ b/www/index.spt
@@ -21,6 +21,7 @@ goal = D('100000')
 today = datetime.date.today()
 ndays = (nov_1 - today).days
 show_campaign = (today >= oct_1) or request.qs.get('i_am_fancy') == 'yes'
+show_campaign = request.qs.get('i_am_fancy') == 'yes'  # hack to suppress until we're ready
 
 result = pay_for_open_source(website.app, request.body) if request.method == 'POST' else {}
 if result and result['errors']:


### PR DESCRIPTION
We want to start building our list under https://github.com/gratipay/inside.gratipay.com/issues/1190 but don't want people to see the campaign quite yet. Will announce later this week when the list is built.

[slack](https://gratipay.slackarchive.io/gratipay/page-100/ts-1506972954000584)