### PR TITLE
Fix #BackTheStack text on small screens

### DIFF
--- a/scss/pages/homepage.scss
+++ b/scss/pages/homepage.scss
@@ -72,6 +72,7 @@
             text-align: justify;
             width: 55%;
             margin: 0 auto 1em;
+            display: inline-block;
         }
 
         #braintree-container {


### PR DESCRIPTION
Fixes #4653.

<img width="382" alt="screen shot 2017-10-06 at 11 16 51 am" src="https://user-images.githubusercontent.com/9266001/31284960-0ddca018-aa88-11e7-8746-433dcd03a863.png">
