### PR TITLE
set httponly=True for csrf token

### DIFF
--- a/gratipay/security/csrf.py
+++ b/gratipay/security/csrf.py
@@ -69,6 +69,4 @@ def add_token_to_response(response, csrf_token=None):
     """Store the latest CSRF token as a cookie.
     """
     if csrf_token:
-        # Don't set httponly so that we can POST using XHR.
-        # https://github.com/gratipay/gratipay.com/issues/3030
-        response.set_cookie(b'csrf_token', csrf_token, expires=CSRF_TIMEOUT, httponly=False)
+        response.set_cookie(b'csrf_token', csrf_token, expires=CSRF_TIMEOUT, httponly=True)


### PR DESCRIPTION
Only instance where httponly=False is set for cookies is csrf token, I hope this fixes #4561
