### PR TITLE
Show current payment instructions to Admins

### DIFF
--- a/gratipay/models/team/__init__.py
+++ b/gratipay/models/team/__init__.py
@@ -27,7 +27,7 @@ def slugize(name):
     """ Create a slug from a team name.
     """
     if TEAM_NAME_PATTERN.match(name) is None:
-      raise InvalidTeamName
+        raise InvalidTeamName
 
     slug = name.strip()
     for c in (',', ' '):
@@ -231,6 +231,19 @@ class Team(Model, Available, Closing, Membership, Package, ReviewStatus, Takes, 
 
         return rec.funded, rec.unfunded
 
+    def get_payment_instructions(self):
+        """
+        Returns the incoming payment instructions for this team.
+
+        Since giving is anonymous on Gratipay, this is only to be used
+        internally by other routines, or for exposing values to admins.
+        """
+        return self.db.all("""
+            SELECT p.username, cpi.amount, cpi.mtime
+              FROM current_payment_instructions cpi
+              JOIN participants p ON p.id = cpi.participant_id
+             WHERE cpi.team_id = %(team_id)s
+        """, {'team_id': self.id})
 
     def get_upcoming_payment(self):
         from gratipay.billing.exchanges import MINIMUM_CHARGE  # dodge circular import

--- a/www/%team/receiving/index.html.spt
+++ b/www/%team/receiving/index.html.spt
@@ -66,7 +66,11 @@ Estimated payment for next week: {{ format_currency(team.get_upcoming_payment(),
 
         {% for payment_instruction in team.get_payment_instructions() %}
             <tr>
-                <td>{{ payment_instruction.username }}</td>
+                <td>
+                    <a href="/~{{ payment_instruction.username }}">
+                        {{ payment_instruction.username }}
+                    </a>
+                </td>
                 <td>{{ payment_instruction.amount }}</td>
                 <td>{{ to_age(payment_instruction.mtime) }} ago</td>
             </tr>

--- a/www/%team/receiving/index.html.spt
+++ b/www/%team/receiving/index.html.spt
@@ -54,6 +54,26 @@ Estimated payment for next week: {{ format_currency(team.get_upcoming_payment(),
     {% include "templates/payment-distribution-amount.html" %}
 {% endif %}
 
+{% if user.ADMIN %}
+    <h2>Current Payment Instructions (Admins Only)</h2>
+
+    <table class="table">
+        <tr>
+            <th>Username</th>
+            <th>Amount</th>
+            <th>Last Modified</th>
+        </tr>
+
+        {% for payment_instruction in team.get_payment_instructions() %}
+            <tr>
+                <td>{{ payment_instruction.username }}</td>
+                <td>{{ payment_instruction.amount }}</td>
+                <td>{{ to_age(payment_instruction.mtime) }} ago</td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endif %}
+
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
From https://github.com/gratipay/gratipay.com/issues/4667#issuecomment-333806874: 

> Questions like these are hard for me to answer without speculation because I can't just query the database and giving is anonymous even for admin users.

Screenshot: 

![screen shot 2017-10-03 at 7 18 34 pm](https://user-images.githubusercontent.com/3893573/31128507-ab7dec84-a86f-11e7-9ba6-7a38af22adfd.png)
